### PR TITLE
- removed now unneeded scope operator

### DIFF
--- a/examples/big1.cc
+++ b/examples/big1.cc
@@ -50,7 +50,7 @@ add_partitions(const string& name)
 int
 main()
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/examples/compare.cc
+++ b/examples/compare.cc
@@ -16,7 +16,7 @@ using namespace storage;
 int
 main()
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/examples/compare1.cc
+++ b/examples/compare1.cc
@@ -20,7 +20,7 @@ using namespace storage;
 int
 main()
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/examples/compare2.cc
+++ b/examples/compare2.cc
@@ -19,7 +19,7 @@ using namespace storage;
 int
 main()
 {
- storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/examples/compare3.cc
+++ b/examples/compare3.cc
@@ -20,7 +20,7 @@ using namespace storage;
 int
 main()
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/examples/compare4.cc
+++ b/examples/compare4.cc
@@ -18,7 +18,7 @@ using namespace storage;
 int
 main()
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/examples/compare5.cc
+++ b/examples/compare5.cc
@@ -20,7 +20,7 @@ using namespace storage;
 int
 main()
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/examples/compare6.cc
+++ b/examples/compare6.cc
@@ -18,7 +18,7 @@ using namespace storage;
 int
 main()
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/testsuite/default-partition-table.cc
+++ b/testsuite/default-partition-table.cc
@@ -30,7 +30,7 @@ namespace std
 
 BOOST_AUTO_TEST_CASE(test1)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(test1)
 
 BOOST_AUTO_TEST_CASE(test2)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(test2)
 
 BOOST_AUTO_TEST_CASE(test3)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
     storage.get_impl().get_arch().set_efiboot(true);

--- a/testsuite/dependencies/test2.cc
+++ b/testsuite/dependencies/test2.cc
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(dependencies)
 	{ "5 - Create logical volume /dev/system/swap (2.00 GiB) ->" }
     });
 
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/testsuite/disk.cc
+++ b/testsuite/disk.cc
@@ -17,7 +17,7 @@ using namespace storage;
 
 BOOST_AUTO_TEST_CASE(disk1)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(disk1)
 
 BOOST_AUTO_TEST_CASE(disk2)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::IMAGE);
+    Environment environment(true, ProbeMode::NONE, TargetMode::IMAGE);
 
     Storage storage(environment);
 

--- a/testsuite/output.cc
+++ b/testsuite/output.cc
@@ -25,7 +25,7 @@ public:
     Fixture()
 	: storage(nullptr)
     {
-	storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+	Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
 	storage = new Storage(environment);
 

--- a/testsuite/partition-size.cc
+++ b/testsuite/partition-size.cc
@@ -20,7 +20,7 @@ using namespace storage;
 
 BOOST_AUTO_TEST_CASE(test_set_region)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(test_set_region)
 
 BOOST_AUTO_TEST_CASE(test_set_size_k)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/testsuite/partition-slots.cc
+++ b/testsuite/partition-slots.cc
@@ -20,7 +20,7 @@ using namespace storage;
 
 BOOST_AUTO_TEST_CASE(test_msdos1)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(test_msdos1)
 
 BOOST_AUTO_TEST_CASE(test_msdos2)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(test_msdos2)
 
 BOOST_AUTO_TEST_CASE(test_msdos3)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(test_msdos3)
 
 BOOST_AUTO_TEST_CASE(test_gpt1)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/testsuite/probe/disk.cc
+++ b/testsuite/probe/disk.cc
@@ -18,7 +18,7 @@ using namespace storage;
 
 BOOST_AUTO_TEST_CASE(dependencies)
 {
-    storage::Environment environment(true, ProbeMode::READ_MOCKUP, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::READ_MOCKUP, TargetMode::DIRECT);
     environment.set_mockup_filename("disk-mockup.xml");
 
     Storage storage(environment);

--- a/testsuite/probe/md1.cc
+++ b/testsuite/probe/md1.cc
@@ -18,7 +18,7 @@ using namespace storage;
 
 BOOST_AUTO_TEST_CASE(dependencies)
 {
-    storage::Environment environment(true, ProbeMode::READ_MOCKUP, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::READ_MOCKUP, TargetMode::DIRECT);
     environment.set_mockup_filename("md1-mockup.xml");
 
     Storage storage(environment);

--- a/testsuite/probe/md2.cc
+++ b/testsuite/probe/md2.cc
@@ -18,7 +18,7 @@ using namespace storage;
 
 BOOST_AUTO_TEST_CASE(dependencies)
 {
-    storage::Environment environment(true, ProbeMode::READ_MOCKUP, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::READ_MOCKUP, TargetMode::DIRECT);
     environment.set_mockup_filename("md2-mockup.xml");
 
     Storage storage(environment);

--- a/testsuite/range.cc
+++ b/testsuite/range.cc
@@ -19,7 +19,7 @@ using namespace storage;
 
 BOOST_AUTO_TEST_CASE(test_msdos)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(test_msdos)
 
 BOOST_AUTO_TEST_CASE(test_gpt)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/testsuite/sorting/disk1.cc
+++ b/testsuite/sorting/disk1.cc
@@ -30,7 +30,7 @@ namespace std
 
 BOOST_AUTO_TEST_CASE(disk_sorting1)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 

--- a/testsuite/sorting/md1.cc
+++ b/testsuite/sorting/md1.cc
@@ -30,7 +30,7 @@ namespace std
 
 BOOST_AUTO_TEST_CASE(md_sorting1)
 {
-    storage::Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
 
     Storage storage(environment);
 


### PR DESCRIPTION
The scope operator was needed when there were different Environment classes in the storage and storage_legacy namespace.