### PR TITLE
- do not create devicegraph without storage object

### DIFF
--- a/storage/Actiongraph.h
+++ b/storage/Actiongraph.h
@@ -2,6 +2,7 @@
 #define STORAGE_ACTIONGRAPH_H
 
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <boost/noncopyable.hpp>

--- a/storage/Devices/NtfsImpl.cc
+++ b/storage/Devices/NtfsImpl.cc
@@ -131,7 +131,7 @@ namespace storage
 	string cmd_line = "echo y | " NTFSRESIZEBIN " --force";
 	if (resize_mode == ResizeMode::SHRINK)
 	    cmd_line += " --size " + to_string(blk_device->get_size_k()) + "k";
-	cmd_line += " " + quote(blk_device->get_name());;
+	cmd_line += " " + quote(blk_device->get_name());
 	cout << cmd_line << endl;
 
 	SystemCmd cmd(cmd_line);

--- a/storage/Utils/LoggerImpl.cc
+++ b/storage/Utils/LoggerImpl.cc
@@ -53,7 +53,7 @@ namespace storage
 	    string::size_type pos1 = 0;
 	    while (true)
 	    {
-		string::size_type pos2 = content.find('\n', pos1);;
+		string::size_type pos2 = content.find('\n', pos1);
 		if (pos2 != string::npos || pos1 != content.length())
 		    logger->write(log_level, component, file, line, func,
 				  content.substr(pos1, pos2 - pos1));

--- a/storage/Utils/OutputProcessor.h
+++ b/storage/Utils/OutputProcessor.h
@@ -24,8 +24,14 @@
 #define STORAGE_OUTPUT_PROCESSOR_H
 
 
+#include <string>
+
+
 namespace storage
 {
+
+    using namespace std;
+
 
     class OutputProcessor
     {

--- a/testsuite/Utils/udev-encoding.cc
+++ b/testsuite/Utils/udev-encoding.cc
@@ -18,13 +18,13 @@ using namespace storage;
 BOOST_AUTO_TEST_CASE(test_udev_encode)
 {
     BOOST_CHECK_EQUAL(udevEncode("nothing"), "nothing");
-    
+
     BOOST_CHECK_EQUAL(udevEncode("hello world"), "hello\\x20world");
     BOOST_CHECK_EQUAL(udevEncode("hello  world"), "hello\\x20\\x20world");
-    
+
     BOOST_CHECK_EQUAL(udevEncode(" beginning"), "\\x20beginning");
     BOOST_CHECK_EQUAL(udevEncode("ending "), "ending\\x20");
-    
+
     BOOST_CHECK_EQUAL(udevEncode("woody's"), "woody\\x27s");
 }
 
@@ -32,12 +32,12 @@ BOOST_AUTO_TEST_CASE(test_udev_encode)
 BOOST_AUTO_TEST_CASE(test_udev_decode)
 {
     BOOST_CHECK_EQUAL(udevDecode("nothing"), "nothing");
-    
+
     BOOST_CHECK_EQUAL(udevDecode("hello\\x20world"), "hello world");
     BOOST_CHECK_EQUAL(udevDecode("hello\\x20\\x20world"), "hello  world");
-    
+
     BOOST_CHECK_EQUAL(udevDecode("\\x20beginning"), " beginning");
     BOOST_CHECK_EQUAL(udevDecode("ending\\x20"), "ending ");
-    
+
     BOOST_CHECK_EQUAL(udevDecode("woody\\x27s"), "woody's");
 }

--- a/testsuite/copy.cc
+++ b/testsuite/copy.cc
@@ -14,15 +14,21 @@
 #include "storage/Devices/Swap.h"
 #include "storage/Holders/User.h"
 #include "storage/Holders/Subdevice.h"
+#include "storage/Environment.h"
+#include "storage/Storage.h"
 #include "storage/Devicegraph.h"
 
 
 using namespace storage;
 
 
-BOOST_AUTO_TEST_CASE(dependencies)
+BOOST_AUTO_TEST_CASE(copy)
 {
-    Devicegraph* devicegraph = new Devicegraph();
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+
+    Storage storage(environment);
+
+    Devicegraph* devicegraph = storage.get_staging();
 
     Disk* sda = Disk::create(devicegraph, "/dev/sda");
 
@@ -45,14 +51,10 @@ BOOST_AUTO_TEST_CASE(dependencies)
 
     devicegraph->check();
 
-    Devicegraph* devicegraph_copy = new Devicegraph();
-    devicegraph->copy(*devicegraph_copy);
+    Devicegraph* devicegraph_copy = storage.copy_devicegraph("staging", "copy");
 
     BOOST_CHECK_EQUAL(devicegraph_copy->num_devices(), 8);
     BOOST_CHECK_EQUAL(devicegraph_copy->num_holders(), 2);
 
     devicegraph_copy->check();
-
-    delete devicegraph;
-    delete devicegraph_copy;
 }

--- a/testsuite/find-vertex.cc
+++ b/testsuite/find-vertex.cc
@@ -7,6 +7,8 @@
 #include "storage/Devices/Disk.h"
 #include "storage/Devices/Partition.h"
 #include "storage/Holders/Subdevice.h"
+#include "storage/Environment.h"
+#include "storage/Storage.h"
 #include "storage/Devicegraph.h"
 
 
@@ -15,7 +17,11 @@ using namespace storage;
 
 BOOST_AUTO_TEST_CASE(find_vertex)
 {
-    Devicegraph* devicegraph = new Devicegraph();
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+
+    Storage storage(environment);
+
+    Devicegraph* devicegraph = storage.get_staging();
 
     Disk* sda = Disk::create(devicegraph, "/dev/sda");
 
@@ -28,6 +34,4 @@ BOOST_AUTO_TEST_CASE(find_vertex)
     BOOST_CHECK_EQUAL(BlkDevice::find(devicegraph, "/dev/sda"), sda);
     BOOST_CHECK_EQUAL(BlkDevice::find(devicegraph, "/dev/sda1"), sda1);
     BOOST_CHECK_THROW(BlkDevice::find(devicegraph, "/dev/sda2"), DeviceNotFound);
-
-    delete devicegraph;
 }

--- a/testsuite/relatives.cc
+++ b/testsuite/relatives.cc
@@ -14,6 +14,8 @@
 #include "storage/Devices/Swap.h"
 #include "storage/Holders/User.h"
 #include "storage/Holders/Subdevice.h"
+#include "storage/Environment.h"
+#include "storage/Storage.h"
 #include "storage/Devicegraph.h"
 
 
@@ -46,7 +48,11 @@ namespace std
 
 BOOST_AUTO_TEST_CASE(dependencies)
 {
-    Devicegraph* devicegraph = new Devicegraph();
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+
+    Storage storage(environment);
+
+    Devicegraph* devicegraph = storage.get_staging();
 
     Disk* sda = Disk::create(devicegraph, "/dev/sda");
 
@@ -100,6 +106,4 @@ BOOST_AUTO_TEST_CASE(dependencies)
 
     BOOST_CHECK_EQUAL(sort(sda1->get_roots(false)), sort({ sda }));
     BOOST_CHECK_EQUAL(sort(system_swap->get_roots(false)), sort({ sda, sdb }));
-
-    delete devicegraph;
 }

--- a/testsuite/sorting/disk1.cc
+++ b/testsuite/sorting/disk1.cc
@@ -37,12 +37,12 @@ BOOST_AUTO_TEST_CASE(disk_sorting1)
     Devicegraph* staging = storage.get_staging();
 
     Disk* sda = Disk::create(staging, "/dev/sda");
-    Disk* sdz =  Disk::create(staging, "/dev/sdz");
-    Disk* sdaa =  Disk::create(staging, "/dev/sdaa");
+    Disk* sdz = Disk::create(staging, "/dev/sdz");
+    Disk* sdaa = Disk::create(staging, "/dev/sdaa");
 
     Disk* vda = Disk::create(staging, "/dev/vda");
-    Disk* vdb =  Disk::create(staging, "/dev/vdb");
-    Disk* vdaa =  Disk::create(staging, "/dev/vdaa");
+    Disk* vdb = Disk::create(staging, "/dev/vdb");
+    Disk* vdaa = Disk::create(staging, "/dev/vdaa");
 
     BOOST_CHECK_EQUAL(staging->get_all_disks(), vector<Disk*>({ sda, sdz, sdaa, vda, vdb, vdaa }));
 }

--- a/testsuite/sorting/md1.cc
+++ b/testsuite/sorting/md1.cc
@@ -37,9 +37,9 @@ BOOST_AUTO_TEST_CASE(md_sorting1)
     Devicegraph* staging = storage.get_staging();
 
     Md* md0 = Md::create(staging, "/dev/md0");
-    Md* md1 =  Md::create(staging, "/dev/md1");
-    Md* md10 =  Md::create(staging, "/dev/md10");
-    Md* md2 =  Md::create(staging, "/dev/md2");
+    Md* md1 = Md::create(staging, "/dev/md1");
+    Md* md10 = Md::create(staging, "/dev/md10");
+    Md* md2 = Md::create(staging, "/dev/md2");
 
     BOOST_CHECK_EQUAL(staging->get_all_mds(), vector<Md*>({ md0, md1, md2, md10 }));
 }

--- a/testsuite/stable.cc
+++ b/testsuite/stable.cc
@@ -7,6 +7,8 @@
 #include "storage/Devices/DiskImpl.h"
 #include "storage/Devices/PartitionImpl.h"
 #include "storage/Holders/Subdevice.h"
+#include "storage/Environment.h"
+#include "storage/Storage.h"
 #include "storage/DevicegraphImpl.h"
 
 
@@ -15,7 +17,11 @@ using namespace storage;
 
 BOOST_AUTO_TEST_CASE(valid)
 {
-    Devicegraph* devicegraph = new Devicegraph();
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+
+    Storage storage(environment);
+
+    Devicegraph* devicegraph = storage.get_staging();
 
     Disk* sda = Disk::create(devicegraph, "/dev/sda");
 
@@ -52,6 +58,4 @@ BOOST_AUTO_TEST_CASE(valid)
     BOOST_CHECK_EXCEPTION(BlkDevice::find(devicegraph, "/dev/sda1"), DeviceNotFound,
 	[](const DeviceNotFound& e) { return strcmp(e.what(), "device not found, name:/dev/sda1") == 0;
     });
-
-    delete devicegraph;
 }


### PR DESCRIPTION
Motivation is to solve the TODO at https://github.com/openSUSE/libstorage-ng/blob/master/storage/Devicegraph.h#L90.
