### PR TITLE
Added support to set label and uuid for swap devices

### DIFF
--- a/storage/Devices/Filesystem.cc
+++ b/storage/Devices/Filesystem.cc
@@ -82,6 +82,13 @@ namespace storage
     }
 
 
+    void
+    Filesystem::set_uuid(const string& uuid)
+    {
+	get_impl().set_uuid(uuid);
+    }
+
+
     const vector<string>&
     Filesystem::get_mountpoints() const
     {

--- a/storage/Devices/Filesystem.h
+++ b/storage/Devices/Filesystem.h
@@ -51,6 +51,7 @@ namespace storage
 	virtual bool supports_uuid() const = 0;
 
 	const std::string& get_uuid() const;
+	void set_uuid(const std::string& uuid);
 
 	const std::vector<std::string>& get_mountpoints() const;
 	void set_mountpoints(const std::vector<std::string>& mountpoints);

--- a/storage/Devices/FilesystemImpl.cc
+++ b/storage/Devices/FilesystemImpl.cc
@@ -75,6 +75,13 @@ namespace storage
 
 
     void
+    Filesystem::Impl::set_uuid(const string& uuid)
+    {
+	Impl::uuid = uuid;
+    }
+
+
+    void
     Filesystem::Impl::set_mountpoints(const vector<string>& mountpoints)
     {
 	Impl::mountpoints = mountpoints;
@@ -352,6 +359,16 @@ namespace storage
 	    last = set_label;
 	}
 
+	if (!get_uuid().empty())
+	{
+	    Action::SetUuid* set_uuid = new Action::SetUuid(get_sid());
+	    Actiongraph::Impl::vertex_descriptor tmp2 = actiongraph.add_vertex(set_uuid);
+	    actiongraph.add_edge(v1, tmp2);
+	    v1 = tmp2;
+
+	    last = set_uuid;
+	}
+
 	if (!get_mountpoints().empty())
 	{
 	    Action::Base* sync = new Action::Create(get_sid(), true);
@@ -566,6 +583,21 @@ namespace storage
 	// TODO - stub
     }
 
+    Text
+    Filesystem::Impl::do_set_uuid_text(Tense tense) const
+    {
+	const BlkDevice* blk_device = get_blk_device();
+
+	return sformat(_("Set UUID of %1$s to %2$s"), blk_device->get_name().c_str(),
+		       uuid.c_str());
+    }
+
+
+    void
+    Filesystem::Impl::do_set_uuid() const
+    {
+	// TODO - stub
+    }
 
     Text
     Filesystem::Impl::do_mount_text(const string& mountpoint, Tense tense) const
@@ -756,6 +788,22 @@ namespace storage
 	{
 	    const Filesystem* filesystem = to_filesystem(get_device_rhs(actiongraph));
 	    filesystem->get_impl().do_set_label();
+	}
+
+
+	Text
+	SetUuid::text(const Actiongraph::Impl& actiongraph, Tense tense) const
+	{
+	    const Filesystem* filesystem = to_filesystem(get_device_rhs(actiongraph));
+	    return filesystem->get_impl().do_set_uuid_text(tense);
+	}
+
+
+	void
+	SetUuid::commit(const Actiongraph::Impl& actiongraph) const
+	{
+	    const Filesystem* filesystem = to_filesystem(get_device_rhs(actiongraph));
+	    filesystem->get_impl().do_set_uuid();
 	}
 
 

--- a/storage/Devices/FilesystemImpl.cc
+++ b/storage/Devices/FilesystemImpl.cc
@@ -402,7 +402,7 @@ namespace storage
 
 	if (get_type() != lhs.get_type())
 	{
-	    throw runtime_error("cannot change filesystem type");
+	    ST_THROW(Exception("cannot change filesystem type"));
 	}
 
 	if (get_label() != lhs.get_label())

--- a/storage/Devices/FilesystemImpl.cc
+++ b/storage/Devices/FilesystemImpl.cc
@@ -395,6 +395,31 @@ namespace storage
 
 
     void
+    Filesystem::Impl::add_modify_actions(Actiongraph::Impl& actiongraph, const Device* lhs_base) const
+    {
+	const Impl& lhs = dynamic_cast<const Impl&>(lhs_base->get_impl());
+	vector<Action::Base*> actions;
+
+	if (get_type() != lhs.get_type())
+	{
+	    throw runtime_error("cannot change filesystem type");
+	}
+
+	if (get_label() != lhs.get_label())
+	{
+	    actions.push_back(new Action::SetLabel(get_sid()));
+	}
+
+	if (get_uuid() != lhs.get_uuid())
+	{
+	    actions.push_back(new Action::SetUuid(get_sid()));
+	}
+
+	actiongraph.add_chain(actions);
+    }
+
+
+    void
     Filesystem::Impl::add_delete_actions(Actiongraph::Impl& actiongraph) const
     {
 	Action::Base* first = nullptr;

--- a/storage/Devices/FilesystemImpl.h
+++ b/storage/Devices/FilesystemImpl.h
@@ -54,6 +54,7 @@ namespace storage
 	void set_tune_options(const string& tune_options);
 
 	virtual void add_create_actions(Actiongraph::Impl& actiongraph) const override;
+	virtual void add_modify_actions(Actiongraph::Impl& actiongraph, const Device* lhs) const override;
 	virtual void add_delete_actions(Actiongraph::Impl& actiongraph) const override;
 
 	virtual void probe_pass_3(Devicegraph* probed, SystemInfo& systeminfo, EtcFstab& fstab);

--- a/storage/Devices/FilesystemImpl.h
+++ b/storage/Devices/FilesystemImpl.h
@@ -35,6 +35,7 @@ namespace storage
 	void set_label(const string& label);
 
 	const string& get_uuid() const { return uuid; }
+	void set_uuid(const string& uuid);
 
 	const vector<string>& get_mountpoints() const { return mountpoints; }
 	void set_mountpoints(const std::vector<std::string>& mountpoints);
@@ -79,6 +80,9 @@ namespace storage
 
 	virtual Text do_set_label_text(Tense tense) const;
 	virtual void do_set_label() const;
+
+	virtual Text do_set_uuid_text(Tense tense) const;
+	virtual void do_set_uuid() const;
 
 	virtual Text do_mount_text(const string& mountpoint, Tense tense) const;
 	virtual void do_mount(const Actiongraph::Impl& actiongraph, const string& mountpoint) const;
@@ -141,6 +145,18 @@ namespace storage
 	public:
 
 	    SetLabel(sid_t sid) : Modify(sid) {}
+
+	    virtual Text text(const Actiongraph::Impl& actiongraph, Tense tense) const override;
+	    virtual void commit(const Actiongraph::Impl& actiongraph) const override;
+
+	};
+
+
+	class SetUuid : public Modify
+	{
+	public:
+
+	    SetUuid(sid_t sid) : Modify(sid) {}
 
 	    virtual Text text(const Actiongraph::Impl& actiongraph, Tense tense) const override;
 	    virtual void commit(const Actiongraph::Impl& actiongraph) const override;

--- a/storage/Devices/SwapImpl.cc
+++ b/storage/Devices/SwapImpl.cc
@@ -104,4 +104,30 @@ namespace storage
 	    ST_THROW(Exception("resize ext4 failed"));
     }
 
+    void
+    Swap::Impl::do_set_label() const
+    {
+	const BlkDevice* blk_device = get_blk_device();
+
+	string cmd_line = SWAPLABELBIN " -L " + quote(get_label()) + " " + quote(blk_device->get_name());
+	cout << cmd_line << endl;
+
+	SystemCmd cmd(cmd_line);
+	if (cmd.retcode() != 0)
+	    ST_THROW(Exception("set-label swap failed"));
+    }
+
+    void
+    Swap::Impl::do_set_uuid() const
+    {
+	const BlkDevice* blk_device = get_blk_device();
+
+	string cmd_line = SWAPLABELBIN " -U " + quote(get_uuid()) + " " + quote(blk_device->get_name());
+	cout << cmd_line << endl;
+
+	SystemCmd cmd(cmd_line);
+	if (cmd.retcode() != 0)
+	    ST_THROW(Exception("set-uuid swap failed"));
+    }
+
 }

--- a/storage/Devices/SwapImpl.h
+++ b/storage/Devices/SwapImpl.h
@@ -44,6 +44,10 @@ namespace storage
 
 	virtual void do_resize(ResizeMode resize_mode) const override;
 
+	virtual void do_set_label() const override;
+
+	virtual void do_set_uuid() const override;
+
     };
 
 }

--- a/storage/Utils/StorageDefines.h
+++ b/storage/Utils/StorageDefines.h
@@ -104,6 +104,7 @@
 #define XFSADMINBIN    "/usr/sbin/xfs_admin"
 #define NTFSLABELBIN   "/usr/sbin/ntfslabel"
 #define FATLABELBIN	"/usr/sbin/fatlabel"
+#define SWAPLABELBIN   "/sbin/swaplabel"
 
 #define FSCKBIN        "/sbin/fsck"
 #define FSCKEXT2BIN    "/sbin/fsck.ext2"


### PR DESCRIPTION
set_uuid implemented at Filesystem level

do_set_uuid implemented only for swap. It would be easy to extend it for other filesystems using tune2fs.