### PR TITLE
- allow to set minimal grain

### DIFF
--- a/storage/Utils/Topology.cc
+++ b/storage/Utils/Topology.cc
@@ -106,6 +106,20 @@ namespace storage
 
 
     unsigned long
+    Topology::get_minimal_grain() const
+    {
+	return get_impl().get_minimal_grain();
+    }
+
+
+    void
+    Topology::set_minimal_grain(unsigned long minimal_grain)
+    {
+	get_impl().set_minimal_grain(minimal_grain);
+    }
+
+
+    unsigned long
     Topology::calculate_grain() const
     {
 	return get_impl().calculate_grain();

--- a/storage/Utils/Topology.h
+++ b/storage/Utils/Topology.h
@@ -71,6 +71,9 @@ namespace storage
 	unsigned long get_optimal_io_size() const;
 	void set_optimal_io_size(unsigned long optimal_io_size);
 
+	unsigned long get_minimal_grain() const;
+	void set_minimal_grain(unsigned long minimal_grain);
+
 	/**
 	 * Calculates the grain.
 	 */

--- a/storage/Utils/TopologyImpl.cc
+++ b/storage/Utils/TopologyImpl.cc
@@ -42,12 +42,19 @@ namespace storage
     }
 
 
+    void
+    Topology::Impl::set_minimal_grain(unsigned long minimal_grain)
+    {
+	Impl::minimal_grain = minimal_grain;
+    }
+
+
     unsigned long
     Topology::Impl::calculate_grain() const
     {
 	unsigned long grain = max(optimal_io_size, 1UL);
 
-	while (grain < 1 * MiB)
+	while (grain < minimal_grain)
 	    grain *= 2;
 
 	return grain;
@@ -146,14 +153,19 @@ namespace storage
     Topology::Impl::operator==(const Topology::Impl& rhs) const
     {
 	return alignment_offset == rhs.alignment_offset &&
-	    optimal_io_size == rhs.optimal_io_size;
+	    optimal_io_size == rhs.optimal_io_size && minimal_grain == rhs.minimal_grain;
     }
 
 
     std::ostream&
     operator<<(std::ostream& s, const Topology::Impl& impl)
     {
-	return s << "[" << impl.alignment_offset << " B, " << impl.optimal_io_size << " B]";
+	s << "[" << impl.alignment_offset << " B, " << impl.optimal_io_size << " B";
+	if (impl.minimal_grain != impl.default_minimal_grain)
+	    s << ", " << impl.minimal_grain << " B";
+	s << "]";
+
+	return s;
     }
 
 
@@ -166,6 +178,7 @@ namespace storage
 
 	getChildValue(tmp, "alignment-offset", value.alignment_offset);
 	getChildValue(tmp, "optimal-io-size", value.optimal_io_size);
+	getChildValue(tmp, "minimal-grain", value.minimal_grain);
 
 	return true;
     }
@@ -178,6 +191,8 @@ namespace storage
 
 	setChildValueIf(tmp, "alignment-offset", value.alignment_offset, value.alignment_offset != 0);
 	setChildValueIf(tmp, "optimal-io-size", value.optimal_io_size, value.optimal_io_size != 0);
+	setChildValueIf(tmp, "minimal-grain", value.minimal_grain,
+			value.minimal_grain != value.default_minimal_grain);
     }
 
 }

--- a/storage/Utils/TopologyImpl.h
+++ b/storage/Utils/TopologyImpl.h
@@ -24,9 +24,10 @@
 #define STORAGE_TOPOLOGY_IMPL_H
 
 
+#include "storage/Utils/Topology.h"
 #include "storage/Utils/Region.h"
 #include "storage/Utils/XmlFile.h"
-#include "storage/Utils/Topology.h"
+#include "storage/Utils/HumanString.h"
 
 
 namespace storage
@@ -36,15 +37,19 @@ namespace storage
     {
     public:
 
-	Impl() : alignment_offset(0), optimal_io_size(0) {}
+	Impl() : alignment_offset(0), optimal_io_size(0), minimal_grain(default_minimal_grain) {}
 	Impl(long alignment_offset, unsigned long optimal_io_size) :
-	    alignment_offset(alignment_offset), optimal_io_size(optimal_io_size) {}
+	    alignment_offset(alignment_offset), optimal_io_size(optimal_io_size),
+	    minimal_grain(default_minimal_grain) {}
 
 	long get_alignment_offset() const { return alignment_offset; }
 	void set_alignment_offset(long alignment_offset);
 
 	unsigned long get_optimal_io_size() const { return optimal_io_size; }
 	void set_optimal_io_size(unsigned long optimal_io_size);
+
+	unsigned long get_minimal_grain() const { return minimal_grain; }
+	void set_minimal_grain(unsigned long minimal_grain);
 
 	unsigned long calculate_grain() const;
 
@@ -69,8 +74,11 @@ namespace storage
 
     private:
 
+	const unsigned long default_minimal_grain = 1 * MiB;
+
 	long alignment_offset;
 	unsigned long optimal_io_size;
+	unsigned long minimal_grain;
 
     };
 

--- a/testsuite/Utils/topology.cc
+++ b/testsuite/Utils/topology.cc
@@ -12,7 +12,7 @@ using namespace std;
 using namespace storage;
 
 
-BOOST_AUTO_TEST_CASE(test_output)
+BOOST_AUTO_TEST_CASE(test_output1)
 {
     Topology topology(-512, 4096);
 
@@ -20,6 +20,18 @@ BOOST_AUTO_TEST_CASE(test_output)
     out << topology;
 
     BOOST_CHECK_EQUAL(out.str(), "[-512 B, 4096 B]");
+}
+
+
+BOOST_AUTO_TEST_CASE(test_output2)
+{
+    Topology topology(-512, 4096);
+    topology.set_minimal_grain(128 * KiB);
+
+    ostringstream out;
+    out << topology;
+
+    BOOST_CHECK_EQUAL(out.str(), "[-512 B, 4096 B, 131072 B]");
 }
 
 


### PR DESCRIPTION
Allow to set the minimal grain. Currently needed for testing the proposal for small MBR gaps.