### PR TITLE
- use fallback lookup by major and minor number

### DIFF
--- a/storage/Devices/FilesystemImpl.cc
+++ b/storage/Devices/FilesystemImpl.cc
@@ -162,7 +162,7 @@ namespace storage
 
 	const Blkid& blkid = systeminfo.getBlkid();
 	Blkid::Entry entry;
-	if (blkid.getEntry(blk_device->get_name(), entry))
+	if (blkid.find_by_name(blk_device->get_name(), entry, systeminfo))
 	{
 	    label = entry.fs_label;
 	    uuid = entry.fs_uuid;

--- a/storage/SystemInfo/CmdBlkid.cc
+++ b/storage/SystemInfo/CmdBlkid.cc
@@ -138,18 +138,6 @@ namespace storage
 
 
     bool
-    Blkid::getEntry(const string& device, Entry& entry) const
-    {
-	const_iterator i = data.find(device);
-	if (i == data.end())
-	    return false;
-
-	entry = i->second;
-	return true;
-    }
-
-
-    bool
     Blkid::find_by_name(const string& device, Entry& entry, SystemInfo& systeminfo) const
     {
 	const_iterator it = data.find(device);

--- a/storage/SystemInfo/CmdBlkid.h
+++ b/storage/SystemInfo/CmdBlkid.h
@@ -70,8 +70,6 @@ namespace storage
 	friend std::ostream& operator<<(std::ostream& s, const Blkid& blkid);
 	friend std::ostream& operator<<(std::ostream& s, const Entry& entry);
 
-	bool getEntry(const string& device, Entry& entry) const;
-
 	bool find_by_name(const string& device, Entry& entry, SystemInfo& systeminfo) const;
 
 	bool any_md() const;

--- a/testsuite/probe/lvm1-devicegraph.xml
+++ b/testsuite/probe/lvm1-devicegraph.xml
@@ -87,16 +87,19 @@
       <sid>50</sid>
       <fstab-options>defaults</fstab-options>
       <mountpoint>/home</mountpoint>
+      <uuid>5a32b2fb-ac84-4b2f-b53c-4ff68c4721c7</uuid>
     </Xfs>
     <Ext4>
       <sid>51</sid>
       <fstab-options>acl,user_xattr</fstab-options>
       <mountpoint>/</mountpoint>
+      <uuid>7992b624-af87-446f-896a-b310acd6e082</uuid>
     </Ext4>
     <Swap>
       <sid>52</sid>
       <fstab-options>defaults</fstab-options>
       <mountpoint>swap</mountpoint>
+      <uuid>82afe683-54d7-406f-8c60-d3a32febbac7</uuid>
     </Swap>
   </Devices>
   <Holders>


### PR DESCRIPTION
Now filesystem the label and uuid on lvm logical volumes are detected properly.