### PR TITLE
Catch base exception in the bindings

### DIFF
--- a/bindings/storage-catches.i
+++ b/bindings/storage-catches.i
@@ -109,4 +109,4 @@
 %catches(storage::Exception) storage::Storage::copy_devicegraph(const std::string&, const std::string&);
 %catches(storage::Exception) storage::Storage::remove_devicegraph(const std::string&);
 %catches(storage::Exception) storage::Storage::restore_devicegraph(const std::string&);
-
+%catches(storage::Exception) storage::Storage::Storage(const Environment&);


### PR DESCRIPTION
Tested manually in the installer. It fixes the observed crash.