### PR TITLE
- do not try to probe unavailable information for inactive logical volumes

### DIFF
--- a/examples/probe.cc
+++ b/examples/probe.cc
@@ -34,6 +34,9 @@ doit()
 
     const Devicegraph* probed = storage.get_probed();
 
+    cout.setf(ios::boolalpha);
+    cout.setf(ios::showbase);
+
     cout << *probed << endl;
 
     probed->check();

--- a/storage/Devices/BlkDeviceImpl.h
+++ b/storage/Devices/BlkDeviceImpl.h
@@ -61,6 +61,9 @@ namespace storage
 	const string& get_sysfs_path() const { return sysfs_path; }
 	void set_sysfs_path(const string& sysfs_path) { Impl::sysfs_path = sysfs_path; }
 
+	bool is_active() const { return active; }
+	void set_active(bool active) { Impl::active = active; }
+
 	const Region& get_region() const { return region; }
 	virtual void set_region(const Region& region);
 
@@ -135,6 +138,11 @@ namespace storage
 
 	string sysfs_name;
 	string sysfs_path;
+
+	/**
+	 * Some blk devices can be inactive, e.g. LVM LVs or LUKSes.
+	 */
+	bool active;
 
 	/**
 	 * For most devices region.start is zero. Always used to keep track of

--- a/storage/Devices/LvmLvImpl.cc
+++ b/storage/Devices/LvmLvImpl.cc
@@ -90,6 +90,7 @@ namespace storage
 	    LvmVg* lvm_vg = LvmVg::Impl::find_by_uuid(probed, lv.vg_uuid);
 	    LvmLv* lvm_lv = lvm_vg->create_lvm_lv(lv.lv_name, lv.size);
 	    lvm_lv->get_impl().set_uuid(lv.lv_uuid);
+	    lvm_lv->get_impl().set_active(lv.active);
 	    lvm_lv->get_impl().probe_pass_1(probed, systeminfo);
 	}
     }
@@ -104,12 +105,15 @@ namespace storage
 
 	set_dm_table_name(make_dm_table_name(lvm_vg->get_vg_name(), lv_name));
 
-	const CmdDmsetupTable& cmd_dmsetup_table = systeminfo.getCmdDmsetupTable();
-	vector<CmdDmsetupTable::Table> tables = cmd_dmsetup_table.get_tables(get_dm_table_name());
-	if (tables[0].target == "striped")
+	if (is_active())
 	{
-	    stripes = tables[0].stripes;
-	    stripe_size = tables[0].stripe_size;
+	    const CmdDmsetupTable& cmd_dmsetup_table = systeminfo.getCmdDmsetupTable();
+	    vector<CmdDmsetupTable::Table> tables = cmd_dmsetup_table.get_tables(get_dm_table_name());
+	    if (tables[0].target == "striped")
+	    {
+		stripes = tables[0].stripes;
+		stripe_size = tables[0].stripe_size;
+	    }
 	}
     }
 

--- a/storage/SystemInfo/CmdLvm.h
+++ b/storage/SystemInfo/CmdLvm.h
@@ -77,12 +77,13 @@ namespace storage
 
 	struct Lv
 	{
-	    Lv() : lv_name(), lv_uuid(), vg_name(), vg_uuid(), size(0) {}
+	    Lv() : lv_name(), lv_uuid(), vg_name(), vg_uuid(), active(false), size(0) {}
 
 	    string lv_name;
 	    string lv_uuid;
 	    string vg_name;
 	    string vg_uuid;
+	    bool active;
 	    unsigned long long size;
 	};
 

--- a/storage/Utils/Exception.h
+++ b/storage/Utils/Exception.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
+ * Copyright (c) 2016 SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -413,7 +414,7 @@ namespace storage
 
 	    return str << prefix << msg()
 		       << "; expected: \"" << _expected
-		       << "\" seen: \"" << _seen
+		       << "\" seen: \"" << _seen << "\""
 		       << std::endl;
 	}
 

--- a/testsuite/SystemInfo/lvs.cc
+++ b/testsuite/SystemInfo/lvs.cc
@@ -19,7 +19,7 @@ check(const vector<string>& input, const vector<string>& output)
 {
     Mockup::set_mode(Mockup::Mode::PLAYBACK);
     Mockup::set_command(LVSBIN " --noheadings --unbuffered --units b --nosuffix --options lv_name,"
-			"lv_uuid,vg_name,vg_uuid,lv_size", input);
+			"lv_uuid,vg_name,vg_uuid,lv_attr,lv_size", input);
 
     CmdLvs cmd_lvs;
 
@@ -37,14 +37,14 @@ check(const vector<string>& input, const vector<string>& output)
 BOOST_AUTO_TEST_CASE(parse1)
 {
     vector<string> input = {
-	"  root 89Crg8-K5dO-0Vvj-Vwur-vCLK-4efh-WCtRfN system OMPzXF-m3am-1zIl-AVdQ-i5Wx-tmyN-cevmRn 34359738368",
-	"  swap KKC5tf-bWLp-sF2t-oVKQ-tE0w-xeQp-Up8bV0 system OMPzXF-m3am-1zIl-AVdQ-i5Wx-tmyN-cevmRn 2147483648"
+	"  root 89Crg8-K5dO-0Vvj-Vwur-vCLK-4efh-WCtRfN system OMPzXF-m3am-1zIl-AVdQ-i5Wx-tmyN-cevmRn -wi-ao---- 34359738368",
+	"  swap KKC5tf-bWLp-sF2t-oVKQ-tE0w-xeQp-Up8bV0 system OMPzXF-m3am-1zIl-AVdQ-i5Wx-tmyN-cevmRn -wi-ao---- 2147483648"
     };
 
     // TODO bad output format
 
     vector<string> output = {
-	"lvs:<lv-name:root lv-uuid:89Crg8-K5dO-0Vvj-Vwur-vCLK-4efh-WCtRfN vg-name:system vg-uuid:OMPzXF-m3am-1zIl-AVdQ-i5Wx-tmyN-cevmRn size:34359738368 lv-name:swap lv-uuid:KKC5tf-bWLp-sF2t-oVKQ-tE0w-xeQp-Up8bV0 vg-name:system vg-uuid:OMPzXF-m3am-1zIl-AVdQ-i5Wx-tmyN-cevmRn size:2147483648>"
+	"lvs:<lv-name:root lv-uuid:89Crg8-K5dO-0Vvj-Vwur-vCLK-4efh-WCtRfN vg-name:system vg-uuid:OMPzXF-m3am-1zIl-AVdQ-i5Wx-tmyN-cevmRn active:true size:34359738368 lv-name:swap lv-uuid:KKC5tf-bWLp-sF2t-oVKQ-tE0w-xeQp-Up8bV0 vg-name:system vg-uuid:OMPzXF-m3am-1zIl-AVdQ-i5Wx-tmyN-cevmRn active:true size:2147483648>"
     };
 
     check(input, output);

--- a/testsuite/SystemInfo/pvs.cc
+++ b/testsuite/SystemInfo/pvs.cc
@@ -19,7 +19,7 @@ check(const vector<string>& input, const vector<string>& output)
 {
     Mockup::set_mode(Mockup::Mode::PLAYBACK);
     Mockup::set_command(PVSBIN " --noheadings --unbuffered --units b --nosuffix --options pv_name,"
-			"pv_uuid,vg_name,vg_uuid", input);
+			"pv_uuid,vg_name,vg_uuid,pv_attr", input);
 
     CmdPvs cmd_pvs;
 
@@ -37,7 +37,7 @@ check(const vector<string>& input, const vector<string>& output)
 BOOST_AUTO_TEST_CASE(parse1)
 {
     vector<string> input = {
-	"  /dev/sda2  qquP1O-WWoh-Ofas-Rbx0-y72T-0sNe-Wnyc33 system OMPzXF-m3am-1zIl-AVdQ-i5Wx-tmyN-cevmRn"
+	"  /dev/sda2  qquP1O-WWoh-Ofas-Rbx0-y72T-0sNe-Wnyc33 system OMPzXF-m3am-1zIl-AVdQ-i5Wx-tmyN-cevmRn a--"
     };
 
     vector<string> output = {

--- a/testsuite/SystemInfo/vgs.cc
+++ b/testsuite/SystemInfo/vgs.cc
@@ -19,7 +19,7 @@ check(const vector<string>& input, const vector<string>& output)
 {
     Mockup::set_mode(Mockup::Mode::PLAYBACK);
     Mockup::set_command(VGSBIN " --noheadings --unbuffered --units b --nosuffix --options vg_name,"
-			"vg_uuid,vg_extent_size,vg_extent_count", input);
+			"vg_uuid,vg_attr,vg_extent_size,vg_extent_count", input);
 
     CmdVgs cmd_vgs;
 
@@ -37,7 +37,7 @@ check(const vector<string>& input, const vector<string>& output)
 BOOST_AUTO_TEST_CASE(parse1)
 {
     vector<string> input = {
-	"  system  OMPzXF-m3am-1zIl-AVdQ-i5Wx-tmyN-cevmRn 4194304 230400"
+	"  system  OMPzXF-m3am-1zIl-AVdQ-i5Wx-tmyN-cevmRn wz--n- 4194304 230400"
     };
 
     vector<string> output = {

--- a/testsuite/probe/lvm1-mockup.xml
+++ b/testsuite/probe/lvm1-mockup.xml
@@ -28,14 +28,14 @@
       <stdout>system-root: 0 12189696 linear 8:1 18294784</stdout>
     </Command>
     <Command>
-      <name>/sbin/lvs --noheadings --unbuffered --units b --nosuffix --options lv_name,lv_uuid,vg_name,vg_uuid,lv_size</name>
-      <stdout>  home h2EA7Z-e564-bocL-7iFD-Fpj8-1GUh-5eyc3S system 2honil-ni5v-B8ll-23M8-tfpQ-NC96-3hkLcL 9365880832</stdout>
-      <stdout>  root Y5Og1S-LvHZ-Ivob-doBF-0xwB-myYU-WzKfq5 system 2honil-ni5v-B8ll-23M8-tfpQ-NC96-3hkLcL 6241124352</stdout>
-      <stdout>  swap wGZ7UT-icrj-6iSM-gl0F-jxme-CW48-tOyl8Y system 2honil-ni5v-B8ll-23M8-tfpQ-NC96-3hkLcL 1560281088</stdout>
+      <name>/sbin/lvs --noheadings --unbuffered --units b --nosuffix --options lv_name,lv_uuid,vg_name,vg_uuid,lv_attr,lv_size</name>
+      <stdout>  home h2EA7Z-e564-bocL-7iFD-Fpj8-1GUh-5eyc3S system 2honil-ni5v-B8ll-23M8-tfpQ-NC96-3hkLcL -wi-ao---- 9365880832</stdout>
+      <stdout>  root Y5Og1S-LvHZ-Ivob-doBF-0xwB-myYU-WzKfq5 system 2honil-ni5v-B8ll-23M8-tfpQ-NC96-3hkLcL -wi-ao---- 6241124352</stdout>
+      <stdout>  swap wGZ7UT-icrj-6iSM-gl0F-jxme-CW48-tOyl8Y system 2honil-ni5v-B8ll-23M8-tfpQ-NC96-3hkLcL -wi-ao---- 1560281088</stdout>
     </Command>
     <Command>
-      <name>/sbin/pvs --noheadings --unbuffered --units b --nosuffix --options pv_name,pv_uuid,vg_name,vg_uuid</name>
-      <stdout>  /dev/sda1  h6d56s-qYq0-PWtG-Vso0-jWHR-mfH0-rohSdU system 2honil-ni5v-B8ll-23M8-tfpQ-NC96-3hkLcL</stdout>
+      <name>/sbin/pvs --noheadings --unbuffered --units b --nosuffix --options pv_name,pv_uuid,vg_name,vg_uuid,pv_attr</name>
+      <stdout>  /dev/sda1  h6d56s-qYq0-PWtG-Vso0-jWHR-mfH0-rohSdU system 2honil-ni5v-B8ll-23M8-tfpQ-NC96-3hkLcL a--</stdout>
     </Command>
     <Command>
       <name>/sbin/udevadm info '/dev/dm-0'</name>
@@ -628,8 +628,8 @@
       <name>/sbin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
-      <name>/sbin/vgs --noheadings --unbuffered --units b --nosuffix --options vg_name,vg_uuid,vg_extent_size,vg_extent_count</name>
-      <stdout>  system 2honil-ni5v-B8ll-23M8-tfpQ-NC96-3hkLcL 4194304 4095</stdout>
+      <name>/sbin/vgs --noheadings --unbuffered --units b --nosuffix --options vg_name,vg_uuid,vg_attr,vg_extent_size,vg_extent_count</name>
+      <stdout>  system 2honil-ni5v-B8ll-23M8-tfpQ-NC96-3hkLcL wz--n- 4194304 4095</stdout>
     </Command>
     <Command>
       <name>/usr/bin/lsscsi --transport</name>


### PR DESCRIPTION
A small addition for https://trello.com/c/puxZ3UdL/413-5-yast2-storage-ng-lvm-support-part-two.

So far pv_attr and vg_attr are not used in CmdLvm.cc but will likely be soon. Added them now avoids having to update mockups later. In any case they are good for debugging.