### PR TITLE
Obsolete again old libstorage

### DIFF
--- a/libstorage-ng.spec.in
+++ b/libstorage-ng.spec.in
@@ -143,9 +143,8 @@ Requires:       s390-tools
 %if 0%{?suse_version}
 PreReq:         %fillup_prereq
 %endif
-# Temporarily, we need libstorage-ng to be installable alongside libstorage
-# Obsoletes:      yast2-storage-lib
-# Obsoletes:      libstorage %(echo `seq -s " " -f "libstorage%.f" 9`)
+Obsoletes:      yast2-storage-lib
+Obsoletes:      libstorage %(echo `seq -s " " -f "libstorage%.f" 9`)
 Obsoletes:      libstorage-ng@LIBVERSION_MAJOR@ < %{version}
 Summary:        Library for storage management
 Group:          System/Libraries


### PR DESCRIPTION
We moved .deb packages depending on libstorage-ng to their own OBS project and removed all explicit dependencies from the old stack. Thus, we don't need both generations to be installed at the same time anymore.