### PR TITLE
the dependency fix: updated from the specfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,22 @@ Requirements
 
 Some required tools for compiling and testing libstorage-ng are:
 
-gcc-c++ boost-devel libxml2-devel libtool doxygen graphviz python-devel ruby ruby-devel ruby2.1-rubygem-test-unit rubypick rubygem-test-unit
+gcc-c++ boost-devel libxml2-devel libtool doxygen graphviz python-devel ruby ruby-devel
 swig >= 3.0.3 and != 3.0.8 (from [YaST:storage-ng](https://build.opensuse.org/project/show/YaST:storage-ng))
 
+In addition to the previous packages, add these distribution-specific packages as well.
+
+For openSUSE 13.2 and 13.1:
+
+rubygem-test-unit
+
+For Leap, Tumbleweed, SLES:
+
+ruby2.1-rubygem-test-unit
+
+For Fedora:
+
+rubypick rubygem-test-unit
 
 Compiling
 ---------

--- a/README.md
+++ b/README.md
@@ -12,22 +12,18 @@ Requirements
 
 Some required tools for compiling and testing libstorage-ng are:
 
-gcc-c++ boost-devel libxml2-devel libtool doxygen graphviz python-devel ruby ruby-devel
+gcc-c++ boost-devel libxml2-devel libtool doxygen graphviz python-devel ruby ruby-devel rubygem-test-unit
 swig >= 3.0.3 and != 3.0.8 (from [YaST:storage-ng](https://build.opensuse.org/project/show/YaST:storage-ng))
 
 In addition to the previous packages, add these distribution-specific packages as well.
 
-For openSUSE 13.2 and 13.1:
-
-rubygem-test-unit
-
-For Leap, Tumbleweed, SLES:
+For some openSUSE/SUSE distributions the naming of `rubygem-test-unit` might be the following:
 
 ruby2.1-rubygem-test-unit
 
 For Fedora:
 
-rubypick rubygem-test-unit
+rubypick
 
 Compiling
 ---------

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Requirements
 
 Some required tools for compiling and testing libstorage-ng are:
 
-gcc-c++, boost-devel, libxml2-devel, libtool, swig >= 3.0.3 and != 3.0.8
-(from [YaST:storage-ng](https://build.opensuse.org/project/show/YaST:storage-ng)),
-doxygen, python-devel, ruby, ruby-devel, rubygem-test-unit
+gcc-c++ boost-devel libxml2-devel libtool doxygen graphviz python-devel ruby ruby-devel ruby2.1-rubygem-test-unit rubypick rubygem-test-unit
+swig >= 3.0.3 and != 3.0.8 (from [YaST:storage-ng](https://build.opensuse.org/project/show/YaST:storage-ng))
+
 
 Compiling
 ---------


### PR DESCRIPTION
- added graphviz, rubypick[1]

- specified that rubygem-test-unit needs to be the ruby2.1-rubygem-test-unit package to avoid the error documented in the specfile (ruby2.1-stdlib does NOT actually provide rubygem-test-unit capabilities)[2]

- layout minor changes: removed commas and moved swig's comment to the end of the line for easier copy paste from README to zypper

[1] a quick search on the build services gave no results about this package. Is this dependency in the spec file still actual?

[2] https://bugzilla.suse.com/show_bug.cgi?id=961709