### PR TITLE
- temporarily mount filesystem for detect_resize_info and detect_content_info if required

### DIFF
--- a/storage/Filesystems/FilesystemImpl.cc
+++ b/storage/Filesystems/FilesystemImpl.cc
@@ -226,16 +226,9 @@ namespace storage
 
 	// TODO only in real probe mode allowed
 
-	const BlkDevice* blk_device = get_blk_device();
+	EnsureMounted ensure_mounted(this, TmpMount::READ_ONLY);
 
-	blk_device->get_impl().wait_for_device();
-
-	// TODO filesystem must be mounted
-
-	if (mountpoints.empty())
-	    ST_THROW(Exception("filesystem must be mounted"));
-
-	StatVfs stat_vfs = detect_stat_vfs(mountpoints.front());
+	StatVfs stat_vfs = detect_stat_vfs(ensure_mounted.get_any_mountpoint());
 
 	ResizeInfo resize_info(true);
 	resize_info.min_size = stat_vfs.size - stat_vfs.free;
@@ -273,19 +266,12 @@ namespace storage
 
 	// TODO only in real probe mode allowed
 
-	const BlkDevice* blk_device = get_blk_device();
-
-	blk_device->get_impl().wait_for_device();
-
-	// TODO filesystem must be mounted
-
-	if (mountpoints.empty())
-	    throw;
+	EnsureMounted ensure_mounted(this, TmpMount::READ_ONLY);
 
 	ContentInfo content_info;
 	content_info.is_windows = false;
 	content_info.is_efi = false;
-	content_info.num_homes = detect_num_homes(mountpoints.front());
+	content_info.num_homes = detect_num_homes(ensure_mounted.get_any_mountpoint());
 
 	return content_info;
     }

--- a/storage/Filesystems/FilesystemImpl.cc
+++ b/storage/Filesystems/FilesystemImpl.cc
@@ -226,7 +226,7 @@ namespace storage
 
 	// TODO only in real probe mode allowed
 
-	EnsureMounted ensure_mounted(this, TmpMount::READ_ONLY);
+	EnsureMounted ensure_mounted(this, TmpMount::Mode::READ_ONLY);
 
 	StatVfs stat_vfs = detect_stat_vfs(ensure_mounted.get_any_mountpoint());
 
@@ -266,7 +266,7 @@ namespace storage
 
 	// TODO only in real probe mode allowed
 
-	EnsureMounted ensure_mounted(this, TmpMount::READ_ONLY);
+	EnsureMounted ensure_mounted(this, TmpMount::Mode::READ_ONLY);
 
 	ContentInfo content_info;
 	content_info.is_windows = false;

--- a/storage/Filesystems/FilesystemImpl.cc
+++ b/storage/Filesystems/FilesystemImpl.cc
@@ -287,6 +287,9 @@ namespace storage
     bool
     Filesystem::Impl::detect_is_windows(const string& mountpoint)
     {
+	// The file '$Boot' is special. It is a reserved name of NTFS and from
+	// linux not visible with 'ls /mnt' but with 'ls /mnt/$Boot'.
+
 	const char* files[] = { "boot.ini", "msdos.sys", "io.sys", "config.sys", "MSDOS.SYS",
 				"IO.SYS", "bootmgr", "$Boot" };
 

--- a/storage/Filesystems/FilesystemImpl.cc
+++ b/storage/Filesystems/FilesystemImpl.cc
@@ -226,7 +226,7 @@ namespace storage
 
 	// TODO only in real probe mode allowed
 
-	EnsureMounted ensure_mounted(this, TmpMount::Mode::READ_ONLY);
+	EnsureMounted ensure_mounted(this);
 
 	StatVfs stat_vfs = detect_stat_vfs(ensure_mounted.get_any_mountpoint());
 
@@ -266,7 +266,7 @@ namespace storage
 
 	// TODO only in real probe mode allowed
 
-	EnsureMounted ensure_mounted(this, TmpMount::Mode::READ_ONLY);
+	EnsureMounted ensure_mounted(this);
 
 	ContentInfo content_info;
 	content_info.is_windows = false;
@@ -930,7 +930,7 @@ namespace storage
     }
 
 
-    EnsureMounted::EnsureMounted(const Filesystem::Impl* filesystem, TmpMount::Mode mode)
+    EnsureMounted::EnsureMounted(const Filesystem::Impl* filesystem)
 	: filesystem(filesystem), tmp_mount()
     {
 	if (!filesystem->get_mountpoints().empty())
@@ -942,7 +942,7 @@ namespace storage
 	blk_device->get_impl().wait_for_device();
 
 	tmp_mount.reset(new TmpMount(storage->get_impl().get_tmp_dir().get_fullname(),
-				     "tmp-mount-XXXXXX", blk_device->get_name(), mode));
+				     "tmp-mount-XXXXXX", blk_device->get_name()));
     }
 
 

--- a/storage/Filesystems/FilesystemImpl.cc
+++ b/storage/Filesystems/FilesystemImpl.cc
@@ -940,4 +940,30 @@ namespace storage
 
     }
 
+
+    EnsureMounted::EnsureMounted(const Filesystem::Impl* filesystem, TmpMount::Mode mode)
+	: filesystem(filesystem), tmp_mount()
+    {
+	if (!filesystem->get_mountpoints().empty())
+	    return;
+
+	const Storage* storage = filesystem->get_storage();
+	const BlkDevice* blk_device = filesystem->get_blk_device();
+
+	blk_device->get_impl().wait_for_device();
+
+	tmp_mount.reset(new TmpMount(storage->get_impl().get_tmp_dir().get_fullname(),
+				     "tmp-mount-XXXXXX", blk_device->get_name(), mode));
+    }
+
+
+    string
+    EnsureMounted::get_any_mountpoint() const
+    {
+	if (tmp_mount)
+	    return tmp_mount->get_fullname();
+	else
+	    return filesystem->get_mountpoints().front();
+    }
+
 }

--- a/storage/Filesystems/FilesystemImpl.h
+++ b/storage/Filesystems/FilesystemImpl.h
@@ -27,6 +27,7 @@
 
 #include "storage/Utils/Enum.h"
 #include "storage/Utils/CDgD.h"
+#include "storage/Utils/FileUtils.h"
 #include "storage/Filesystems/Filesystem.h"
 #include "storage/Devices/DeviceImpl.h"
 #include "storage/FreeInfo.h"
@@ -251,6 +252,32 @@ namespace storage
 	};
 
     }
+
+
+    class EnsureMounted : boost::noncopyable
+    {
+
+    public:
+
+	/**
+	 * Ensures that the filesystem is mounted somewhere.
+	 *
+	 * The mode is not enforced.
+	 */
+	EnsureMounted(const Filesystem::Impl* filesystem, TmpMount::Mode mode);
+
+	/**
+	 * Returns any mountpoint of the filesystem.
+	 */
+	string get_any_mountpoint() const;
+
+    private:
+
+	const Filesystem::Impl* filesystem;
+
+	unique_ptr<TmpMount> tmp_mount;
+
+    };
 
 }
 

--- a/storage/Filesystems/FilesystemImpl.h
+++ b/storage/Filesystems/FilesystemImpl.h
@@ -264,7 +264,7 @@ namespace storage
 	 *
 	 * The mode is not enforced.
 	 */
-	EnsureMounted(const Filesystem::Impl* filesystem, TmpMount::Mode mode);
+	EnsureMounted(const Filesystem::Impl* filesystem);
 
 	/**
 	 * Returns any mountpoint of the filesystem.

--- a/storage/Filesystems/NtfsImpl.cc
+++ b/storage/Filesystems/NtfsImpl.cc
@@ -94,7 +94,7 @@ namespace storage
     ContentInfo
     Ntfs::Impl::detect_content_info_pure() const
     {
-	EnsureMounted ensure_mounted(this, TmpMount::READ_ONLY);
+	EnsureMounted ensure_mounted(this, TmpMount::Mode::READ_ONLY);
 
 	ContentInfo content_info;
 

--- a/storage/Filesystems/NtfsImpl.cc
+++ b/storage/Filesystems/NtfsImpl.cc
@@ -94,18 +94,11 @@ namespace storage
     ContentInfo
     Ntfs::Impl::detect_content_info_pure() const
     {
-	const BlkDevice* blk_device = get_blk_device();
-
-	blk_device->get_impl().wait_for_device();
-
-	// TODO filesystem must be mounted
-
-	if (get_mountpoints().empty())
-	    throw;
+	EnsureMounted ensure_mounted(this, TmpMount::READ_ONLY);
 
 	ContentInfo content_info;
 
-	content_info.is_windows = detect_is_windows(get_mountpoints().front());
+	content_info.is_windows = detect_is_windows(ensure_mounted.get_any_mountpoint());
 
 	return content_info;
     }

--- a/storage/Filesystems/NtfsImpl.cc
+++ b/storage/Filesystems/NtfsImpl.cc
@@ -94,7 +94,7 @@ namespace storage
     ContentInfo
     Ntfs::Impl::detect_content_info_pure() const
     {
-	EnsureMounted ensure_mounted(this, TmpMount::Mode::READ_ONLY);
+	EnsureMounted ensure_mounted(this);
 
 	ContentInfo content_info;
 

--- a/storage/Filesystems/VfatImpl.cc
+++ b/storage/Filesystems/VfatImpl.cc
@@ -60,7 +60,7 @@ namespace storage
     ContentInfo
     Vfat::Impl::detect_content_info_pure() const
     {
-	EnsureMounted ensure_mounted(this, TmpMount::Mode::READ_ONLY);
+	EnsureMounted ensure_mounted(this);
 
 	ContentInfo content_info;
 

--- a/storage/Filesystems/VfatImpl.cc
+++ b/storage/Filesystems/VfatImpl.cc
@@ -60,7 +60,7 @@ namespace storage
     ContentInfo
     Vfat::Impl::detect_content_info_pure() const
     {
-	EnsureMounted ensure_mounted(this, TmpMount::READ_ONLY);
+	EnsureMounted ensure_mounted(this, TmpMount::Mode::READ_ONLY);
 
 	ContentInfo content_info;
 

--- a/storage/Filesystems/VfatImpl.cc
+++ b/storage/Filesystems/VfatImpl.cc
@@ -60,21 +60,14 @@ namespace storage
     ContentInfo
     Vfat::Impl::detect_content_info_pure() const
     {
-	const BlkDevice* blk_device = get_blk_device();
-
-	blk_device->get_impl().wait_for_device();
-
-	// TODO filesystem must be mounted
-
-	if (get_mountpoints().empty())
-	    throw;
+	EnsureMounted ensure_mounted(this, TmpMount::READ_ONLY);
 
 	ContentInfo content_info;
 
-	if (detect_is_efi(get_mountpoints().front()))
+	if (detect_is_efi(ensure_mounted.get_any_mountpoint()))
 	    content_info.is_efi = true;
 	else
-	    content_info.is_windows = detect_is_windows(get_mountpoints().front());
+	    content_info.is_windows = detect_is_windows(ensure_mounted.get_any_mountpoint());
 
 	return content_info;
     }

--- a/storage/Utils/FileUtils.cc
+++ b/storage/Utils/FileUtils.cc
@@ -85,7 +85,7 @@ namespace storage
 	: TmpDir(path, name_template)
     {
 	string cmd_line = MOUNTBIN;
-	if (mode == READ_ONLY)
+	if (mode == Mode::READ_ONLY)
 	    cmd_line += " --read-only";
 	cmd_line += " " + quote(device) + " " + quote(get_fullname());
 

--- a/storage/Utils/FileUtils.cc
+++ b/storage/Utils/FileUtils.cc
@@ -80,14 +80,10 @@ namespace storage
     }
 
 
-    TmpMount::TmpMount(const string& path, const string& name_template, const string& device,
-		       Mode mode)
+    TmpMount::TmpMount(const string& path, const string& name_template, const string& device)
 	: TmpDir(path, name_template)
     {
-	string cmd_line = MOUNTBIN;
-	if (mode == Mode::READ_ONLY)
-	    cmd_line += " --read-only";
-	cmd_line += " " + quote(device) + " " + quote(get_fullname());
+	string cmd_line = MOUNTBIN " --read-only " + quote(device) + " " + quote(get_fullname());
 
 	SystemCmd cmd(cmd_line);
 	if (cmd.retcode() != 0)

--- a/storage/Utils/FileUtils.h
+++ b/storage/Utils/FileUtils.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Novell, Inc.
+ * Copyright (c) 2016 SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -25,6 +26,7 @@
 
 
 #include <string>
+#include <boost/noncopyable.hpp>
 
 
 namespace storage
@@ -33,10 +35,15 @@ namespace storage
     using std::string;
 
 
-    class TmpDir
+    class TmpDir : private boost::noncopyable
     {
 
     public:
+
+	/**
+	 * Creates a temporary directory in path. For details see mkdtemp.
+	 */
+	TmpDir(const string& path, const string& name_template);
 
 	/**
 	 * Creates a temporary directory. For details see mkdtemp.
@@ -54,14 +61,38 @@ namespace storage
 
 	string get_fullname() const { return path + "/" + name; }
 
-    protected:
+    private:
 
-	string path;
+	const string path;
 	string name;
+
+	/**
+	 * Either value of TMPDIR or as a fallback /tmp.
+	 */
+	static string default_path();
+
+    };
+
+
+    class TmpMount : public TmpDir
+    {
+
+    public:
+
+	enum Mode { READ_ONLY, READ_WRITE };
+
+	/**
+	 * Mounts device at TmpDir(path, name_template).
+	 */
+	TmpMount(const string& path, const string& name_template, const string& device, Mode mode);
+
+	/**
+	 * Unmounts the device.
+	 */
+	~TmpMount();
 
     };
 
 }
-
 
 #endif

--- a/storage/Utils/FileUtils.h
+++ b/storage/Utils/FileUtils.h
@@ -79,12 +79,10 @@ namespace storage
 
     public:
 
-	enum class Mode { READ_ONLY, READ_WRITE };
-
 	/**
 	 * Mounts device at TmpDir(path, name_template).
 	 */
-	TmpMount(const string& path, const string& name_template, const string& device, Mode mode);
+	TmpMount(const string& path, const string& name_template, const string& device);
 
 	/**
 	 * Unmounts the device.

--- a/storage/Utils/FileUtils.h
+++ b/storage/Utils/FileUtils.h
@@ -79,7 +79,7 @@ namespace storage
 
     public:
 
-	enum Mode { READ_ONLY, READ_WRITE };
+	enum class Mode { READ_ONLY, READ_WRITE };
 
 	/**
 	 * Mounts device at TmpDir(path, name_template).


### PR DESCRIPTION
Temporarily mount filesystem for detect_resize_info and detect_content_info if required. Uses RAII for excepetion safety and to avoid programming mistakes.

For https://trello.com/c/YTeaoJYo/411-3-storageng-do-real-check-for-the-windows-partition.
