### PR TITLE
Added LvmLv.get_all()

### DIFF
--- a/storage/Devices/LvmLv.cc
+++ b/storage/Devices/LvmLv.cc
@@ -78,6 +78,20 @@ namespace storage
     }
 
 
+    vector<LvmLv*>
+    LvmLv::get_all(Devicegraph* devicegraph)
+    {
+	return devicegraph->get_impl().get_devices_of_type<LvmLv>();
+    }
+
+
+    vector<const LvmLv*>
+    LvmLv::get_all(const Devicegraph* devicegraph)
+    {
+	return devicegraph->get_impl().get_devices_of_type<const LvmLv>();
+    }
+
+
     const string&
     LvmLv::get_lv_name() const
     {

--- a/storage/Devices/LvmLv.h
+++ b/storage/Devices/LvmLv.h
@@ -42,6 +42,9 @@ namespace storage
 	static LvmLv* create(Devicegraph* devicegraph, const std::string& vg_name, const std::string& lv_name);
 	static LvmLv* load(Devicegraph* devicegraph, const xmlNode* node);
 
+	static std::vector<LvmLv*> get_all(Devicegraph* devicegraph);
+	static std::vector<const LvmLv*> get_all(const Devicegraph* devicegraph);
+
 	/**
 	 * Get logical volume name. This is different from get_name().
 	 */


### PR DESCRIPTION
Without this, `::Storage::LvmLv.all(devicegraph)` returns a list of all the devices. Quite unexpected.