### PR TITLE
- added interface to query used features

### DIFF
--- a/bindings/storage.deps
+++ b/bindings/storage.deps
@@ -36,6 +36,7 @@ DEPENDENCIES =						\
 	${top_srcdir}/storage/Holders/MdUser.h		\
 	${top_srcdir}/storage/Storage.h			\
 	${top_srcdir}/storage/FreeInfo.h		\
+	${top_srcdir}/storage/UsedFeatures.h		\
 	${top_srcdir}/storage/SystemInfo/Arch.h		\
 	${top_srcdir}/storage/Utils/Swig.h		\
 	${top_srcdir}/storage/Utils/Logger.h		\

--- a/bindings/storage.i
+++ b/bindings/storage.i
@@ -33,6 +33,7 @@
 #include "storage/Utils/Topology.h"
 #include "storage/Utils/Remote.h"
 #include "storage/FreeInfo.h"
+#include "storage/UsedFeatures.h"
 
 #include "storage/Devices/Device.h"
 #include "storage/Filesystems/Filesystem.h"
@@ -85,6 +86,7 @@
 %include "../../storage/Utils/Topology.h"
 %include "../../storage/Utils/Remote.h"
 %include "../../storage/FreeInfo.h"
+%include "../../storage/UsedFeatures.h"
 
 %include "../../storage/Devices/Device.h"
 %include "../../storage/Filesystems/Filesystem.h"

--- a/storage/Devicegraph.cc
+++ b/storage/Devicegraph.cc
@@ -343,6 +343,13 @@ namespace storage
     }
 
 
+    uint64_t
+    Devicegraph::used_features() const
+    {
+	return get_impl().used_features();
+    }
+
+
     void
     Devicegraph::copy(Devicegraph& dest) const
     {

--- a/storage/Devicegraph.h
+++ b/storage/Devicegraph.h
@@ -190,6 +190,11 @@ namespace storage
 
 	void check() const;
 
+	/**
+	 * Calculates a bit-field with the used features of the devicegraph.
+	 */
+	uint64_t used_features() const;
+
 	// TODO move to Impl
 	void copy(Devicegraph& dest) const;
 

--- a/storage/DevicegraphImpl.cc
+++ b/storage/DevicegraphImpl.cc
@@ -222,6 +222,21 @@ namespace storage
     }
 
 
+    uint64_t
+    Devicegraph::Impl::used_features() const
+    {
+	uint64_t ret = 0;
+
+	for (vertex_descriptor vertex : vertices())
+	{
+	    const Device* device = graph[vertex].get();
+	    ret |= device->get_impl().used_features();
+	}
+
+	return ret;
+    }
+
+
     bool
     Devicegraph::Impl::is_probed() const
     {

--- a/storage/DevicegraphImpl.h
+++ b/storage/DevicegraphImpl.h
@@ -82,6 +82,8 @@ namespace storage
 
 	void check() const;
 
+	uint64_t used_features() const;
+
 	void log_diff(std::ostream& log, const Impl& rhs) const;
 
 	/**

--- a/storage/Devices/BcacheCsetImpl.cc
+++ b/storage/Devices/BcacheCsetImpl.cc
@@ -30,6 +30,7 @@
 #include "storage/Devices/Bcache.h"
 #include "storage/Devices/BlkDeviceImpl.h"
 #include "storage/Holders/User.h"
+#include "storage/UsedFeatures.h"
 
 
 namespace storage
@@ -64,6 +65,13 @@ namespace storage
 
 	if (!get_uuid().empty() && !is_valid_uuid(get_uuid()))
 	    ST_THROW(Exception("invalid uuid"));
+    }
+
+
+    uint64_t
+    BcacheCset::Impl::used_features() const
+    {
+	return UF_BCACHE | Device::Impl::used_features();
     }
 
 

--- a/storage/Devices/BcacheCsetImpl.h
+++ b/storage/Devices/BcacheCsetImpl.h
@@ -70,6 +70,8 @@ namespace storage
 
 	virtual void check() const override;
 
+	virtual uint64_t used_features() const override;
+
 	const string& get_uuid() const { return uuid; }
 	void set_uuid(const string& uuid) { Impl::uuid = uuid; }
 

--- a/storage/Devices/BcacheImpl.cc
+++ b/storage/Devices/BcacheImpl.cc
@@ -29,6 +29,7 @@
 #include "storage/Devices/BcacheCset.h"
 #include "storage/Devicegraph.h"
 #include "storage/SystemInfo/SystemInfo.h"
+#include "storage/UsedFeatures.h"
 
 
 namespace storage
@@ -98,6 +99,13 @@ namespace storage
 
 	const BlkDevice* blk_device = BlkDevice::Impl::find_by_name(probed, dev, systeminfo);
 	User::create(probed, blk_device, get_device());
+    }
+
+
+    uint64_t
+    Bcache::Impl::used_features() const
+    {
+	return UF_BCACHE | BlkDevice::Impl::used_features();
     }
 
 

--- a/storage/Devices/BcacheImpl.h
+++ b/storage/Devices/BcacheImpl.h
@@ -60,6 +60,8 @@ namespace storage
 
 	virtual void save(xmlNode* node) const override;
 
+	virtual uint64_t used_features() const override;
+
 	unsigned int get_number() const;
 
 	const BlkDevice* get_blk_device() const;

--- a/storage/Devices/DeviceImpl.h
+++ b/storage/Devices/DeviceImpl.h
@@ -128,6 +128,8 @@ namespace storage
 
 	virtual void parent_has_new_region(const Device* parent);
 
+	virtual uint64_t used_features() const { return 0; }
+
 	/**
 	 * Add create actions for the Device.
 	 * @param actiongraph The Actiongraph fow which actions are added.

--- a/storage/Devices/DiskImpl.cc
+++ b/storage/Devices/DiskImpl.cc
@@ -36,6 +36,7 @@
 #include "storage/Utils/StorageTypes.h"
 #include "storage/Utils/StorageDefines.h"
 #include "storage/Utils/XmlFile.h"
+#include "storage/UsedFeatures.h"
 
 
 namespace storage
@@ -108,6 +109,23 @@ namespace storage
 	Lsscsi::Entry entry;
 	if (systeminfo.getLsscsi().getEntry(get_name(), entry))
 	    transport = entry.transport;
+    }
+
+
+    uint64_t
+    Disk::Impl::used_features() const
+    {
+	uint64_t ret = 0;
+
+	switch (transport)
+	{
+	    case Transport::FC: ret = UF_FC; break;
+	    case Transport::FCOE: ret = UF_FCOE; break;
+	    case Transport::ISCSI: ret = UF_ISCSI; break;
+	    default: break;
+	}
+
+	return ret | Partitionable::Impl::used_features();
     }
 
 

--- a/storage/Devices/DiskImpl.h
+++ b/storage/Devices/DiskImpl.h
@@ -70,6 +70,8 @@ namespace storage
 	static void probe_disks(Devicegraph* probed, SystemInfo& systeminfo);
 	virtual void probe_pass_1(Devicegraph* probed, SystemInfo& systeminfo) override;
 
+	virtual uint64_t used_features() const override;
+
 	virtual void add_create_actions(Actiongraph::Impl& actiongraph) const override;
 	virtual void add_delete_actions(Actiongraph::Impl& actiongraph) const override;
 

--- a/storage/Devices/LuksImpl.cc
+++ b/storage/Devices/LuksImpl.cc
@@ -31,6 +31,7 @@
 #include "storage/FreeInfo.h"
 #include "storage/StorageImpl.h"
 #include "storage/SystemInfo/SystemInfo.h"
+#include "storage/UsedFeatures.h"
 
 
 namespace storage
@@ -182,6 +183,13 @@ namespace storage
 	// TODO handle metadata size
 
 	return resize_info;
+    }
+
+
+    uint64_t
+    Luks::Impl::used_features() const
+    {
+	return UF_LUKS | Encryption::Impl::used_features();
     }
 
 

--- a/storage/Devices/LuksImpl.h
+++ b/storage/Devices/LuksImpl.h
@@ -71,6 +71,8 @@ namespace storage
 
 	virtual ResizeInfo detect_resize_info() const override;
 
+	virtual uint64_t used_features() const override;
+
 	virtual void do_create() const override;
 
 	virtual void do_delete() const override;

--- a/storage/Devices/LvmPvImpl.cc
+++ b/storage/Devices/LvmPvImpl.cc
@@ -34,6 +34,7 @@
 #include "storage/Devices/BlkDeviceImpl.h"
 #include "storage/FindBy.h"
 #include "storage/FreeInfo.h"
+#include "storage/UsedFeatures.h"
 
 
 namespace storage
@@ -156,6 +157,13 @@ namespace storage
 	}
 
 	return resize_info;
+    }
+
+
+    uint64_t
+    LvmPv::Impl::used_features() const
+    {
+	return UF_LVM | Device::Impl::used_features();
     }
 
 

--- a/storage/Devices/LvmPvImpl.h
+++ b/storage/Devices/LvmPvImpl.h
@@ -72,6 +72,8 @@ namespace storage
 
 	virtual ResizeInfo detect_resize_info() const override;
 
+	virtual uint64_t used_features() const override;
+
 	virtual void parent_has_new_region(const Device* parent) override;
 
 	static LvmPv* find_by_uuid(Devicegraph* devicegraph, const std::string& uuid);

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -41,6 +41,7 @@
 #include "storage/Utils/StorageTmpl.h"
 #include "storage/Utils/XmlFile.h"
 #include "storage/Utils/HumanString.h"
+#include "storage/UsedFeatures.h"
 
 
 namespace storage
@@ -301,6 +302,13 @@ namespace storage
 	    ST_THROW(Exception("md name has no number"));
 
 	return atoi(get_name().substr(pos + 1).c_str());
+    }
+
+
+    uint64_t
+    Md::Impl::used_features() const
+    {
+	return UF_MDRAID | Partitionable::Impl::used_features();
     }
 
 

--- a/storage/Devices/MdImpl.h
+++ b/storage/Devices/MdImpl.h
@@ -95,6 +95,8 @@ namespace storage
 
 	virtual void process_udev_ids(vector<string>& udev_ids) const override;
 
+	virtual uint64_t used_features() const override;
+
 	virtual Text do_create_text(Tense tense) const override;
 	virtual void do_create() const override;
 

--- a/storage/Filesystems/BtrfsImpl.cc
+++ b/storage/Filesystems/BtrfsImpl.cc
@@ -31,6 +31,7 @@
 #include "storage/Utils/HumanString.h"
 #include "storage/Utils/SystemCmd.h"
 #include "storage/FreeInfo.h"
+#include "storage/UsedFeatures.h"
 
 
 namespace storage
@@ -56,6 +57,13 @@ namespace storage
 	resize_info.combine(ResizeInfo(true, 256 * MiB, 16 * EiB));
 
 	return resize_info;
+    }
+
+
+    uint64_t
+    Btrfs::Impl::used_features() const
+    {
+	return UF_BTRFS | Filesystem::Impl::used_features();
     }
 
 

--- a/storage/Filesystems/BtrfsImpl.h
+++ b/storage/Filesystems/BtrfsImpl.h
@@ -58,6 +58,8 @@ namespace storage
 
 	virtual ResizeInfo detect_resize_info() const override;
 
+	virtual uint64_t used_features() const override;
+
 	virtual void do_create() const override;
 
 	virtual void do_set_label() const override;

--- a/storage/Filesystems/Ext4Impl.cc
+++ b/storage/Filesystems/Ext4Impl.cc
@@ -31,6 +31,7 @@
 #include "storage/Devicegraph.h"
 #include "storage/Action.h"
 #include "storage/FreeInfo.h"
+#include "storage/UsedFeatures.h"
 
 
 namespace storage
@@ -56,6 +57,13 @@ namespace storage
 	resize_info.combine(ResizeInfo(true, 32 * MiB, 16 * TiB));
 
 	return resize_info;
+    }
+
+
+    uint64_t
+    Ext4::Impl::used_features() const
+    {
+	return UF_EXT4 | Filesystem::Impl::used_features();
     }
 
 

--- a/storage/Filesystems/Ext4Impl.h
+++ b/storage/Filesystems/Ext4Impl.h
@@ -58,6 +58,8 @@ namespace storage
 
 	virtual ResizeInfo detect_resize_info() const override;
 
+	virtual uint64_t used_features() const override;
+
 	virtual void do_create() const override;
 
 	virtual void do_set_label() const override;

--- a/storage/Filesystems/NtfsImpl.cc
+++ b/storage/Filesystems/NtfsImpl.cc
@@ -31,6 +31,7 @@
 #include "storage/Devices/BlkDeviceImpl.h"
 #include "storage/Filesystems/NtfsImpl.h"
 #include "storage/FreeInfo.h"
+#include "storage/UsedFeatures.h"
 
 
 namespace storage
@@ -101,6 +102,13 @@ namespace storage
 	content_info.is_windows = detect_is_windows(ensure_mounted.get_any_mountpoint());
 
 	return content_info;
+    }
+
+
+    uint64_t
+    Ntfs::Impl::used_features() const
+    {
+	return UF_NTFS | Filesystem::Impl::used_features();
     }
 
 

--- a/storage/Filesystems/NtfsImpl.h
+++ b/storage/Filesystems/NtfsImpl.h
@@ -59,6 +59,8 @@ namespace storage
 
 	virtual ContentInfo detect_content_info_pure() const override;
 
+	virtual uint64_t used_features() const override;
+
 	virtual void do_create() const override;
 
 	virtual void do_set_label() const override;

--- a/storage/Filesystems/SwapImpl.cc
+++ b/storage/Filesystems/SwapImpl.cc
@@ -31,6 +31,7 @@
 #include "storage/Utils/SystemCmd.h"
 #include "storage/Utils/HumanString.h"
 #include "storage/FreeInfo.h"
+#include "storage/UsedFeatures.h"
 
 
 namespace storage
@@ -59,6 +60,13 @@ namespace storage
     Swap::Impl::detect_content_info() const
     {
 	return ContentInfo();
+    }
+
+
+    uint64_t
+    Swap::Impl::used_features() const
+    {
+	return UF_SWAP | Filesystem::Impl::used_features();
     }
 
 

--- a/storage/Filesystems/SwapImpl.h
+++ b/storage/Filesystems/SwapImpl.h
@@ -59,6 +59,8 @@ namespace storage
 
 	virtual ContentInfo detect_content_info() const override;
 
+	virtual uint64_t used_features() const override;
+
 	virtual void do_create() const override;
 
 	virtual void do_mount(const Actiongraph::Impl& actiongraph, const string& mountpoint) const override;

--- a/storage/Filesystems/VfatImpl.cc
+++ b/storage/Filesystems/VfatImpl.cc
@@ -29,6 +29,7 @@
 #include "storage/Devices/BlkDeviceImpl.h"
 #include "storage/Filesystems/VfatImpl.h"
 #include "storage/FreeInfo.h"
+#include "storage/UsedFeatures.h"
 
 
 namespace storage
@@ -70,6 +71,13 @@ namespace storage
 	    content_info.is_windows = detect_is_windows(ensure_mounted.get_any_mountpoint());
 
 	return content_info;
+    }
+
+
+    uint64_t
+    Vfat::Impl::used_features() const
+    {
+	return UF_VFAT | Filesystem::Impl::used_features();
     }
 
 

--- a/storage/Filesystems/VfatImpl.h
+++ b/storage/Filesystems/VfatImpl.h
@@ -59,6 +59,8 @@ namespace storage
 
 	virtual ContentInfo detect_content_info_pure() const override;
 
+	virtual uint64_t used_features() const override;
+
 	virtual void do_create() const override;
 
 	virtual void do_set_label() const override;

--- a/storage/Filesystems/XfsImpl.cc
+++ b/storage/Filesystems/XfsImpl.cc
@@ -31,6 +31,7 @@
 #include "storage/Utils/SystemCmd.h"
 #include "storage/Utils/HumanString.h"
 #include "storage/FreeInfo.h"
+#include "storage/UsedFeatures.h"
 
 
 namespace storage
@@ -56,6 +57,13 @@ namespace storage
 	resize_info.combine(ResizeInfo(true, 40 * MiB, 16 * EiB));
 
 	return resize_info;
+    }
+
+
+    uint64_t
+    Xfs::Impl::used_features() const
+    {
+	return UF_XFS | Filesystem::Impl::used_features();
     }
 
 

--- a/storage/Filesystems/XfsImpl.h
+++ b/storage/Filesystems/XfsImpl.h
@@ -58,6 +58,8 @@ namespace storage
 
 	virtual ResizeInfo detect_resize_info() const override;
 
+	virtual uint64_t used_features() const override;
+
 	virtual void do_create() const override;
 
 	virtual void do_set_label() const override;

--- a/storage/Makefile.am
+++ b/storage/Makefile.am
@@ -21,6 +21,7 @@ libstorage_ng_la_SOURCES =				\
 	EtcFstab.h		EtcFstab.cc		\
 	EtcMdadm.h		EtcMdadm.cc		\
 	FreeInfo.h		FreeInfo.cc		\
+	UsedFeatures.h					\
 	Version.h
 
 libstorage_ng_la_LDFLAGS = -version-info @LIBVERSION_INFO@
@@ -42,5 +43,6 @@ pkginclude_HEADERS =		\
 	Devicegraph.h		\
 	Actiongraph.h		\
 	Graphviz.h		\
-	FreeInfo.h
+	FreeInfo.h		\
+	UsedFeatures.h
 

--- a/storage/UsedFeatures.h
+++ b/storage/UsedFeatures.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2016 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+
+#ifndef STORAGE_USED_FEATURES_H
+#define STORAGE_USED_FEATURES_H
+
+
+#include <stdint.h>
+
+
+enum : uint64_t
+{
+    UF_EXT2 = 1 << 0,
+    US_EXT3 = 1 << 1,
+    UF_EXT4 = 1 << 2,
+    UF_BTRFS = 1 << 3,
+    UF_XFS = 1 << 4,
+    UF_REISERFS = 1 << 5,
+    UF_SWAP = 1 << 6,
+    UF_NTFS = 1 << 7,
+    UF_VFAT = 1 << 8,
+    UF_NFS = 1 << 9,
+    UF_NFS4 = 1 << 10,
+
+    UF_LUKS = 1 << 11,
+
+    UF_LVM = 1 << 12,
+    UF_MDRAID = 1 << 13,
+    UF_DMRAID = 1 << 14,
+    UF_DMMULTIPATH = 1 << 15,
+
+    UF_ISCSI = 1 << 16,
+    UF_FCOE = 1 << 17,
+    UF_FC = 1 << 18,
+
+    UF_QUOTA = 1 << 19
+};
+
+
+#endif

--- a/storage/UsedFeatures.h
+++ b/storage/UsedFeatures.h
@@ -47,12 +47,13 @@ enum : uint64_t
     UF_MDRAID = 1 << 13,
     UF_DMRAID = 1 << 14,
     UF_DMMULTIPATH = 1 << 15,
+    UF_BCACHE = 1 << 16,
 
-    UF_ISCSI = 1 << 16,
-    UF_FCOE = 1 << 17,
-    UF_FC = 1 << 18,
+    UF_ISCSI = 1 << 17,
+    UF_FCOE = 1 << 18,
+    UF_FC = 1 << 19,
 
-    UF_QUOTA = 1 << 19
+    UF_QUOTA = 1 << 20
 };
 
 

--- a/testsuite/probe/bcache1.cc
+++ b/testsuite/probe/bcache1.cc
@@ -8,6 +8,7 @@
 #include "storage/Environment.h"
 #include "storage/Storage.h"
 #include "storage/DevicegraphImpl.h"
+#include "storage/UsedFeatures.h"
 
 #include "testsuite/helpers/TsCmp.h"
 
@@ -36,4 +37,6 @@ BOOST_AUTO_TEST_CASE(dependencies)
 
     TsCmpDevicegraph cmp(*probed, *staging);
     BOOST_CHECK_MESSAGE(cmp.ok(), cmp);
+
+    BOOST_CHECK_BITWISE_EQUAL(probed->used_features(), UF_XFS | UF_EXT4 | UF_SWAP | UF_BCACHE);
 }

--- a/testsuite/probe/disk.cc
+++ b/testsuite/probe/disk.cc
@@ -8,6 +8,7 @@
 #include "storage/Environment.h"
 #include "storage/Storage.h"
 #include "storage/DevicegraphImpl.h"
+#include "storage/UsedFeatures.h"
 
 #include "testsuite/helpers/TsCmp.h"
 
@@ -36,4 +37,6 @@ BOOST_AUTO_TEST_CASE(dependencies)
 
     TsCmpDevicegraph cmp(*probed, *staging);
     BOOST_CHECK_MESSAGE(cmp.ok(), cmp);
+
+    BOOST_CHECK_BITWISE_EQUAL(probed->used_features(), UF_EXT4 | UF_SWAP);
 }

--- a/testsuite/probe/luks1.cc
+++ b/testsuite/probe/luks1.cc
@@ -8,6 +8,7 @@
 #include "storage/Environment.h"
 #include "storage/Storage.h"
 #include "storage/DevicegraphImpl.h"
+#include "storage/UsedFeatures.h"
 
 #include "testsuite/helpers/TsCmp.h"
 
@@ -36,4 +37,6 @@ BOOST_AUTO_TEST_CASE(dependencies)
 
     TsCmpDevicegraph cmp(*probed, *staging);
     BOOST_CHECK_MESSAGE(cmp.ok(), cmp);
+
+    BOOST_CHECK_BITWISE_EQUAL(probed->used_features(), UF_XFS | UF_EXT4 | UF_LUKS);
 }

--- a/testsuite/probe/lvm1.cc
+++ b/testsuite/probe/lvm1.cc
@@ -8,6 +8,7 @@
 #include "storage/Environment.h"
 #include "storage/Storage.h"
 #include "storage/DevicegraphImpl.h"
+#include "storage/UsedFeatures.h"
 
 #include "testsuite/helpers/TsCmp.h"
 
@@ -36,4 +37,6 @@ BOOST_AUTO_TEST_CASE(dependencies)
 
     TsCmpDevicegraph cmp(*probed, *staging);
     BOOST_CHECK_MESSAGE(cmp.ok(), cmp);
+
+    BOOST_CHECK_BITWISE_EQUAL(probed->used_features(), UF_XFS | UF_EXT4 | UF_SWAP| UF_LVM);
 }

--- a/testsuite/probe/md1.cc
+++ b/testsuite/probe/md1.cc
@@ -8,6 +8,7 @@
 #include "storage/Environment.h"
 #include "storage/Storage.h"
 #include "storage/DevicegraphImpl.h"
+#include "storage/UsedFeatures.h"
 
 #include "testsuite/helpers/TsCmp.h"
 
@@ -36,4 +37,6 @@ BOOST_AUTO_TEST_CASE(dependencies)
 
     TsCmpDevicegraph cmp(*probed, *staging);
     BOOST_CHECK_MESSAGE(cmp.ok(), cmp);
+
+    BOOST_CHECK_BITWISE_EQUAL(probed->used_features(), (uint64_t)(UF_MDRAID));
 }

--- a/testsuite/probe/md2.cc
+++ b/testsuite/probe/md2.cc
@@ -8,6 +8,7 @@
 #include "storage/Environment.h"
 #include "storage/Storage.h"
 #include "storage/DevicegraphImpl.h"
+#include "storage/UsedFeatures.h"
 
 #include "testsuite/helpers/TsCmp.h"
 
@@ -36,4 +37,6 @@ BOOST_AUTO_TEST_CASE(dependencies)
 
     TsCmpDevicegraph cmp(*probed, *staging);
     BOOST_CHECK_MESSAGE(cmp.ok(), cmp);
+
+    BOOST_CHECK_BITWISE_EQUAL(probed->used_features(), UF_BTRFS | UF_EXT4 | UF_MDRAID);
 }


### PR DESCRIPTION
The interface can be used to implement SaveUsedFs() and AddPackageList() in Storage.rb for storage-ng. See https://github.com/yast/yast-storage/blob/master/src/lib/storage/used_storage_features.rb for the implementation working on the target-map.

Also see https://trello.com/c/ZSnI5lF0/446-1-summarize-what-the-software-proposal-really-needs-from-storage.

