### PR TITLE
Added Travis support (use Docker for building)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+language: bash
+services:
+  - docker
+
+before_install:
+  - docker build -t libstorage-ng-image .
+script:
+  # the "storage-ng-travis-cpp" script is included in the base yastdevel/storage-ng image
+  # see https://github.com/yast/docker-storage-ng/blob/master/storage-ng-travis-cpp
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" libstorage-ng-image storage-ng-travis-cpp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM yastdevel/storage-ng
+COPY . /usr/src/app
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 libstorage-ng
 =============
 
+[![Build Status](https://travis-ci.org/openSUSE/libstorage-ng.svg?branch=master)](https://travis-ci.org/openSUSE/libstorage-ng)
+
 libstorage-ng is the designated successor of
 [libstorage](https://github.com/openSUSE/libstorage), a C++ library used by
 [YaST](https://github.com/yast) to perform most storage related tasks.


### PR DESCRIPTION
See https://hub.docker.com/r/yastdevel/storage-ng/ and https://github.com/yast/docker-storage-ng for the details about the `yastdevel/storage-ng` Docker image used for building.