### PR TITLE
Superset of "renumber logical partitions"

### DIFF
--- a/integration-tests/partitions/delete-partition.py
+++ b/integration-tests/partitions/delete-partition.py
@@ -4,6 +4,7 @@
 
 
 from storage import *
+from storageitu import *
 
 
 set_logger(get_logfile_logger())
@@ -24,6 +25,5 @@ partition_table.delete_partition("/dev/sdb1")
 
 print staging
 
-storage.calculate_actiongraph()
-storage.commit()
+commit(storage)
 

--- a/storage/ActiongraphImpl.cc
+++ b/storage/ActiongraphImpl.cc
@@ -31,6 +31,7 @@
 #include "storage/Utils/Stopwatch.h"
 #include "storage/Devices/DeviceImpl.h"
 #include "storage/Devices/BlkDevice.h"
+#include "storage/Devices/PartitionTableImpl.h"
 #include "storage/Filesystems/FilesystemImpl.h"
 #include "storage/Devicegraph.h"
 #include "storage/Utils/GraphUtils.h"
@@ -283,6 +284,8 @@ namespace storage
 
 	    device->get_impl().add_dependencies(*this);
 	}
+
+	PartitionTable::Impl::add_all_dependencies(*this);
 
 	for (vertex_descriptor vertex : vertices())
 	{

--- a/storage/Devices/BcacheImpl.cc
+++ b/storage/Devices/BcacheImpl.cc
@@ -22,6 +22,7 @@
 
 #include <boost/regex.hpp>
 
+#include "storage/Utils/AppUtil.h"
 #include "storage/Utils/StorageDefines.h"
 #include "storage/Utils/XmlFile.h"
 #include "storage/Holders/User.h"
@@ -112,11 +113,7 @@ namespace storage
     unsigned int
     Bcache::Impl::get_number() const
     {
-	string::size_type pos = get_name().find_last_not_of("0123456789");
-	if (pos == string::npos || pos == get_name().size() - 1)
-	    ST_THROW(Exception("bcache name has no number"));
-
-	return atoi(get_name().substr(pos + 1).c_str());
+	return device_to_name_and_number(get_name()).second;
     }
 
 

--- a/storage/Devices/EncryptionImpl.cc
+++ b/storage/Devices/EncryptionImpl.cc
@@ -112,7 +112,7 @@ namespace storage
 
 	actions.push_back(new Action::Create(get_sid()));
 	actions.push_back(new Action::Activate(get_sid()));
-	actions.push_back(new Action::AddEtcCrypttab(get_sid()));
+	actions.push_back(new Action::AddToEtcCrypttab(get_sid()));
 
 	actiongraph.add_chain(actions);
     }
@@ -129,7 +129,7 @@ namespace storage
 	// TODO depends on mount-by, whether there actually is an entry in crypttab
 	if (get_blk_device()->get_name() != lhs.get_blk_device()->get_name())
 	{
-	    actions.push_back(new Action::RenameEtcCrypttab(get_sid()));
+	    actions.push_back(new Action::RenameInEtcCrypttab(get_sid()));
 	}
 
 	actiongraph.add_chain(actions);
@@ -141,7 +141,7 @@ namespace storage
     {
 	vector<Action::Base*> actions;
 
-	actions.push_back(new Action::RemoveEtcCrypttab(get_sid()));
+	actions.push_back(new Action::RemoveFromEtcCrypttab(get_sid()));
 	actions.push_back(new Action::Deactivate(get_sid()));
 	actions.push_back(new Action::Delete(get_sid()));
 
@@ -290,7 +290,7 @@ namespace storage
 
 
     Text
-    Encryption::Impl::do_add_etc_crypttab_text(Tense tense) const
+    Encryption::Impl::do_add_to_etc_crypttab_text(Tense tense) const
     {
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
@@ -305,14 +305,14 @@ namespace storage
 
 
     void
-    Encryption::Impl::do_add_etc_crypttab(const Actiongraph::Impl& actiongraph) const
+    Encryption::Impl::do_add_to_etc_crypttab(const Actiongraph::Impl& actiongraph) const
     {
-	ST_THROW(LogicException("stub do_add_etc_crypttab called"));
+	ST_THROW(LogicException("stub do_add_to_etc_crypttab called"));
     }
 
 
     Text
-    Encryption::Impl::do_rename_etc_crypttab_text(const Device* lhs, Tense tense) const
+    Encryption::Impl::do_rename_in_etc_crypttab_text(const Device* lhs, Tense tense) const
     {
 	const BlkDevice* blk_device_lhs = to_encryption(lhs)->get_impl().get_blk_device();
 	const BlkDevice* blk_device_rhs = get_blk_device();
@@ -333,15 +333,15 @@ namespace storage
 
 
     void
-    Encryption::Impl::do_rename_etc_crypttab(const Actiongraph::Impl& actiongraph,
+    Encryption::Impl::do_rename_in_etc_crypttab(const Actiongraph::Impl& actiongraph,
 					     const Device* lhs) const
     {
-        ST_THROW(LogicException("stub do_rename_etc_crypttab called"));
+        ST_THROW(LogicException("stub do_rename_in_etc_crypttab called"));
     }
 
 
     Text
-    Encryption::Impl::do_remove_etc_crypttab_text(Tense tense) const
+    Encryption::Impl::do_remove_from_etc_crypttab_text(Tense tense) const
     {
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
@@ -356,9 +356,9 @@ namespace storage
 
 
     void
-    Encryption::Impl::do_remove_etc_crypttab(const Actiongraph::Impl& actiongraph) const
+    Encryption::Impl::do_remove_from_etc_crypttab(const Actiongraph::Impl& actiongraph) const
     {
-	ST_THROW(LogicException("stub do_remove_etc_crypttab called"));
+	ST_THROW(LogicException("stub do_remove_from_etc_crypttab called"));
     }
 
 
@@ -366,23 +366,23 @@ namespace storage
     {
 
 	Text
-	AddEtcCrypttab::text(const Actiongraph::Impl& actiongraph, Tense tense) const
+	AddToEtcCrypttab::text(const Actiongraph::Impl& actiongraph, Tense tense) const
 	{
 	    const Encryption* encryption = to_encryption(get_device_rhs(actiongraph));
-	    return encryption->get_impl().do_add_etc_crypttab_text(tense);
+	    return encryption->get_impl().do_add_to_etc_crypttab_text(tense);
 	}
 
 
 	void
-	AddEtcCrypttab::commit(const Actiongraph::Impl& actiongraph) const
+	AddToEtcCrypttab::commit(const Actiongraph::Impl& actiongraph) const
 	{
 	    const Encryption* encryption = to_encryption(get_device_rhs(actiongraph));
-	    encryption->get_impl().do_add_etc_crypttab(actiongraph);
+	    encryption->get_impl().do_add_to_etc_crypttab(actiongraph);
 	}
 
 
 	void
-	AddEtcCrypttab::add_dependencies(Actiongraph::Impl::vertex_descriptor vertex,
+	AddToEtcCrypttab::add_dependencies(Actiongraph::Impl::vertex_descriptor vertex,
 					 Actiongraph::Impl& actiongraph) const
 	{
 	    if (actiongraph.mount_root_filesystem != actiongraph.vertices().end())
@@ -391,36 +391,36 @@ namespace storage
 
 
 	Text
-	RenameEtcCrypttab::text(const Actiongraph::Impl& actiongraph, Tense tense) const
+	RenameInEtcCrypttab::text(const Actiongraph::Impl& actiongraph, Tense tense) const
 	{
 	    const Encryption* encryption_lhs = to_encryption(get_device_lhs(actiongraph));
 	    const Encryption* encryption_rhs = to_encryption(get_device_rhs(actiongraph));
-	    return encryption_rhs->get_impl().do_rename_etc_crypttab_text(encryption_lhs, tense);
+	    return encryption_rhs->get_impl().do_rename_in_etc_crypttab_text(encryption_lhs, tense);
 	}
 
 
 	void
-	RenameEtcCrypttab::commit(const Actiongraph::Impl& actiongraph) const
+	RenameInEtcCrypttab::commit(const Actiongraph::Impl& actiongraph) const
 	{
 	    const Encryption* encryption_lhs = to_encryption(get_device_lhs(actiongraph));
 	    const Encryption* encryption_rhs = to_encryption(get_device_rhs(actiongraph));
-	    encryption_rhs->get_impl().do_rename_etc_crypttab(actiongraph, encryption_lhs);
+	    encryption_rhs->get_impl().do_rename_in_etc_crypttab(actiongraph, encryption_lhs);
 	}
 
 
 	Text
-	RemoveEtcCrypttab::text(const Actiongraph::Impl& actiongraph, Tense tense) const
+	RemoveFromEtcCrypttab::text(const Actiongraph::Impl& actiongraph, Tense tense) const
 	{
 	    const Encryption* encryption = to_encryption(get_device_lhs(actiongraph));
-	    return encryption->get_impl().do_remove_etc_crypttab_text(tense);
+	    return encryption->get_impl().do_remove_from_etc_crypttab_text(tense);
 	}
 
 
 	void
-	RemoveEtcCrypttab::commit(const Actiongraph::Impl& actiongraph) const
+	RemoveFromEtcCrypttab::commit(const Actiongraph::Impl& actiongraph) const
 	{
 	    const Encryption* encryption = to_encryption(get_device_lhs(actiongraph));
-	    encryption->get_impl().do_remove_etc_crypttab(actiongraph);
+	    encryption->get_impl().do_remove_from_etc_crypttab(actiongraph);
 	}
 
     }

--- a/storage/Devices/EncryptionImpl.cc
+++ b/storage/Devices/EncryptionImpl.cc
@@ -336,7 +336,7 @@ namespace storage
     Encryption::Impl::do_rename_etc_crypttab(const Actiongraph::Impl& actiongraph,
 					     const Device* lhs) const
     {
-        // TODO
+        ST_THROW(LogicException("stub do_rename_etc_crypttab called"));
     }
 
 

--- a/storage/Devices/EncryptionImpl.h
+++ b/storage/Devices/EncryptionImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -66,6 +66,7 @@ namespace storage
 	void probe_pass_2(Devicegraph* probed, SystemInfo& systeminfo) override;
 
 	virtual void add_create_actions(Actiongraph::Impl& actiongraph) const override;
+	virtual void add_modify_actions(Actiongraph::Impl& actiongraph, const Device* lhs) const override;
 	virtual void add_delete_actions(Actiongraph::Impl& actiongraph) const override;
 
 	virtual bool equal(const Device::Impl& rhs) const override;
@@ -85,6 +86,9 @@ namespace storage
 
 	virtual Text do_add_etc_crypttab_text(Tense tense) const;
 	virtual void do_add_etc_crypttab(const Actiongraph::Impl& actiongraph) const;
+
+	virtual Text do_rename_etc_crypttab_text(const Device* lhs, Tense tense) const;
+	virtual void do_rename_etc_crypttab(const Actiongraph::Impl& actiongraph, const Device* lhs) const;
 
 	virtual Text do_remove_etc_crypttab_text(Tense tense) const;
 	virtual void do_remove_etc_crypttab(const Actiongraph::Impl& actiongraph) const;
@@ -112,6 +116,18 @@ namespace storage
 
 	    virtual void add_dependencies(Actiongraph::Impl::vertex_descriptor vertex,
 					  Actiongraph::Impl& actiongraph) const override;
+
+	};
+
+
+	class RenameEtcCrypttab : public Modify
+	{
+	public:
+
+	    RenameEtcCrypttab(sid_t sid) : Modify(sid) {}
+
+	    virtual Text text(const Actiongraph::Impl& actiongraph, Tense tense) const override;
+	    virtual void commit(const Actiongraph::Impl& actiongraph) const override;
 
 	};
 

--- a/storage/Devices/EncryptionImpl.h
+++ b/storage/Devices/EncryptionImpl.h
@@ -84,14 +84,14 @@ namespace storage
 
 	virtual Text do_deactivate_text(Tense tense) const override;
 
-	virtual Text do_add_etc_crypttab_text(Tense tense) const;
-	virtual void do_add_etc_crypttab(const Actiongraph::Impl& actiongraph) const;
+	virtual Text do_add_to_etc_crypttab_text(Tense tense) const;
+	virtual void do_add_to_etc_crypttab(const Actiongraph::Impl& actiongraph) const;
 
-	virtual Text do_rename_etc_crypttab_text(const Device* lhs, Tense tense) const;
-	virtual void do_rename_etc_crypttab(const Actiongraph::Impl& actiongraph, const Device* lhs) const;
+	virtual Text do_rename_in_etc_crypttab_text(const Device* lhs, Tense tense) const;
+	virtual void do_rename_in_etc_crypttab(const Actiongraph::Impl& actiongraph, const Device* lhs) const;
 
-	virtual Text do_remove_etc_crypttab_text(Tense tense) const;
-	virtual void do_remove_etc_crypttab(const Actiongraph::Impl& actiongraph) const;
+	virtual Text do_remove_from_etc_crypttab_text(Tense tense) const;
+	virtual void do_remove_from_etc_crypttab(const Actiongraph::Impl& actiongraph) const;
 
     private:
 
@@ -105,11 +105,11 @@ namespace storage
     namespace Action
     {
 
-	class AddEtcCrypttab : public Modify
+	class AddToEtcCrypttab : public Modify
 	{
 	public:
 
-	    AddEtcCrypttab(sid_t sid) : Modify(sid) {}
+	    AddToEtcCrypttab(sid_t sid) : Modify(sid) {}
 
 	    virtual Text text(const Actiongraph::Impl& actiongraph, Tense tense) const override;
 	    virtual void commit(const Actiongraph::Impl& actiongraph) const override;
@@ -120,11 +120,11 @@ namespace storage
 	};
 
 
-	class RenameEtcCrypttab : public Modify
+	class RenameInEtcCrypttab : public Modify
 	{
 	public:
 
-	    RenameEtcCrypttab(sid_t sid) : Modify(sid) {}
+	    RenameInEtcCrypttab(sid_t sid) : Modify(sid) {}
 
 	    virtual Text text(const Actiongraph::Impl& actiongraph, Tense tense) const override;
 	    virtual void commit(const Actiongraph::Impl& actiongraph) const override;
@@ -132,11 +132,11 @@ namespace storage
 	};
 
 
-	class RemoveEtcCrypttab : public Modify
+	class RemoveFromEtcCrypttab : public Modify
 	{
 	public:
 
-	    RemoveEtcCrypttab(sid_t sid) : Modify(sid) {}
+	    RemoveFromEtcCrypttab(sid_t sid) : Modify(sid) {}
 
 	    virtual Text text(const Actiongraph::Impl& actiongraph, Tense tense) const override;
 	    virtual void commit(const Actiongraph::Impl& actiongraph) const override;

--- a/storage/Devices/LuksImpl.cc
+++ b/storage/Devices/LuksImpl.cc
@@ -290,6 +290,14 @@ namespace storage
 
 
     void
+    Luks::Impl::do_rename_etc_crypttab(const Actiongraph::Impl& actiongraph,
+				       const Device* lhs) const
+    {
+	// TODO
+    }
+
+
+    void
     Luks::Impl::do_remove_etc_crypttab(const Actiongraph::Impl& actiongraph) const
     {
 	const Storage& storage = actiongraph.get_storage();

--- a/storage/Devices/LuksImpl.cc
+++ b/storage/Devices/LuksImpl.cc
@@ -271,7 +271,7 @@ namespace storage
 
 
     void
-    Luks::Impl::do_add_etc_crypttab(const Actiongraph::Impl& actiongraph) const
+    Luks::Impl::do_add_to_etc_crypttab(const Actiongraph::Impl& actiongraph) const
     {
 	const Storage& storage = actiongraph.get_storage();
 
@@ -290,7 +290,7 @@ namespace storage
 
 
     void
-    Luks::Impl::do_rename_etc_crypttab(const Actiongraph::Impl& actiongraph,
+    Luks::Impl::do_rename_in_etc_crypttab(const Actiongraph::Impl& actiongraph,
 				       const Device* lhs) const
     {
 	// TODO
@@ -298,7 +298,7 @@ namespace storage
 
 
     void
-    Luks::Impl::do_remove_etc_crypttab(const Actiongraph::Impl& actiongraph) const
+    Luks::Impl::do_remove_from_etc_crypttab(const Actiongraph::Impl& actiongraph) const
     {
 	const Storage& storage = actiongraph.get_storage();
 

--- a/storage/Devices/LuksImpl.h
+++ b/storage/Devices/LuksImpl.h
@@ -83,12 +83,12 @@ namespace storage
 
 	virtual void do_deactivate() const override;
 
-	virtual void do_add_etc_crypttab(const Actiongraph::Impl& actiongraph) const override;
+	virtual void do_add_to_etc_crypttab(const Actiongraph::Impl& actiongraph) const override;
 
-	virtual void do_rename_etc_crypttab(const Actiongraph::Impl& actiongraph, const Device* lhs)
+	virtual void do_rename_in_etc_crypttab(const Actiongraph::Impl& actiongraph, const Device* lhs)
 	    const override;
 
-	virtual void do_remove_etc_crypttab(const Actiongraph::Impl& actiongraph) const override;
+	virtual void do_remove_from_etc_crypttab(const Actiongraph::Impl& actiongraph) const override;
 
     private:
 

--- a/storage/Devices/LuksImpl.h
+++ b/storage/Devices/LuksImpl.h
@@ -85,6 +85,9 @@ namespace storage
 
 	virtual void do_add_etc_crypttab(const Actiongraph::Impl& actiongraph) const override;
 
+	virtual void do_rename_etc_crypttab(const Actiongraph::Impl& actiongraph, const Device* lhs)
+	    const override;
+
 	virtual void do_remove_etc_crypttab(const Actiongraph::Impl& actiongraph) const override;
 
     private:

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -213,7 +213,7 @@ namespace storage
 	vector<Action::Base*> actions;
 
 	actions.push_back(new Action::Create(get_sid()));
-	actions.push_back(new Action::AddEtcMdadm(get_sid()));
+	actions.push_back(new Action::AddToEtcMdadm(get_sid()));
 
 	actiongraph.add_chain(actions);
     }
@@ -224,7 +224,7 @@ namespace storage
     {
 	vector<Action::Base*> actions;
 
-	actions.push_back(new Action::RemoveEtcMdadm(get_sid()));
+	actions.push_back(new Action::RemoveFromEtcMdadm(get_sid()));
 	actions.push_back(new Action::Delete(get_sid()));
 
 	actiongraph.add_chain(actions);
@@ -574,7 +574,7 @@ namespace storage
 
 
     Text
-    Md::Impl::do_add_etc_mdadm_text(Tense tense) const
+    Md::Impl::do_add_to_etc_mdadm_text(Tense tense) const
     {
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
@@ -589,14 +589,14 @@ namespace storage
 
 
     void
-    Md::Impl::do_add_etc_mdadm(const Actiongraph::Impl& actiongraph) const
+    Md::Impl::do_add_to_etc_mdadm(const Actiongraph::Impl& actiongraph) const
     {
 	// TODO
     }
 
 
     Text
-    Md::Impl::do_remove_etc_mdadm_text(Tense tense) const
+    Md::Impl::do_remove_from_etc_mdadm_text(Tense tense) const
     {
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
@@ -611,7 +611,7 @@ namespace storage
 
 
     void
-    Md::Impl::do_remove_etc_mdadm(const Actiongraph::Impl& actiongraph) const
+    Md::Impl::do_remove_from_etc_mdadm(const Actiongraph::Impl& actiongraph) const
     {
 	// TODO
     }
@@ -709,23 +709,23 @@ namespace storage
     {
 
 	Text
-	AddEtcMdadm::text(const Actiongraph::Impl& actiongraph, Tense tense) const
+	AddToEtcMdadm::text(const Actiongraph::Impl& actiongraph, Tense tense) const
 	{
 	    const Md* md = to_md(get_device_rhs(actiongraph));
-	    return md->get_impl().do_add_etc_mdadm_text(tense);
+	    return md->get_impl().do_add_to_etc_mdadm_text(tense);
 	}
 
 
 	void
-	AddEtcMdadm::commit(const Actiongraph::Impl& actiongraph) const
+	AddToEtcMdadm::commit(const Actiongraph::Impl& actiongraph) const
 	{
 	    const Md* md = to_md(get_device_rhs(actiongraph));
-	    md->get_impl().do_add_etc_mdadm(actiongraph);
+	    md->get_impl().do_add_to_etc_mdadm(actiongraph);
 	}
 
 
 	void
-	AddEtcMdadm::add_dependencies(Actiongraph::Impl::vertex_descriptor vertex,
+	AddToEtcMdadm::add_dependencies(Actiongraph::Impl::vertex_descriptor vertex,
 				      Actiongraph::Impl& actiongraph) const
 	{
 	    Modify::add_dependencies(vertex, actiongraph);
@@ -736,18 +736,18 @@ namespace storage
 
 
 	Text
-	RemoveEtcMdadm::text(const Actiongraph::Impl& actiongraph, Tense tense) const
+	RemoveFromEtcMdadm::text(const Actiongraph::Impl& actiongraph, Tense tense) const
 	{
 	    const Md* md = to_md(get_device_lhs(actiongraph));
-	    return md->get_impl().do_remove_etc_mdadm_text(tense);
+	    return md->get_impl().do_remove_from_etc_mdadm_text(tense);
 	}
 
 
 	void
-	RemoveEtcMdadm::commit(const Actiongraph::Impl& actiongraph) const
+	RemoveFromEtcMdadm::commit(const Actiongraph::Impl& actiongraph) const
 	{
 	    const Md* md = to_md(get_device_lhs(actiongraph));
-	    md->get_impl().do_remove_etc_mdadm(actiongraph);
+	    md->get_impl().do_remove_from_etc_mdadm(actiongraph);
 	}
 
     }

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -32,6 +32,7 @@
 #include "storage/Storage.h"
 #include "storage/Environment.h"
 #include "storage/SystemInfo/SystemInfo.h"
+#include "storage/Utils/AppUtil.h"
 #include "storage/Utils/Exception.h"
 #include "storage/Utils/Enum.h"
 #include "storage/Utils/StorageTmpl.h"
@@ -297,11 +298,7 @@ namespace storage
     unsigned int
     Md::Impl::get_number() const
     {
-	string::size_type pos = get_name().find_last_not_of("0123456789");
-	if (pos == string::npos || pos == get_name().size() - 1)
-	    ST_THROW(Exception("md name has no number"));
-
-	return atoi(get_name().substr(pos + 1).c_str());
+	return device_to_name_and_number(get_name()).second;
     }
 
 

--- a/storage/Devices/MdImpl.h
+++ b/storage/Devices/MdImpl.h
@@ -103,11 +103,11 @@ namespace storage
 	virtual Text do_delete_text(Tense tense) const override;
 	virtual void do_delete() const override;
 
-	virtual Text do_add_etc_mdadm_text(Tense tense) const;
-	virtual void do_add_etc_mdadm(const Actiongraph::Impl& actiongraph) const;
+	virtual Text do_add_to_etc_mdadm_text(Tense tense) const;
+	virtual void do_add_to_etc_mdadm(const Actiongraph::Impl& actiongraph) const;
 
-	virtual Text do_remove_etc_mdadm_text(Tense tense) const;
-	virtual void do_remove_etc_mdadm(const Actiongraph::Impl& actiongraph) const;
+	virtual Text do_remove_from_etc_mdadm_text(Tense tense) const;
+	virtual void do_remove_from_etc_mdadm(const Actiongraph::Impl& actiongraph) const;
 
 	virtual Text do_reallot_text(ReallotMode reallot_mode, const Device* device,
 				     Tense tense) const override;
@@ -132,11 +132,11 @@ namespace storage
     namespace Action
     {
 
-	class AddEtcMdadm : public Modify
+	class AddToEtcMdadm : public Modify
 	{
 	public:
 
-	    AddEtcMdadm(sid_t sid)
+	    AddToEtcMdadm(sid_t sid)
 		: Modify(sid) {}
 
 	    virtual Text text(const Actiongraph::Impl& actiongraph, Tense tense) const override;
@@ -148,11 +148,11 @@ namespace storage
 	};
 
 
-	class RemoveEtcMdadm : public Modify
+	class RemoveFromEtcMdadm : public Modify
 	{
 	public:
 
-	    RemoveEtcMdadm(sid_t sid)
+	    RemoveFromEtcMdadm(sid_t sid)
 		: Modify(sid) {}
 
 	    virtual Text text(const Actiongraph::Impl& actiongraph, Tense tense) const override;

--- a/storage/Devices/MsdosImpl.cc
+++ b/storage/Devices/MsdosImpl.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -59,6 +59,29 @@ namespace storage
 
 	setChildValueIf(node, "minimal-mbr-gap", minimal_mbr_gap, minimal_mbr_gap !=
 			default_minimal_mbr_gap);
+    }
+
+
+    void
+    Msdos::Impl::delete_partition(Partition* partition)
+    {
+	PartitionType old_type = partition->get_type();
+	unsigned int old_number = partition->get_number();
+
+	PartitionTable::Impl::delete_partition(partition);
+
+	// After deleting a logical partition the numbers of partitions with
+	// higher numbers are shifted.
+	if (old_type == PartitionType::LOGICAL)
+	{
+	    vector<Partition*> partitions = get_partitions();
+            for (Partition* tmp : partitions)
+	    {
+		unsigned int number = tmp->get_number();
+		if (number > old_number)
+		    tmp->get_impl().set_number(number - 1);
+	    }
+	}
     }
 
 

--- a/storage/Devices/MsdosImpl.h
+++ b/storage/Devices/MsdosImpl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -51,6 +51,8 @@ namespace storage
 	virtual const char* get_classname() const override { return DeviceTraits<Msdos>::classname; }
 
 	virtual string get_displayname() const override { return "msdos"; }
+
+	virtual void delete_partition(Partition* partition) override;
 
 	virtual PtType get_type() const override { return PtType::MSDOS; }
 

--- a/storage/Devices/PartitionImpl.cc
+++ b/storage/Devices/PartitionImpl.cc
@@ -23,6 +23,7 @@
 
 #include <iostream>
 
+#include "storage/Utils/AppUtil.h"
 #include "storage/Utils/SystemCmd.h"
 #include "storage/Utils/StorageDefines.h"
 #include "storage/Utils/StorageTmpl.h"
@@ -133,26 +134,16 @@ namespace storage
     unsigned int
     Partition::Impl::get_number() const
     {
-	const string& name = get_name();
-
-	string::size_type pos = name.find_last_not_of("0123456789");
-	if (pos == string::npos || pos == name.size() - 1)
-	    ST_THROW(Exception("partition name has no number"));
-
-	return atoi(name.substr(pos + 1).c_str());
+	return device_to_name_and_number(get_name()).second;
     }
 
 
     void
     Partition::Impl::set_number(unsigned int number)
     {
-	const string& name = get_name();
+	std::pair<string, unsigned int> pair = device_to_name_and_number(get_name());
 
-	string::size_type pos = name.find_last_not_of("0123456789");
-        if (pos == string::npos || pos == name.size() - 1)
-            ST_THROW(Exception("partition name has no number"));
-
-	set_name(name.substr(0, pos + 1) + to_string(number));
+	set_name(name_and_number_to_device(pair.first, number));
 
 	update_sysfs_name_and_path();
 	update_udev_paths_and_ids();

--- a/storage/Devices/PartitionImpl.h
+++ b/storage/Devices/PartitionImpl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -65,6 +65,7 @@ namespace storage
 	virtual void check() const override;
 
 	unsigned int get_number() const;
+	void set_number(unsigned int number);
 
 	virtual void set_region(const Region& region) override;
 
@@ -80,6 +81,7 @@ namespace storage
 	bool is_legacy_boot() const { return legacy_boot; }
 	void set_legacy_boot(bool legacy_boot);
 
+	void update_sysfs_name_and_path();
 	void update_udev_paths_and_ids();
 
 	virtual ResizeInfo detect_resize_info() const override;

--- a/storage/Devices/PartitionTableImpl.h
+++ b/storage/Devices/PartitionTableImpl.h
@@ -123,7 +123,13 @@ namespace storage
 
 	Region align(const Region& region, AlignPolicy align_policy = AlignPolicy::ALIGN_END) const;
 
-	virtual void add_dependencies(Actiongraph::Impl& actiongraph) const override;
+	/*
+	 * Add dependencies for all the partition tables
+	 *
+	 * Implemented as a static method because going through the actions for
+	 * every partition table individually would be slow.
+	 */
+	static void add_all_dependencies(Actiongraph::Impl& actiongraph);
 
     protected:
 
@@ -138,6 +144,22 @@ namespace storage
 
 	bool read_only;
 
+	struct ActionsStruct
+	{
+	    vector<Actiongraph::Impl::vertex_descriptor> create_actions;
+	    vector<Actiongraph::Impl::vertex_descriptor> resize_actions;
+	    vector<Actiongraph::Impl::vertex_descriptor> rename_actions;
+	    vector<Actiongraph::Impl::vertex_descriptor> delete_actions;
+	};
+
+	/**
+	 * Finds the actions for all partition tables.
+	 *
+	 * See add_all_dependencies
+	 *
+	 * In the result, sid_t is the sid of the partition table.
+	 */
+	static map<sid_t, ActionsStruct> find_actions(const Actiongraph::Impl& actiongraph);
     };
 
 }

--- a/storage/Devices/PartitionTableImpl.h
+++ b/storage/Devices/PartitionTableImpl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -56,7 +56,7 @@ namespace storage
 
 	Partition* create_partition(const string& name, const Region& region, PartitionType type);
 
-	void delete_partition(Partition* partition);
+	virtual void delete_partition(Partition* partition);
 
 	void delete_partition(const string& name);
 

--- a/storage/Filesystems/FilesystemImpl.cc
+++ b/storage/Filesystems/FilesystemImpl.cc
@@ -388,8 +388,8 @@ namespace storage
 		Action::Mount* mount = new Action::Mount(get_sid(), mountpoint);
 		Actiongraph::Impl::vertex_descriptor t1 = actiongraph.add_vertex(mount);
 
-		Action::AddEtcFstab* add_etc_fstab = new Action::AddEtcFstab(get_sid(), mountpoint);
-		Actiongraph::Impl::vertex_descriptor t2 = actiongraph.add_vertex(add_etc_fstab);
+		Action::AddToEtcFstab* add_to_etc_fstab = new Action::AddToEtcFstab(get_sid(), mountpoint);
+		Actiongraph::Impl::vertex_descriptor t2 = actiongraph.add_vertex(add_to_etc_fstab);
 
 		actiongraph.add_edge(v1, t1);
 		actiongraph.add_edge(t1, t2);
@@ -428,7 +428,7 @@ namespace storage
 	if (get_blk_device()->get_name() != lhs.get_blk_device()->get_name())
 	{
 	    for (const string& mountpoint : get_mountpoints())
-		actions.push_back(new Action::RenameEtcFstab(get_sid(), mountpoint));
+		actions.push_back(new Action::RenameInEtcFstab(get_sid(), mountpoint));
 	}
 
 	actiongraph.add_chain(actions);
@@ -453,8 +453,8 @@ namespace storage
 
 	    for (const string& mountpoint : get_mountpoints())
 	    {
-		Action::RemoveEtcFstab* remove_etc_fstab = new Action::RemoveEtcFstab(get_sid(), mountpoint);
-		Actiongraph::Impl::vertex_descriptor t1 = actiongraph.add_vertex(remove_etc_fstab);
+		Action::RemoveFromEtcFstab* remove_from_etc_fstab = new Action::RemoveFromEtcFstab(get_sid(), mountpoint);
+		Actiongraph::Impl::vertex_descriptor t1 = actiongraph.add_vertex(remove_from_etc_fstab);
 
 		Action::Umount* umount = new Action::Umount(get_sid(), mountpoint);
 		Actiongraph::Impl::vertex_descriptor t2 = actiongraph.add_vertex(umount);
@@ -750,7 +750,7 @@ namespace storage
 
 
     Text
-    Filesystem::Impl::do_add_etc_fstab_text(const string& mountpoint, Tense tense) const
+    Filesystem::Impl::do_add_to_etc_fstab_text(const string& mountpoint, Tense tense) const
     {
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
@@ -767,7 +767,7 @@ namespace storage
 
 
     void
-    Filesystem::Impl::do_add_etc_fstab(const Actiongraph::Impl& actiongraph,
+    Filesystem::Impl::do_add_to_etc_fstab(const Actiongraph::Impl& actiongraph,
 				       const string& mountpoint) const
     {
 	const Storage& storage = actiongraph.get_storage();
@@ -791,7 +791,7 @@ namespace storage
 
 
     Text
-    Filesystem::Impl::do_rename_etc_fstab_text(const Device* lhs, const string& mountpoint,
+    Filesystem::Impl::do_rename_in_etc_fstab_text(const Device* lhs, const string& mountpoint,
 					       Tense tense) const
     {
 	const BlkDevice* blk_device_lhs = to_filesystem(lhs)->get_impl().get_blk_device();
@@ -815,7 +815,7 @@ namespace storage
 
 
     void
-    Filesystem::Impl::do_rename_etc_fstab(const Actiongraph::Impl& actiongraph, const Device* lhs,
+    Filesystem::Impl::do_rename_in_etc_fstab(const Actiongraph::Impl& actiongraph, const Device* lhs,
 					  const string& mountpoint) const
     {
 	const Storage& storage = actiongraph.get_storage();
@@ -839,7 +839,7 @@ namespace storage
 
 
     Text
-    Filesystem::Impl::do_remove_etc_fstab_text(const string& mountpoint, Tense tense) const
+    Filesystem::Impl::do_remove_from_etc_fstab_text(const string& mountpoint, Tense tense) const
     {
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
@@ -856,7 +856,7 @@ namespace storage
 
 
     void
-    Filesystem::Impl::do_remove_etc_fstab(const Actiongraph::Impl& actiongraph,
+    Filesystem::Impl::do_remove_from_etc_fstab(const Actiongraph::Impl& actiongraph,
 					  const string& mountpoint) const
     {
 	const Storage& storage = actiongraph.get_storage();
@@ -993,23 +993,23 @@ namespace storage
 
 
 	Text
-	AddEtcFstab::text(const Actiongraph::Impl& actiongraph, Tense tense) const
+	AddToEtcFstab::text(const Actiongraph::Impl& actiongraph, Tense tense) const
 	{
 	    const Filesystem* filesystem = to_filesystem(get_device_rhs(actiongraph));
-	    return filesystem->get_impl().do_add_etc_fstab_text(mountpoint, tense);
+	    return filesystem->get_impl().do_add_to_etc_fstab_text(mountpoint, tense);
 	}
 
 
 	void
-	AddEtcFstab::commit(const Actiongraph::Impl& actiongraph) const
+	AddToEtcFstab::commit(const Actiongraph::Impl& actiongraph) const
 	{
 	    const Filesystem* filesystem = to_filesystem(get_device_rhs(actiongraph));
-	    filesystem->get_impl().do_add_etc_fstab(actiongraph, mountpoint);
+	    filesystem->get_impl().do_add_to_etc_fstab(actiongraph, mountpoint);
 	}
 
 
 	void
-	AddEtcFstab::add_dependencies(Actiongraph::Impl::vertex_descriptor vertex,
+	AddToEtcFstab::add_dependencies(Actiongraph::Impl::vertex_descriptor vertex,
 				      Actiongraph::Impl& actiongraph) const
 	{
 	    if (mountpoint == "swap")
@@ -1019,36 +1019,36 @@ namespace storage
 
 
 	Text
-	RenameEtcFstab::text(const Actiongraph::Impl& actiongraph, Tense tense) const
+	RenameInEtcFstab::text(const Actiongraph::Impl& actiongraph, Tense tense) const
 	{
 	    const Filesystem* filesystem_lhs = to_filesystem(get_device_lhs(actiongraph));
 	    const Filesystem* filesystem_rhs = to_filesystem(get_device_rhs(actiongraph));
-	    return filesystem_rhs->get_impl().do_rename_etc_fstab_text(filesystem_lhs, mountpoint, tense);
+	    return filesystem_rhs->get_impl().do_rename_in_etc_fstab_text(filesystem_lhs, mountpoint, tense);
 	}
 
 
 	void
-	RenameEtcFstab::commit(const Actiongraph::Impl& actiongraph) const
+	RenameInEtcFstab::commit(const Actiongraph::Impl& actiongraph) const
 	{
 	    const Filesystem* filesystem_lhs = to_filesystem(get_device_lhs(actiongraph));
 	    const Filesystem* filesystem_rhs = to_filesystem(get_device_rhs(actiongraph));
-	    filesystem_rhs->get_impl().do_rename_etc_fstab(actiongraph, filesystem_lhs, mountpoint);
+	    filesystem_rhs->get_impl().do_rename_in_etc_fstab(actiongraph, filesystem_lhs, mountpoint);
 	}
 
 
 	Text
-	RemoveEtcFstab::text(const Actiongraph::Impl& actiongraph, Tense tense) const
+	RemoveFromEtcFstab::text(const Actiongraph::Impl& actiongraph, Tense tense) const
 	{
 	    const Filesystem* filesystem = to_filesystem(get_device_lhs(actiongraph));
-	    return filesystem->get_impl().do_remove_etc_fstab_text(mountpoint, tense);
+	    return filesystem->get_impl().do_remove_from_etc_fstab_text(mountpoint, tense);
 	}
 
 
 	void
-	RemoveEtcFstab::commit(const Actiongraph::Impl& actiongraph) const
+	RemoveFromEtcFstab::commit(const Actiongraph::Impl& actiongraph) const
 	{
 	    const Filesystem* filesystem = to_filesystem(get_device_lhs(actiongraph));
-	    filesystem->get_impl().do_remove_etc_fstab(actiongraph, mountpoint);
+	    filesystem->get_impl().do_remove_from_etc_fstab(actiongraph, mountpoint);
 	}
 
     }

--- a/storage/Filesystems/FilesystemImpl.cc
+++ b/storage/Filesystems/FilesystemImpl.cc
@@ -747,11 +747,11 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by mountpoint (e.g. /home),
-			   // %2$s is replaced by device name (e.g. /dev/sda1),
+			   // %2$s is replaced by device name (e.g. /dev/sda1)
 			   _("Add mountpoint %1$s of %2$s to /etc/fstab"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by mountpoint (e.g. /home),
-			   // %2$s is replaced by device name (e.g. /dev/sda1),
+			   // %2$s is replaced by device name (e.g. /dev/sda1)
 			   _("Adding mountpoint %1$s of %2$s to /etc/fstab"));
 
 	return sformat(text, mountpoint.c_str(), get_blk_device()->get_name().c_str());
@@ -788,11 +788,11 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by mountpoint (e.g. /home),
-			   // %2$s is replaced by device name (e.g. /dev/sda1),
+			   // %2$s is replaced by device name (e.g. /dev/sda1)
 			   _("Remove mountpoint %1$s of %2$s from /etc/fstab"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by mountpoint (e.g. /home),
-			   // %2$s is replaced by device name (e.g. /dev/sda1),
+			   // %2$s is replaced by device name (e.g. /dev/sda1)
 			   _("Removing mountpoint %1$s of %2$s from /etc/fstab"));
 
 	return sformat(text, mountpoint.c_str(), get_blk_device()->get_name().c_str());

--- a/storage/Filesystems/FilesystemImpl.cc
+++ b/storage/Filesystems/FilesystemImpl.cc
@@ -818,7 +818,23 @@ namespace storage
     Filesystem::Impl::do_rename_etc_fstab(const Actiongraph::Impl& actiongraph, const Device* lhs,
 					  const string& mountpoint) const
     {
+	const Storage& storage = actiongraph.get_storage();
+
+	EtcFstab fstab(storage.get_impl().prepend_rootprefix("/etc"));	// TODO pass as parameter
+
+	const BlkDevice* blk_device_lhs = to_filesystem(lhs)->get_impl().get_blk_device();
+
 	// TODO
+
+	FstabChange entry;
+	entry.device = blk_device_lhs->get_name();
+	entry.dentry = get_mount_by_string();
+	entry.mount = mountpoint;
+	entry.fs = toString(get_type());
+	entry.opts = fstab_options;
+
+	fstab.addEntry(entry);
+	fstab.flush();
     }
 
 

--- a/storage/Filesystems/FilesystemImpl.h
+++ b/storage/Filesystems/FilesystemImpl.h
@@ -115,14 +115,14 @@ namespace storage
 	virtual Text do_umount_text(const string& mountpoint, Tense tense) const;
 	virtual void do_umount(const Actiongraph::Impl& actiongraph, const string& mountpoint) const;
 
-	virtual Text do_add_etc_fstab_text(const string& mountpoint, Tense tense) const;
-	virtual void do_add_etc_fstab(const Actiongraph::Impl& actiongraph, const string& mountpoint) const;
+	virtual Text do_add_to_etc_fstab_text(const string& mountpoint, Tense tense) const;
+	virtual void do_add_to_etc_fstab(const Actiongraph::Impl& actiongraph, const string& mountpoint) const;
 
-	virtual Text do_rename_etc_fstab_text(const Device* lhs, const string& mountpoint,Tense tense) const;
-	virtual void do_rename_etc_fstab(const Actiongraph::Impl& actiongraph, const Device* lhs, const string& mountpoint) const;
+	virtual Text do_rename_in_etc_fstab_text(const Device* lhs, const string& mountpoint,Tense tense) const;
+	virtual void do_rename_in_etc_fstab(const Actiongraph::Impl& actiongraph, const Device* lhs, const string& mountpoint) const;
 
-	virtual Text do_remove_etc_fstab_text(const string& mountpoint, Tense tense) const;
-	virtual void do_remove_etc_fstab(const Actiongraph::Impl& actiongraph, const string& mountpoint) const;
+	virtual Text do_remove_from_etc_fstab_text(const string& mountpoint, Tense tense) const;
+	virtual void do_remove_from_etc_fstab(const Actiongraph::Impl& actiongraph, const string& mountpoint) const;
 
 	virtual Text do_resize_text(ResizeMode resize_mode, const Device* lhs, Tense tense) const override;
 
@@ -222,11 +222,11 @@ namespace storage
 	};
 
 
-	class AddEtcFstab : public Modify
+	class AddToEtcFstab : public Modify
 	{
 	public:
 
-	    AddEtcFstab(sid_t sid, const string& mountpoint)
+	    AddToEtcFstab(sid_t sid, const string& mountpoint)
 		: Modify(sid), mountpoint(mountpoint) {}
 
 	    virtual Text text(const Actiongraph::Impl& actiongraph, Tense tense) const override;
@@ -240,11 +240,11 @@ namespace storage
 	};
 
 
-	class RenameEtcFstab : public Modify
+	class RenameInEtcFstab : public Modify
 	{
 	public:
 
-	    RenameEtcFstab(sid_t sid, const string& mountpoint)
+	    RenameInEtcFstab(sid_t sid, const string& mountpoint)
 		: Modify(sid), mountpoint(mountpoint) {}
 
 	    virtual Text text(const Actiongraph::Impl& actiongraph, Tense tense) const override;
@@ -255,11 +255,11 @@ namespace storage
 	};
 
 
-	class RemoveEtcFstab : public Modify
+	class RemoveFromEtcFstab : public Modify
 	{
 	public:
 
-	    RemoveEtcFstab(sid_t sid, const string& mountpoint)
+	    RemoveFromEtcFstab(sid_t sid, const string& mountpoint)
 		: Modify(sid), mountpoint(mountpoint) {}
 
 	    virtual Text text(const Actiongraph::Impl& actiongraph, Tense tense) const override;

--- a/storage/Filesystems/FilesystemImpl.h
+++ b/storage/Filesystems/FilesystemImpl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -118,6 +118,9 @@ namespace storage
 	virtual Text do_add_etc_fstab_text(const string& mountpoint, Tense tense) const;
 	virtual void do_add_etc_fstab(const Actiongraph::Impl& actiongraph, const string& mountpoint) const;
 
+	virtual Text do_rename_etc_fstab_text(const Device* lhs, const string& mountpoint,Tense tense) const;
+	virtual void do_rename_etc_fstab(const Actiongraph::Impl& actiongraph, const Device* lhs, const string& mountpoint) const;
+
 	virtual Text do_remove_etc_fstab_text(const string& mountpoint, Tense tense) const;
 	virtual void do_remove_etc_fstab(const Actiongraph::Impl& actiongraph, const string& mountpoint) const;
 
@@ -231,6 +234,21 @@ namespace storage
 
 	    virtual void add_dependencies(Actiongraph::Impl::vertex_descriptor vertex,
 					  Actiongraph::Impl& actiongraph) const override;
+
+	    const string mountpoint;
+
+	};
+
+
+	class RenameEtcFstab : public Modify
+	{
+	public:
+
+	    RenameEtcFstab(sid_t sid, const string& mountpoint)
+		: Modify(sid), mountpoint(mountpoint) {}
+
+	    virtual Text text(const Actiongraph::Impl& actiongraph, Tense tense) const override;
+	    virtual void commit(const Actiongraph::Impl& actiongraph) const override;
 
 	    const string mountpoint;
 

--- a/storage/Utils/AppUtil.cc
+++ b/storage/Utils/AppUtil.cc
@@ -452,4 +452,28 @@ string afterLast(const string& s, const string& pat )
 
 const string app_ws = " \t\n";
 
+    /**
+     * Breaks a device name like "/dev/sda2" into "/dev/sda" and 2
+     *
+     * Throws an exception if the provided name does not contain the number
+     * part.
+     */
+    std::pair<string, unsigned int>
+    device_to_name_and_number(const string& full_name)
+    {
+	string::size_type pos = full_name.find_last_not_of("0123456789");
+        if (pos == string::npos || pos == full_name.size() - 1)
+            ST_THROW(Exception("device name has no number"));
+
+	return std::make_pair(full_name.substr(0, pos + 1), atoi(full_name.substr(pos + 1).c_str()));
+    }
+
+    /**
+     * Inverse of device_to_name_and_number
+     */
+    string
+    name_and_number_to_device(const string& name, unsigned int number)
+    {
+	return (name + to_string(number));
+    }
 }

--- a/storage/Utils/AppUtil.h
+++ b/storage/Utils/AppUtil.h
@@ -54,6 +54,9 @@ bool setStatMode(const string& Path_Cv, mode_t val );
 
     string make_dev_block_name(dev_t majorminor);
 
+    std::pair<string, unsigned int> device_to_name_and_number(const string& full_name);
+    string name_and_number_to_device(const string& name, unsigned int number);
+
     vector<string> glob(const string& path, int flags);
 
     struct StatVfs

--- a/testsuite/partitions/Makefile.am
+++ b/testsuite/partitions/Makefile.am
@@ -8,7 +8,8 @@ LDADD = ../../storage/libstorage-ng.la ../helpers/libhelpers.la			\
 	-lboost_unit_test_framework
 
 check_PROGRAMS =								\
-	get1.test size.test slots.test udev1.test attributes.test
+	get1.test size.test slots.test udev1.test attributes.test		\
+	set-number.test
 
 AM_DEFAULT_SOURCE_EXT = .cc
 

--- a/testsuite/partitions/Makefile.am
+++ b/testsuite/partitions/Makefile.am
@@ -9,7 +9,7 @@ LDADD = ../../storage/libstorage-ng.la ../helpers/libhelpers.la			\
 
 check_PROGRAMS =								\
 	get1.test size.test slots.test udev1.test attributes.test		\
-	set-number.test
+	set-number.test delete1.test
 
 AM_DEFAULT_SOURCE_EXT = .cc
 

--- a/testsuite/partitions/delete1.cc
+++ b/testsuite/partitions/delete1.cc
@@ -1,0 +1,56 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE libstorage
+
+#include <boost/algorithm/string.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "storage/Devices/DiskImpl.h"
+#include "storage/Devices/Msdos.h"
+#include "storage/Devices/Partition.h"
+#include "storage/Devicegraph.h"
+#include "storage/Storage.h"
+#include "storage/Environment.h"
+#include "storage/Utils/Region.h"
+
+
+using namespace std;
+using namespace storage;
+
+
+BOOST_AUTO_TEST_CASE(test_delete_logical)
+{
+    set_logger(get_stdout_logger());
+
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+
+    Storage storage(environment);
+
+    Devicegraph* devicegraph = storage.get_staging();
+
+    Disk* sda = Disk::create(devicegraph, "/dev/sda", Region(0, 1000000, 512));
+
+    PartitionTable* msdos = sda->create_partition_table(PtType::MSDOS);
+
+    msdos->create_partition("/dev/sda1", Region(1 * 2048, 100 * 2048, 512), PartitionType::EXTENDED);
+
+    Partition* sda5 = msdos->create_partition("/dev/sda5", Region(2 * 2048, 10 * 2048, 512), PartitionType::LOGICAL);
+    msdos->create_partition("/dev/sda6", Region(12 * 2048, 10 * 2048, 512), PartitionType::LOGICAL);
+    Partition* sda7 = msdos->create_partition("/dev/sda7", Region(24 * 2048, 10 * 2048, 512), PartitionType::LOGICAL);
+    msdos->create_partition("/dev/sda8", Region(36 * 2048, 10 * 2048, 512), PartitionType::LOGICAL);
+
+    msdos->delete_partition(sda5);
+    msdos->delete_partition(sda7);
+
+    vector<Partition*> partitions = msdos->get_partitions();
+
+    BOOST_REQUIRE_EQUAL(partitions.size(), 3);
+
+    // originally sda6
+    BOOST_CHECK_EQUAL(partitions[1]->get_name(), "/dev/sda5");
+    BOOST_CHECK_EQUAL(partitions[1]->get_region(), Region(12 * 2048, 10 * 2048, 512));
+
+    // originally sda8
+    BOOST_CHECK_EQUAL(partitions[2]->get_name(), "/dev/sda6");
+    BOOST_CHECK_EQUAL(partitions[2]->get_region(), Region(36 * 2048, 10 * 2048, 512));
+}

--- a/testsuite/partitions/set-number.cc
+++ b/testsuite/partitions/set-number.cc
@@ -1,0 +1,61 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE libstorage
+
+#include <boost/algorithm/string.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include "storage/Devices/DiskImpl.h"
+#include "storage/Devices/Msdos.h"
+#include "storage/Devices/PartitionImpl.h"
+#include "storage/Devicegraph.h"
+#include "storage/Storage.h"
+#include "storage/Environment.h"
+#include "storage/Utils/Region.h"
+
+
+using namespace std;
+using namespace storage;
+
+
+BOOST_AUTO_TEST_CASE(test1)
+{
+    set_logger(get_stdout_logger());
+
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+
+    Storage storage(environment);
+
+    Devicegraph* devicegraph = storage.get_staging();
+
+    Disk* sda = Disk::create(devicegraph, "/dev/sda", Region(0, 1000000, 512));
+    sda->get_impl().set_sysfs_name("sda");
+    sda->get_impl().set_sysfs_path("/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda");
+    sda->get_impl().set_udev_paths({ "pci-0000:00:1f.2-ata-1" });
+    sda->get_impl().set_udev_ids({ "ata-WDC_WD10EADS-00M2B0_WD-WCAV52321683", "scsi-350014ee203733bb5" });
+
+    PartitionTable* msdos = sda->create_partition_table(PtType::MSDOS);
+
+    msdos->create_partition("/dev/sda1", Region(1 * 2048, 100 * 2048, 512), PartitionType::EXTENDED);
+
+    Partition* sda5 = msdos->create_partition("/dev/sda5", Region(2 * 2048, 10 * 2048, 512), PartitionType::LOGICAL);
+
+    sda5->get_impl().set_number(6);
+
+    vector<Partition*> partitions = msdos->get_partitions();
+
+    BOOST_REQUIRE_EQUAL(partitions.size(), 2);
+
+    BOOST_CHECK_EQUAL(partitions[1]->get_name(), "/dev/sda6");
+
+    BOOST_CHECK_EQUAL(partitions[1]->get_sysfs_name(), "sda6");
+
+    BOOST_CHECK_EQUAL(partitions[1]->get_sysfs_path(), "/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda6");
+
+    BOOST_REQUIRE_EQUAL(partitions[1]->get_udev_paths().size(), 1);
+    BOOST_CHECK_EQUAL(partitions[1]->get_udev_paths()[0], "pci-0000:00:1f.2-ata-1-part6");
+
+    BOOST_REQUIRE_EQUAL(partitions[1]->get_udev_ids().size(), 2);
+    BOOST_CHECK_EQUAL(partitions[1]->get_udev_ids()[0], "ata-WDC_WD10EADS-00M2B0_WD-WCAV52321683-part6");
+    BOOST_CHECK_EQUAL(partitions[1]->get_udev_ids()[1], "scsi-350014ee203733bb5-part6");
+}


### PR DESCRIPTION
This pull request includes:
 * All the commits from #180 (cherry-picked because @aschnell's master would need a rebase so I cannot "duplicate" the PR cleanly).
 * Two commits to fix issues pointed during code review of #180 (2 out of 3 issues addressed).
 * An extra commit implementing dependencies for deleting partitions (first deletions in descending order and afterwards creations in ascending one). 99% of the code is taken from @aschnell patch at https://trello.com/c/EPvvvAs3/ (I left out a lot of code from that patch for which I didn't get the point).

Dependencies and renumbering of partitions tested manually. Everything seems to work. Unit tests not added.