### PR TITLE
- implemented do_rename_in_etc_crypttab()

### DIFF
--- a/storage/Devices/LuksImpl.cc
+++ b/storage/Devices/LuksImpl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -291,9 +291,25 @@ namespace storage
 
     void
     Luks::Impl::do_rename_in_etc_crypttab(const Actiongraph::Impl& actiongraph,
-				       const Device* lhs) const
+					  const Device* lhs) const
     {
-	// TODO
+	const Storage& storage = actiongraph.get_storage();
+
+	const Luks* luks_lhs = to_luks(lhs);
+
+	// TODO, error handling and mount-by
+
+	EtcFstab fstab(storage.get_impl().prepend_rootprefix("/etc"));	// TODO pass as parameter
+
+	FstabKey key(luks_lhs->get_blk_device()->get_name(), "");
+	FstabChange entry;
+	entry.device = get_blk_device()->get_name();
+	entry.dentry = get_name();
+	entry.encr = EncryptionType::LUKS;
+
+	fstab.removeEntry(key);
+	fstab.addEntry(entry);
+	fstab.flush();
     }
 
 

--- a/testsuite/fstab.cc
+++ b/testsuite/fstab.cc
@@ -355,6 +355,38 @@ BOOST_AUTO_TEST_CASE(update6)
 }
 
 
+BOOST_AUTO_TEST_CASE(update7)
+{
+    setup({
+	""
+    }, {
+	"cr_test  /dev/sdb6  none  none"
+    });
+
+    EtcFstab fstab("/etc");
+
+    // TODO figure out how the rename can be done in one step. or even better
+    // rewrite EtcFstab
+
+    FstabKey key("/dev/sdb6", "");
+
+    FstabChange entry;
+    entry.device = "/dev/sdb5";
+    entry.dentry = "cr_test";
+    entry.encr = EncryptionType::LUKS;
+
+    fstab.removeEntry(key);
+    fstab.addEntry(entry);
+    fstab.flush();
+
+    check({
+	""
+    }, {
+	"cr_test         /dev/sdb5            none       none"
+    });
+}
+
+
 BOOST_AUTO_TEST_CASE(remove1)
 {
     setup({


### PR DESCRIPTION
For https://trello.com/c/EPvvvAs3/444-5-storage-ng-renaming-of-logical-partitions-volumes-works-in-structures-and-udev-names.