### PR TITLE
- fixed shrinking devices

### DIFF
--- a/integration-tests/storageitu.py
+++ b/integration-tests/storageitu.py
@@ -21,7 +21,7 @@ class MyCommitCallbacks(CommitCallbacks):
 
 
 def commit(storage, skip_save_graphs = True, skip_print_actiongraph = True,
-           skip_commit = True):
+           skip_commit = False):
 
     if not skip_save_graphs:
         storage.get_probed().save("probed.xml")

--- a/storage/Devices/DeviceImpl.cc
+++ b/storage/Devices/DeviceImpl.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -362,7 +362,7 @@ namespace storage
 
 
     void
-    Device::Impl::do_resize(ResizeMode resize_mode) const
+    Device::Impl::do_resize(ResizeMode resize_mode, const Device* rhs) const
     {
 	ST_THROW(LogicException("stub do_resize called"));
     }
@@ -431,8 +431,10 @@ namespace storage
 	void
 	Resize::commit(const Actiongraph::Impl& actiongraph) const
 	{
+	    const Device* device_rhs = get_device(actiongraph, RHS);
+
 	    const Device* device = get_device(actiongraph, get_side());
-	    device->get_impl().do_resize(resize_mode);
+	    device->get_impl().do_resize(resize_mode, device_rhs);
 	}
 
 

--- a/storage/Devices/DeviceImpl.h
+++ b/storage/Devices/DeviceImpl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -173,7 +173,7 @@ namespace storage
 
 	virtual Text do_resize_text(ResizeMode resize_mode, const Device* lhs, const Device* rhs,
 				    Tense tense) const;
-	virtual void do_resize(ResizeMode resize_mode) const;
+	virtual void do_resize(ResizeMode resize_mode, const Device* rhs) const;
 
 	virtual Text do_reallot_text(ReallotMode reallot_mode, const Device* device,
 				     Tense tense) const;

--- a/storage/Devices/LuksImpl.cc
+++ b/storage/Devices/LuksImpl.cc
@@ -228,12 +228,14 @@ namespace storage
 
 
     void
-    Luks::Impl::do_resize(ResizeMode resize_mode) const
+    Luks::Impl::do_resize(ResizeMode resize_mode, const Device* rhs) const
     {
+	const Luks* luks_rhs = to_luks(rhs);
+
 	string cmd_line = CRYPTSETUPBIN " resize " + quote(get_dm_table_name());
 
 	if (resize_mode == ResizeMode::SHRINK)
-	    cmd_line += " --size " + to_string(get_size() / (512 * B));
+	    cmd_line += " --size " + to_string(luks_rhs->get_impl().get_size() / (512 * B));
 
 	cout << cmd_line << endl;
 

--- a/storage/Devices/LuksImpl.h
+++ b/storage/Devices/LuksImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -79,7 +79,7 @@ namespace storage
 
 	virtual void do_delete() const override;
 
-	virtual void do_resize(ResizeMode resize_mode) const override;
+	virtual void do_resize(ResizeMode resize_mode, const Device* rhs) const override;
 
 	virtual void do_activate() const override;
 

--- a/storage/Devices/LvmLvImpl.cc
+++ b/storage/Devices/LvmLvImpl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -361,9 +361,11 @@ namespace storage
 
 
     void
-    LvmLv::Impl::do_resize(ResizeMode resize_mode) const
+    LvmLv::Impl::do_resize(ResizeMode resize_mode, const Device* rhs) const
     {
 	const LvmVg* lvm_vg = get_lvm_vg();
+
+	const LvmLv* lvm_lv_rhs = to_lvm_lv(rhs);
 
 	string cmd_line = LVRESIZEBIN;
 
@@ -371,7 +373,7 @@ namespace storage
 	    cmd_line += " --force";
 
 	cmd_line += " " + quote(lvm_vg->get_vg_name() + "/" + lv_name) + " --extents " +
-	    to_string(get_region().get_length());
+	    to_string(lvm_lv_rhs->get_region().get_length());
 
 	cout << cmd_line << endl;
 

--- a/storage/Devices/LvmLvImpl.h
+++ b/storage/Devices/LvmLvImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -94,7 +94,7 @@ namespace storage
 
 	virtual Text do_resize_text(ResizeMode resize_mode, const Device* lhs, const Device* rhs,
 				    Tense tense) const override;
-	virtual void do_resize(ResizeMode resize_mode) const override;
+	virtual void do_resize(ResizeMode resize_mode, const Device* rhs) const override;
 
 	virtual Text do_delete_text(Tense tense) const override;
 	virtual void do_delete() const override;

--- a/storage/Devices/LvmPvImpl.cc
+++ b/storage/Devices/LvmPvImpl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -307,13 +307,14 @@ namespace storage
 
 
     void
-    LvmPv::Impl::do_resize(ResizeMode resize_mode) const
+    LvmPv::Impl::do_resize(ResizeMode resize_mode, const Device* rhs) const
     {
 	const BlkDevice* blk_device = get_blk_device();
+	const BlkDevice* blk_device_rhs = to_lvm_pv(rhs)->get_impl().get_blk_device();
 
 	string cmd_line = PVRESIZEBIN " " + quote(blk_device->get_name());
 	if (resize_mode == ResizeMode::SHRINK)
-	    cmd_line += " --setphysicalvolumesize " + to_string(blk_device->get_size()) + "b";
+	    cmd_line += " --setphysicalvolumesize " + to_string(blk_device_rhs->get_size()) + "b";
 
 	cout << cmd_line << endl;
 

--- a/storage/Devices/LvmPvImpl.h
+++ b/storage/Devices/LvmPvImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -89,7 +89,7 @@ namespace storage
 
 	virtual Text do_resize_text(ResizeMode resize_mode, const Device* lhs, const Device* rhs,
 				    Tense tense) const override;
-	virtual void do_resize(ResizeMode resize_mode) const override;
+	virtual void do_resize(ResizeMode resize_mode, const Device* rhs) const override;
 
 	virtual Text do_delete_text(Tense tense) const override;
 	virtual void do_delete() const override;

--- a/storage/Devices/PartitionImpl.cc
+++ b/storage/Devices/PartitionImpl.cc
@@ -831,12 +831,13 @@ namespace storage
 
 
     void
-    Partition::Impl::do_resize(ResizeMode resize_mode) const
+    Partition::Impl::do_resize(ResizeMode resize_mode, const Device* rhs) const
     {
+	const Partition* partition_rhs = to_partition(rhs);
 	const Partitionable* partitionable = get_partitionable();
 
 	string cmd_line = PARTEDBIN " --script " + quote(partitionable->get_name()) + " unit s "
-	    "resize " + to_string(get_number()) + " " + to_string(get_region().get_end());
+	    "resize " + to_string(get_number()) + " " + to_string(partition_rhs->get_region().get_end());
 	cout << cmd_line << endl;
 
 	wait_for_device();

--- a/storage/Devices/PartitionImpl.h
+++ b/storage/Devices/PartitionImpl.h
@@ -122,7 +122,7 @@ namespace storage
 
 	virtual Text do_resize_text(ResizeMode resize_mode, const Device* lhs, const Device* rhs,
 				    Tense tense) const override;
-	virtual void do_resize(ResizeMode resize_mode) const override;
+	virtual void do_resize(ResizeMode resize_mode, const Device* rhs) const override;
 
 	static unsigned int default_id_for_type(PartitionType type);
 

--- a/storage/Filesystems/Ext4Impl.cc
+++ b/storage/Filesystems/Ext4Impl.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -98,13 +98,14 @@ namespace storage
 
 
     void
-    Ext4::Impl::do_resize(ResizeMode resize_mode) const
+    Ext4::Impl::do_resize(ResizeMode resize_mode, const Device* rhs) const
     {
 	const BlkDevice* blk_device = get_blk_device();
+	const BlkDevice* blk_device_rhs = to_ext4(rhs)->get_impl().get_blk_device();
 
 	string cmd_line = EXT2RESIZEBIN " -f " + quote(blk_device->get_name());
 	if (resize_mode == ResizeMode::SHRINK)
-	    cmd_line += " " + to_string(blk_device->get_size() / KiB) + "K";
+	    cmd_line += " " + to_string(blk_device_rhs->get_size() / KiB) + "K";
 	cout << cmd_line << endl;
 
 	blk_device->get_impl().wait_for_device();

--- a/storage/Filesystems/Ext4Impl.h
+++ b/storage/Filesystems/Ext4Impl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -64,7 +64,7 @@ namespace storage
 
 	virtual void do_set_label() const override;
 
-	virtual void do_resize(ResizeMode resize_mode) const override;
+	virtual void do_resize(ResizeMode resize_mode, const Device* rhs) const override;
 
     };
 

--- a/storage/Filesystems/NtfsImpl.cc
+++ b/storage/Filesystems/NtfsImpl.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -144,13 +144,14 @@ namespace storage
 
 
     void
-    Ntfs::Impl::do_resize(ResizeMode resize_mode) const
+    Ntfs::Impl::do_resize(ResizeMode resize_mode, const Device* rhs) const
     {
 	const BlkDevice* blk_device = get_blk_device();
+	const BlkDevice* blk_device_rhs = to_ntfs(rhs)->get_impl().get_blk_device();
 
 	string cmd_line = "echo y | " NTFSRESIZEBIN " --force";
 	if (resize_mode == ResizeMode::SHRINK)
-	    cmd_line += " --size " + to_string(blk_device->get_size());
+	    cmd_line += " --size " + to_string(blk_device_rhs->get_size());
 	cmd_line += " " + quote(blk_device->get_name());
 	cout << cmd_line << endl;
 

--- a/storage/Filesystems/NtfsImpl.h
+++ b/storage/Filesystems/NtfsImpl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -65,7 +65,7 @@ namespace storage
 
 	virtual void do_set_label() const override;
 
-	virtual void do_resize(ResizeMode resize_mode) const override;
+	virtual void do_resize(ResizeMode resize_mode, const Device* rhs) const override;
 
     };
 

--- a/storage/Filesystems/SwapImpl.cc
+++ b/storage/Filesystems/SwapImpl.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -115,9 +115,10 @@ namespace storage
 
 
     void
-    Swap::Impl::do_resize(ResizeMode resize_mode) const
+    Swap::Impl::do_resize(ResizeMode resize_mode, const Device* rhs) const
     {
 	const BlkDevice* blk_device = get_blk_device();
+	const BlkDevice* blk_device_rhs = to_swap(rhs)->get_impl().get_blk_device();
 
 	string cmd_line = MKSWAPBIN;
 	if (!get_label().empty())
@@ -125,6 +126,8 @@ namespace storage
 	if (!get_uuid().empty())
 	    cmd_line += " -U " + quote(get_uuid());
 	cmd_line += " " + quote(blk_device->get_name());
+	if (resize_mode == ResizeMode::SHRINK)
+	    cmd_line += " " + to_string(blk_device_rhs->get_size() / KiB);
 	cout << cmd_line << endl;
 
 	blk_device->get_impl().wait_for_device();
@@ -133,6 +136,7 @@ namespace storage
 	if (cmd.retcode() != 0)
 	    ST_THROW(Exception("resize swap failed"));
     }
+
 
     void
     Swap::Impl::do_set_label() const
@@ -146,6 +150,7 @@ namespace storage
 	if (cmd.retcode() != 0)
 	    ST_THROW(Exception("set-label swap failed"));
     }
+
 
     void
     Swap::Impl::do_set_uuid() const

--- a/storage/Filesystems/SwapImpl.h
+++ b/storage/Filesystems/SwapImpl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -67,7 +67,7 @@ namespace storage
 
 	virtual void do_umount(const Actiongraph::Impl& actiongraph, const string& mountpoint) const override;
 
-	virtual void do_resize(ResizeMode resize_mode) const override;
+	virtual void do_resize(ResizeMode resize_mode, const Device* rhs) const override;
 
 	virtual void do_set_label() const override;
 

--- a/storage/Filesystems/VfatImpl.cc
+++ b/storage/Filesystems/VfatImpl.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -113,13 +113,14 @@ namespace storage
 
 
     void
-    Vfat::Impl::do_resize(ResizeMode resize_mode) const
+    Vfat::Impl::do_resize(ResizeMode resize_mode, const Device* rhs) const
     {
 	const BlkDevice* blk_device = get_blk_device();
+	const BlkDevice* blk_device_rhs = to_vfat(rhs)->get_impl().get_blk_device();
 
 	string cmd_line = FATRESIZE " " + quote(blk_device->get_name());
 	if (resize_mode == ResizeMode::SHRINK)
-	    cmd_line += " " + to_string(blk_device->get_size() / KiB);
+	    cmd_line += " " + to_string(blk_device_rhs->get_size() / KiB);
 	cout << cmd_line << endl;
 
 	blk_device->get_impl().wait_for_device();

--- a/storage/Filesystems/VfatImpl.h
+++ b/storage/Filesystems/VfatImpl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -65,7 +65,7 @@ namespace storage
 
 	virtual void do_set_label() const override;
 
-	virtual void do_resize(ResizeMode resize_mode) const override;
+	virtual void do_resize(ResizeMode resize_mode, const Device* rhs) const override;
 
     };
 


### PR DESCRIPTION
When shrinking the do_resize function is called on the LHS object so the new size must be taken from the RHS object.