### PR TITLE
Diff for EtcFstab

### DIFF
--- a/storage/EtcFstab.cc
+++ b/storage/EtcFstab.cc
@@ -265,6 +265,7 @@ namespace storage
 	set_max_column_width( col++,  1 ); // fsck pass
 
 	set_pad_columns( true );
+        set_diff_enabled();
     }
 
 
@@ -504,6 +505,18 @@ namespace storage
 
         if ( ! get_filename().empty() )
             y2mil( get_filename() );
+
+        for ( size_t i=0; i < lines.size(); ++i )
+            y2mil( lines[i] );
+    }
+
+
+    void EtcFstab::log_diff()
+    {
+        string_vec lines = diff();
+
+        if ( ! get_filename().empty() )
+            y2mil( get_filename() << " diff: " );
 
         for ( size_t i=0; i < lines.size(); ++i )
             y2mil( lines[i] );

--- a/storage/EtcFstab.h
+++ b/storage/EtcFstab.h
@@ -354,6 +354,12 @@ namespace storage
          **/
         void log();
 
+        /**
+         * Dump a diff to the previous state before the last read() / parse() /
+         * write().
+         **/
+        void log_diff();
+
 	/**
 	 * Construct all aliases usable in /etc/fstab based on information of
 	 * blk_device and blk_filesystem, that is block device name, block

--- a/storage/Filesystems/BlkFilesystemImpl.cc
+++ b/storage/Filesystems/BlkFilesystemImpl.cc
@@ -640,7 +640,7 @@ namespace storage
 	if (entry)
         {
             entry->set_device(get_mount_by_name());
-            fstab.log();
+            fstab.log_diff();
             fstab.write();
         }
     }

--- a/storage/Filesystems/MountableImpl.cc
+++ b/storage/Filesystems/MountableImpl.cc
@@ -286,7 +286,7 @@ namespace storage
         // TODO: entry->set_fsck_pass( ?? );
 
         fstab.add(entry);
-        fstab.log();
+        fstab.log_diff();
         fstab.write();
     }
 
@@ -320,7 +320,7 @@ namespace storage
 	if (entry)
         {
             fstab.remove( entry );
-            fstab.log();
+            fstab.log_diff();
             fstab.write();
         }
     }

--- a/storage/Utils/CommentedConfigFile.cc
+++ b/storage/Utils/CommentedConfigFile.cc
@@ -26,6 +26,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include "storage/Utils/CommentedConfigFile.h"
+#include "storage/Utils/Diff.h"
 #include "storage/Utils/ExceptionImpl.h"
 #include "storage/Utils/Logger.h"
 #include "storage/Utils/AsciiFile.h"
@@ -40,7 +41,8 @@ using namespace storage;
 
 
 CommentedConfigFile::CommentedConfigFile():
-    comment_marker( "#" )
+    comment_marker( "#" ),
+    diff_enabled( false )
 {
 }
 
@@ -185,6 +187,9 @@ bool CommentedConfigFile::parse( const string_vec & lines )
     }
 
     bool success = parse_entries( lines, content_start, content_end );
+
+    if ( diff_enabled )
+        save_orig();
 
     return success;
 }
@@ -381,3 +386,28 @@ void CommentedConfigFile::strip_trailing_whitespace( string & line )
     else
         line.clear();
 }
+
+
+string_vec CommentedConfigFile::diff()
+{
+    return Diff::diff( orig_lines, format_lines() );
+}
+
+
+string_vec CommentedConfigFile::diff( const string_vec & formatted_lines )
+{
+    return Diff::diff( orig_lines, formatted_lines );
+}
+
+
+void CommentedConfigFile::save_orig()
+{
+    save_orig( format_lines() );
+}
+
+
+void CommentedConfigFile::save_orig( const string_vec & new_orig_lines )
+{
+    orig_lines = new_orig_lines;
+}
+

--- a/storage/Utils/CommentedConfigFile.h
+++ b/storage/Utils/CommentedConfigFile.h
@@ -402,6 +402,60 @@ public:
      **/
     void set_comment_marker( const string & marker ) { comment_marker = marker; }
 
+    /**
+     * Return 'true' if diffs are enabled. Diffs are not enabled by default.
+     **/
+    bool get_diff_enabled() const { return diff_enabled; }
+
+    /**
+     * Enable or disable diffs. This saves a copy of the formatted text lines
+     * at certain points, i.e. this comes at a memory and performance cost.
+     **/
+    void set_diff_enabled( bool enabled = true ) { diff_enabled = enabled; }
+
+    /**
+     * Diff the current status against the last one saved with save_orig().
+     **/
+    string_vec diff();
+
+    /**
+     * Diff 'formatted_lines' against the last status saved with save_orig().
+     **/
+    string_vec diff( const string_vec & formatted_lines );
+
+    /**
+     * Save the current status as the original reference for future diffs.
+     * This calls format_lines() internally which is a pretty expensive
+     * operation, so if you call format_lines() anyway, consider using the
+     * overloaded version of this that takes a string_vec.
+     *
+     * Notice that this is called automatically when the file is loaded, when
+     * lines are parsed and when the file is written.
+     **/
+    void save_orig();
+
+    /**
+     * Save the 'orig_lines' as the original reference for future
+     * diffs. 'orig_lines' should be the result of a previous format_lines()
+     * call.
+     **/
+    void save_orig( const string_vec & orig_lines );
+
+    /**
+     * Get the orig_lines as saved with the last save_orig().
+     **/
+    const string_vec & get_orig_lines() const { return orig_lines; }
+
+    /**
+     * Generic static diff method: Diff the lines in 'new_lines' against the
+     * lines in 'old_lines'.
+     *
+     * The result is similar to the Linux/Unix "diff -u" command.
+     **/
+    static string_vec diff( const string_vec & old_lines,
+                            const string_vec & new_lines );
+
+
 protected:
 
     /**
@@ -454,10 +508,12 @@ private:
 
     string	    filename;
     string	    comment_marker;
+    bool            diff_enabled;
 
     string_vec	    header_comments;
     vector<Entry *> entries;
     string_vec	    footer_comments;
+    string_vec      orig_lines;
 
 };
 

--- a/storage/Utils/Diff.cc
+++ b/storage/Utils/Diff.cc
@@ -137,13 +137,20 @@ void Diff::diff( Range a, Range b )
 	    if ( context_lines > 0 )
 	    {
 		Range context;
-		context.start = std::max( 0, a.start - context_lines );
-		context.end   = std::max( 0, a.start - 1 );
-		add_lines( hunk.context_lines_before, lines_a, context );
 
-		context.start = std::min( (int) lines_a.size(), a.end + 1 );
-		context.end   = std::min( (int) lines_a.size(), a.end + context_lines );
-		add_lines( hunk.context_lines_after, lines_a, context );
+                if ( a.start > 0 )
+                {
+                    context.start = std::max( 0, a.start - context_lines );
+                    context.end   = std::max( 0, a.start - 1 );
+                    add_lines( hunk.context_lines_before, lines_a, context );
+                }
+
+                if ( a.end < (int) lines_a.size() -1 )
+                {
+                    context.start = std::min( (int) lines_a.size() - 1, a.end + 1 );
+                    context.end   = std::min( (int) lines_a.size() - 1, a.end + context_lines );
+                    add_lines( hunk.context_lines_after, lines_a, context );
+                }
 	    }
 
 	    hunks.push_back( hunk );

--- a/storage/Utils/Diff.cc
+++ b/storage/Utils/Diff.cc
@@ -194,7 +194,7 @@ Diff::find_common_subsequence( const Range & a, const Range & b )
 
 #if VERBOSE
     for ( int i =0; i < best_len; ++i )
-        cout << "  common seq> " << lines_a[ common_pos_a_ret + i ] << endl;
+        cout << "  common seq> " << lines_a[ seq.pos_a + i ] << endl;
 #endif
 
     return seq;

--- a/storage/Utils/Diff.cc
+++ b/storage/Utils/Diff.cc
@@ -212,7 +212,7 @@ void Diff::add_lines( string_vec &	 lines,
 		      const string_vec & lines_to_add,
 		      const Range &	 range )
 {
-    for ( int i = range.start; i <= range.end; ++i )
+    for ( int i = range.start; i <= range.end && i < (int) lines_to_add.size(); ++i )
 	lines.push_back( lines_to_add[i] );
 }
 

--- a/storage/Utils/Diff.cc
+++ b/storage/Utils/Diff.cc
@@ -1,0 +1,401 @@
+/**
+ * File: Diff.cc
+ *
+ * Copyright (c) 2017 Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
+ *
+ * This is part of the commented-config-file project.
+ * License: GPL V2
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ */
+
+
+#include <algorithm>
+#include <iostream>
+#include <stdexcept>
+
+#include "storage/Utils/Diff.h"
+
+#define VERBOSE 0
+
+using std::cout;
+using std::endl;
+
+using namespace storage;
+
+
+string_vec Diff::diff( const string_vec & lines_a,
+		       const string_vec & lines_b,
+		       int		  context_lines )
+{
+    Diff d( lines_a, lines_b, context_lines );
+
+    return d.format_hunks();
+}
+
+
+Diff::Diff( const string_vec & lines_a,
+	    const string_vec & lines_b,
+	    int		       context_lines ):
+    lines_a( lines_a ),
+    lines_b( lines_b ),
+    context_lines( context_lines )
+{
+    Range a( lines_a );
+    Range b( lines_b );
+
+    diff( a, b );
+    fix_hunk_overlap();
+}
+
+
+const Diff::Hunk &
+Diff::get_hunk( int index ) const
+{
+    if ( index < 0 || index >= (int) hunks.size() )
+	throw std::out_of_range( "hunk index out of range" );
+
+    return hunks[ index ];
+}
+
+
+void Diff::diff( Range a, Range b )
+{
+#if VERBOSE
+    cout << "diff a.start: " << a.start << " a.end: " << a.end
+	 << " b.start: " << b.start << " b.end: " << b.end
+	 << endl;
+#endif
+
+    // Skip common lines at the start
+
+    while ( a.start <= a.end && b.start <= b.end &&
+	    lines_a[ a.start ] == lines_b[ b.start ] )
+    {
+#if VERBOSE
+	cout << "  common start> " << lines_a[ a.start ] << endl;
+#endif
+	++a.start;
+	++b.start;
+    }
+
+    // Skip common lines at the end
+
+    while ( a.end > a.start && b.end > b.start &&
+	    lines_a[ a.end ] == lines_b[ b.end ] )
+    {
+#if VERBOSE
+	cout << "  common   end> " << lines_a[ a.end ] << endl;
+#endif
+	--a.end;
+	--b.end;
+    }
+
+
+    // Check if there is a diff at all
+
+    if ( a.start <= a.end || b.start <= b.end )
+    {
+	// Find longest common subsequence
+
+        SubSequence seq = find_common_subsequence( a, b );
+
+	if ( seq.len > 0 )
+	{
+	    // Cut in two parts and recurse
+
+	    diff( Range( a.start, seq.pos_a - 1 ),
+		  Range( b.start, seq.pos_b - 1 ) );
+
+	    diff( Range( seq.pos_a + seq.len, a.end ),
+		  Range( seq.pos_b + seq.len, b.end ) );
+	}
+	else
+	{
+	    // Hunk output
+
+	    Hunk hunk;
+
+	    add_lines( hunk.lines_removed, lines_a, a );
+	    add_lines( hunk.lines_added,   lines_b, b );
+
+	    hunk.removed_start_pos = a.start;
+	    hunk.added_start_pos   = b.start;
+
+	    // Add context
+
+	    if ( context_lines > 0 )
+	    {
+		Range context;
+		context.start = std::max( 0, a.start - context_lines );
+		context.end   = std::max( 0, a.start - 1 );
+		add_lines( hunk.context_lines_before, lines_a, context );
+
+		context.start = std::min( (int) lines_a.size(), a.end + 1 );
+		context.end   = std::min( (int) lines_a.size(), a.end + context_lines );
+		add_lines( hunk.context_lines_after, lines_a, context );
+	    }
+
+	    hunks.push_back( hunk );
+	}
+    }
+}
+
+
+Diff::SubSequence
+Diff::find_common_subsequence( const Range & a, const Range & b )
+{
+    SubSequence seq;
+    int best_len = 0;
+
+    for ( int pos_a = a.start; pos_a <= a.end; ++pos_a )
+    {
+	const string & start_line_a = lines_a[ pos_a ];
+
+	for ( int pos_b = b.start; pos_b <= b.end; ++pos_b )
+	{
+	    if ( start_line_a == lines_b[ pos_b ] ) // Found a sequence start
+	    {
+		int i = pos_a + 1;
+		int j = pos_b + 1;
+
+		while ( i <= a.end && j <= b.end &&
+			lines_a[ i ] == lines_b[ j ] )
+		{
+		    ++i;
+		    ++j;
+		}
+
+		int len = i - pos_a;
+
+		if ( len > best_len ) // This sequence is longer than the old one
+		{
+		    // Save the sequence we just found
+
+		    best_len  = len;
+
+                    seq.len   = len;
+                    seq.pos_a = pos_a;
+                    seq.pos_b = pos_b;
+		}
+	    }
+	}
+    }
+
+#if VERBOSE
+    for ( int i =0; i < best_len; ++i )
+        cout << "  common seq> " << lines_a[ common_pos_a_ret + i ] << endl;
+#endif
+
+    return seq;
+}
+
+
+void Diff::add_lines( string_vec &	 lines,
+		      const string_vec & lines_to_add )
+{
+    add_lines( lines, lines_to_add, Range( lines_to_add ) );
+}
+
+
+void Diff::add_lines( string_vec &	 lines,
+		      const string_vec & lines_to_add,
+		      const Range &	 range )
+{
+    for ( int i = range.start; i <= range.end; ++i )
+	lines.push_back( lines_to_add[i] );
+}
+
+
+void Diff::fix_hunk_overlap()
+{
+    for ( size_t i=1; i < hunks.size(); ++i )
+    {
+        Hunk & prev_hunk = hunks[ i-1 ];
+        Hunk & hunk      = hunks[ i   ];
+
+        int prev_end = prev_hunk.removed_range().end;
+        int current_start = hunk.removed_range().start;
+        int overlap = prev_end - current_start + 1;
+
+        string_vec & prev_context    = prev_hunk.context_lines_after;
+        string_vec & current_context = hunk.context_lines_before;
+
+        while ( overlap > 0 && prev_context.size() + current_context.size() > 0 )
+        {
+            if ( ! prev_context.empty() )
+            {
+                prev_context.pop_back();
+                --overlap;
+            }
+
+            if ( overlap > 0 && ! current_context.empty() )
+            {
+                current_context.erase( current_context.begin() );
+                --overlap;
+            }
+        }
+    }
+}
+
+
+string_vec Diff::format_hunks()
+{
+    string_vec result;
+
+    string_vec merged_lines;
+    Range merged_range_a( -1, -1 );
+    Range merged_range_b( -1, -1 );
+
+    for ( size_t i=0; i < hunks.size(); ++i )
+    {
+        const Hunk & hunk = hunks[i];
+        bool merging = false;
+
+        if ( i+1 < hunks.size() )
+        {
+            int current_end = hunk.removed_range().end;
+            int next_start  = hunks[ i+1 ].removed_range().start;
+
+            if ( current_end +1 >= next_start )
+                merging = true;
+        }
+
+        if ( merging || ! merged_lines.empty() )
+        {
+            // Prepare to merge this hunk and the next
+
+            Range range_a = hunk.removed_range();
+            Range range_b = hunk.added_range();
+
+            if ( merged_lines.empty() )
+            {
+                merged_range_a = range_a;
+                merged_range_b = range_b;
+            }
+            else
+            {
+                merged_range_a.end = range_a.end;
+                merged_range_b.end = range_b.end;
+            }
+
+            add_lines( merged_lines, hunk.format_lines() );
+        }
+
+        if ( ! merging )
+        {
+            if ( ! merged_lines.empty() )
+            {
+                // Flush pending merged lines
+
+                result.push_back( Hunk::format_header( merged_range_a, merged_range_b ) );
+                add_lines( result, merged_lines );
+                merged_lines.clear();
+            }
+            else
+            {
+                add_lines( result, hunk.format() );
+            }
+        }
+    }
+
+    return result;
+}
+
+
+string_vec Diff::format_patch_header( const string & filename_old,
+                                      const string & filename_new )
+{
+    string_vec result;
+
+    result.push_back( string( "--- " ) + filename_old );
+    result.push_back( string( "+++ " ) + filename_new );
+
+    return result;
+}
+
+
+
+
+string_vec Diff::Hunk::format() const
+{
+    string_vec result = format_lines();
+    result.insert( result.begin(), format_header() );
+
+    return result;
+}
+
+
+string_vec Diff::Hunk::format_lines() const
+{
+    string_vec result;
+
+    add_with_prefix( " ", result, context_lines_before );
+    add_with_prefix( "-", result, lines_removed );
+    add_with_prefix( "+", result, lines_added	);
+    add_with_prefix( " ", result, context_lines_after );
+
+    return result;
+}
+
+
+string Diff::Hunk::format_header() const
+{
+    return format_header( removed_range(), added_range() );
+}
+
+
+string Diff::Hunk::format_header( const Range & a, const Range & b )
+{
+    char hunk_header[100];
+
+    snprintf( hunk_header, sizeof( hunk_header ),
+	      "@@ -%d,%d +%d,%d @@",
+	      a.start + 1, a.length(),
+	      b.start + 1, b.length() );
+
+    return string( hunk_header );
+}
+
+
+void Diff::Hunk::add_with_prefix( const string &     prefix,
+                                  string_vec &	     lines,
+                                  const string_vec & lines_to_add ) const
+{
+    for ( size_t i=0; i < lines_to_add.size(); ++i )
+	lines.push_back( prefix + lines_to_add[i] );
+}
+
+
+Diff::Range
+Diff::Hunk::removed_range() const
+{
+    Range range;
+
+    range.start = removed_start_pos - context_lines_before.size();
+    range.end   = removed_start_pos + lines_removed.size() + context_lines_after.size() - 1;
+
+    return range;
+}
+
+
+Diff::Range
+Diff::Hunk::added_range() const
+{
+    Range range;
+
+    range.start = added_start_pos - context_lines_before.size();
+    range.end   = added_start_pos + lines_added.size() + context_lines_after.size() - 1;
+
+    return range;
+}

--- a/storage/Utils/Diff.cc
+++ b/storage/Utils/Diff.cc
@@ -368,8 +368,10 @@ string Diff::Hunk::format_header( const Range & a, const Range & b )
 
     snprintf( hunk_header, sizeof( hunk_header ),
 	      "@@ -%d,%d +%d,%d @@",
-	      a.start + 1, a.length(),
-	      b.start + 1, b.length() );
+	      a.empty() ? 0 : a.start + 1,
+              a.length(),
+	      b.empty() ? 0 : b.start + 1,
+              b.length() );
 
     return string( hunk_header );
 }

--- a/storage/Utils/Diff.h
+++ b/storage/Utils/Diff.h
@@ -1,0 +1,250 @@
+/**
+ * File: Diff.h
+ *
+ * Copyright (c) 2017 Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
+ *
+ * This is part of the commented-config-file project.
+ * License: GPL V2
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ */
+
+
+#ifndef Diff_h
+#define Diff_h
+
+#include <string>
+#include <vector>
+
+#define DEFAULT_CONTEXT_LINES   3
+
+
+namespace storage
+{
+
+using std::string;
+using std::vector;
+
+typedef vector<string> string_vec;
+
+
+/**
+ * Class to diff string vectors against each other.
+ **/
+class Diff
+{
+    /**
+     * Helper class defining an interval to operate in: From line no. 'start'
+     * (starting with 0) including to line no. 'end'.
+     **/
+    class Range
+    {
+    public:
+        Range():
+            start(0),
+            end(-1)
+            {}
+
+        Range( int start, int end ):
+            start( start ),
+            end( end )
+            {}
+
+        Range( const string_vec & lines ):
+            start(0),
+            end( lines.size() - 1 )
+            {}
+
+        int  length() const { return end - start + 1; }
+        int  size()   const { return length(); }
+        bool empty()  const { return length() < 1; }
+
+        int start;
+        int end;
+    };
+
+
+    /**
+     * Helper class to collect information about one diff 'hunk'.
+     *
+     * One hunk is one set of changes with a number of consecutive lines
+     * removed and a number of consecutive lines added instead.
+     **/
+    class Hunk
+    {
+    public:
+        string_vec lines_removed;
+        string_vec lines_added;
+        int        removed_start_pos; // without context lines
+        int        added_start_pos;   // without context lines
+
+        string_vec context_lines_before;
+        string_vec context_lines_after;
+
+        /**
+         * Format this hunk just like a 'diff -u' output, including the '@@'
+         * header.
+         **/
+        string_vec format() const;
+
+        /**
+         * Format the header of this hunk just like the '@@' line in a 'diff
+         * -u' output.
+         **/
+        string format_header() const;
+
+        /**
+         * Static version of format_header().
+         **/
+        static string format_header( const Range & a, const Range & b );
+
+        /**
+         * Format the lines of this hunk: Context lines before, removed lines,
+         * added lines, context lines after.
+         **/
+        string_vec format_lines() const;
+
+        /**
+         * Return the range of the removed lines including context.
+         **/
+        Range removed_range() const;
+
+        /**
+         * Return the range of the added lines including context.
+         **/
+        Range added_range() const;
+
+    protected:
+
+        /**
+         * Add (append) all lines from 'lines_to_add' to 'lines' and prefix
+         * each of the added lines with 'prefix'.
+         **/
+        void add_with_prefix( const string &     prefix,
+                              string_vec &       lines,
+                              const string_vec & lines_to_add ) const;
+    };
+
+
+public:
+
+    /**
+     * Generic diff method for string vectors: Diff the lines in 'new_lines'
+     * against the lines in 'old_lines'.
+     *
+     * The result is similar to the Linux/Unix "diff -u" command.
+     **/
+    static string_vec diff( const string_vec & old_lines,
+                            const string_vec & new_lines,
+                            int context_lines = DEFAULT_CONTEXT_LINES );
+
+    /**
+     * Add (append) all lines from 'lines_to_add' to 'lines'.
+     **/
+    static void add_lines( string_vec &       lines,
+                           const string_vec & lines_to_add );
+
+    /**
+     * Add (append) a range of lines from 'lines_to_add' to 'lines'.
+     **/
+    static void add_lines( string_vec &       lines,
+                           const string_vec & lines_to_add,
+                           const Range &      range );
+
+
+    /**
+     * Constructor. In most cases, it is advised to use the static methods
+     * rather than creating your own instance.
+     **/
+    Diff( const string_vec & lines_a,
+          const string_vec & lines_b,
+          int                context_lines = DEFAULT_CONTEXT_LINES );
+
+    /**
+     * Return the number of result hunks.
+     **/
+    int get_hunk_count() const { return hunks.size(); }
+
+    /**
+     * Return one result hunk.
+     **/
+    const Hunk & get_hunk( int index ) const;
+
+    /**
+     * Format the collected hunks and return them in as a string vector.
+     **/
+    string_vec format_hunks();
+
+    /**
+     * Format a patch header like expected by the Linux patch(1) command:
+     *
+     *   --- filename_old
+     *   +++ filename_new
+     *
+     * This does not make the diff output prettier, but it can be fed directly
+     * to the 'patch' command. If there is no such header, the 'patch' command
+     * will complain "input contains only garbage".
+     **/
+    static string_vec format_patch_header( const string & filename_old,
+                                           const string & filename_new );
+
+
+protected:
+    /**
+     * Diff lines betwen start and end and add the result to the internal
+     * hunks.
+     **/
+    void diff( Range a, Range b );
+
+    /**
+     * Helper struct for the find_common_subsequence return values.
+     **/
+    struct SubSequence
+    {
+        int pos_a;
+        int pos_b;
+        int len;
+
+        SubSequence():
+            pos_a(-1),
+            pos_b(-1),
+            len(0)
+            {}
+    };
+
+    /**
+     * Diff helper: find longest common subsequence between start and
+     * end. Return the length of the sequence. Set the _ret parameters to the
+     * respective position where the sequence was found.
+     **/
+    SubSequence find_common_subsequence( const Range & a, const Range & b );
+
+    /**
+     * Make sure hunks don't overlap because of context lines.
+     **/
+    void fix_hunk_overlap();
+
+
+    //
+    // Data members
+    //
+
+    const string_vec & lines_a;
+    const string_vec & lines_b;
+    int                context_lines;
+    vector<Hunk>       hunks;
+};
+
+} // namespace storage
+
+#endif // Diff_h

--- a/storage/Utils/Diff.h
+++ b/storage/Utils/Diff.h
@@ -91,6 +91,11 @@ class Diff
         string_vec context_lines_before;
         string_vec context_lines_after;
 
+        Hunk():
+            removed_start_pos(0),
+            added_start_pos(0)
+            {}
+
         /**
          * Format this hunk just like a 'diff -u' output, including the '@@'
          * header.

--- a/storage/Utils/Makefile.am
+++ b/storage/Utils/Makefile.am
@@ -10,6 +10,7 @@ libutils_la_SOURCES =					\
 	AppUtil.cc		AppUtil.h		\
 	CommentedConfigFile.cc  CommentedConfigFile.h	\
 	ColumnConfigFile.cc	ColumnConfigFile.h	\
+	Diff.cc			Diff.h			\
 	Text.cc			Text.h			\
 	Stopwatch.cc		Stopwatch.h		\
 	Math.cc			Math.h			\

--- a/testsuite/commented-config-file/Makefile.am
+++ b/testsuite/commented-config-file/Makefile.am
@@ -10,7 +10,8 @@ check_PROGRAMS =		\
 	simple_string_ops.test	\
 	container_ops.test	\
 	parser.test		\
-	formatter.test
+	formatter.test		\
+	diff.test
 
 AM_DEFAULT_SOURCE_EXT = .cc
 

--- a/testsuite/commented-config-file/diff.cc
+++ b/testsuite/commented-config-file/diff.cc
@@ -8,7 +8,10 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/algorithm/string.hpp>
 
-#include "Diff.h"
+#include "storage/Utils/Diff.h"
+
+using namespace storage;
+
 
 using std::cout;
 using std::endl;

--- a/testsuite/commented-config-file/diff.cc
+++ b/testsuite/commented-config-file/diff.cc
@@ -1,0 +1,347 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE diff
+
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <boost/test/unit_test.hpp>
+#include <boost/algorithm/string.hpp>
+
+#include "Diff.h"
+
+using std::cout;
+using std::endl;
+using std::ostream;
+using std::stringstream;
+
+
+ostream & operator<<( ostream & stream, const string_vec & lines )
+{
+    stream << endl;
+
+    for ( size_t i=0; i < lines.size(); ++i )
+	stream << std::setfill('0') << std::setw(2) << i+1
+	       << ": \"" << lines[i] << "\"" << endl;
+
+    return stream;
+}
+
+
+boost::test_tools::predicate_result
+check_diff( const string_vec & input_a,
+	    const string_vec & input_b,
+	    const string_vec & expected,
+	    int		       context = 0 )
+{
+    boost::test_tools::predicate_result result( false );
+    stringstream str;
+
+    string_vec actual = Diff::diff( input_a, input_b, context );
+
+    if ( actual.size() != expected.size() )
+    {
+	str << "Actual:" << actual << "\nExpected: " << expected;
+
+	result.message() << "Size mismatch: Actual size:"
+			 << actual.size()
+			 << "; Expected size: " << expected.size()
+			 << "\n\n" << str.str();
+	return result;
+    }
+
+
+    for ( size_t i = 0;
+	  i < expected.size() && i < actual.size();
+	  ++i )
+    {
+	if ( boost::starts_with( expected[i], "@@ ??" ) &&
+	     boost::starts_with( actual[i], "@@ " ) )
+	    continue;
+
+	if ( actual[i] != expected[i] )
+	{
+	    str << "Actual:" << actual << "\nExpected: " << expected;
+
+	    result.message() << "\n\nResult line #" << i+1 << " mismatch:"
+			     << "\nActual   line: \"" << actual[i]   << "\""
+			     << "\nExpected line: \"" << expected[i] << "\""
+			     << "\n\n" << str.str();
+	    return result;
+	}
+    }
+
+    return true;
+}
+
+
+BOOST_AUTO_TEST_CASE( diff_simple )
+{
+    string_vec input01 = {
+	"aaa",
+	"bbb",
+	"ccc",
+	"ddd"
+    };
+
+    string_vec input02 = {
+	"aaa",
+	"ccc",
+	"ddd"
+    };
+
+    string_vec aaa = {
+	"aaa"
+    };
+
+    string_vec aaa_bbb = {
+	"aaa",
+	"bbb"
+    };
+
+    // The line numbers in the @@ lines are not checked if the line starts with "@@ ???".
+
+    BOOST_CHECK( check_diff( input01, input02, { "@@ ???", "-bbb" } ) );
+    BOOST_CHECK( check_diff( input02, input01, { "@@ ???", "+bbb" } ) );
+    BOOST_CHECK( check_diff( input01, input01, {}		    ) );
+    BOOST_CHECK( check_diff( {},      {},      {}                   ) );
+    BOOST_CHECK( check_diff( {},      aaa,     { "@@ -0,0 +1,1 @@", "+aaa" } ) );
+    BOOST_CHECK( check_diff( aaa,     {},      { "@@ -1,1 +0,0 @@", "-aaa" } ) );
+    BOOST_CHECK( check_diff( {},      aaa_bbb, { "@@ -0,0 +1,2 @@", "+aaa", "+bbb" } ) );
+    BOOST_CHECK( check_diff( aaa_bbb, {},      { "@@ -1,2 +0,0 @@", "-aaa", "-bbb" } ) );
+}
+
+
+BOOST_AUTO_TEST_CASE( diff_with_context )
+{
+    string_vec input01 = {
+	"aaa",
+	"bbb",
+	"ccc",
+	"ddd",
+	"eee",
+	"fff",
+	"ggg",
+	"hhh",
+	"iii",
+	"jjj",
+	"kkk"
+    };
+
+    string_vec input02 = {
+	"aaa",
+	"bbb",
+	"ccc",
+	"ddd",
+	// "eee",
+	"fff",
+	"ggg",
+	"hhh",
+	"iii",
+	"jjj",
+	"kkk"
+    };
+
+    string_vec input03 = {
+	"aaa",
+	// "bbb",
+	"ccc",
+	"ddd",
+	"eee",
+	"fff",
+	"ggg",
+	"hhh",
+	"iii",
+	// "jjj",
+	"kkk"
+    };
+
+    string_vec input04 = {
+	// "aaa",
+	"bbb",
+	"ccc",
+	"ddd",
+	"eee",
+	"fff",
+	"ggg",
+	"hhh",
+	"iii",
+	"jjj",
+	"kkk"
+    };
+
+    string_vec input05 = {
+	"aaa",
+	"bbb",
+	"ccc",
+	"ddd",
+	"eee",
+	"fff",
+	"ggg",
+	"hhh",
+	"iii",
+	"jjj"
+	// "kkk"
+    };
+
+    string_vec input06 = {
+	"aaa",
+	"bbb",
+	"ccc",
+	"ddd",
+	// "eee",
+	"fff",
+	"ggg",
+	// "hhh",
+	"iii",
+	"jjj",
+	"kkk"
+    };
+
+    string_vec input07 = {
+	"aaa",
+	"bbb",
+	"xxx", // changed
+	"yyy", // changed
+	"eee",
+	"fff",
+	// "ggg",
+	"hhh",
+	"iii",
+        "zzz", // added
+	"jjj",
+	"kkk"
+    };
+
+    //--------------------------------------------------
+
+    string_vec expected_01_02 = {
+	"@@ ???",
+	" bbb",
+	" ccc",
+	" ddd",
+	"-eee",
+	" fff",
+	" ggg",
+	" hhh"
+    };
+
+    string_vec expected_02_01 = {
+	"@@ ???",
+	" bbb",
+	" ccc",
+	" ddd",
+	"+eee",
+	" fff",
+	" ggg",
+	" hhh"
+    };
+
+    string_vec expected_01_03 = {
+	"@@ ???",
+	" aaa",
+	"-bbb",
+	" ccc",
+	" ddd",
+	" eee",
+	"@@ ???",
+	" ggg",
+	" hhh",
+	" iii",
+	"-jjj",
+	" kkk"
+    };
+
+    string_vec expected_03_01 = {
+	"@@ ???",
+	" aaa",
+	"+bbb",
+	" ccc",
+	" ddd",
+	" eee",
+	"@@ ???",
+	" ggg",
+	" hhh",
+	" iii",
+	"+jjj",
+	" kkk"
+    };
+
+    string_vec expected_01_04 = {
+	"@@ ???",
+	"-aaa",
+	" bbb",
+	" ccc",
+	" ddd"
+    };
+
+    string_vec expected_01_05 = {
+	"@@ ???",
+	" hhh",
+	" iii",
+	" jjj",
+	"-kkk"
+    };
+
+    string_vec expected_01_06 = {
+	"@@ ???",
+	" bbb",
+	" ccc",
+	" ddd",
+	"-eee",
+	" fff",
+	" ggg",
+	"-hhh",
+	" iii",
+	" jjj",
+	" kkk"
+    };
+
+    string_vec expected_01_07 = {
+	"@@ ???",
+	" aaa",
+	" bbb",
+        "-ccc",
+        "-ddd",
+	"+xxx",
+	"+yyy",
+	" eee",
+	" fff",
+	"-ggg",
+	" hhh",
+	" iii",
+        "+zzz",
+	" jjj",
+	" kkk"
+    };
+
+    string_vec expected_00_01 = {
+	"@@ -0,0 +1,11 @@",
+	"+aaa",
+	"+bbb",
+	"+ccc",
+	"+ddd",
+	"+eee",
+	"+fff",
+	"+ggg",
+	"+hhh",
+	"+iii",
+	"+jjj",
+	"+kkk"
+    };
+
+
+
+    const int context = 3;
+
+    BOOST_CHECK( check_diff( input01, input02, expected_01_02, context ) );
+    BOOST_CHECK( check_diff( input01, input03, expected_01_03, context ) );
+    BOOST_CHECK( check_diff( input01, input04, expected_01_04, context ) );
+    BOOST_CHECK( check_diff( input01, input05, expected_01_05, context ) );
+    BOOST_CHECK( check_diff( input01, input06, expected_01_06, context ) );
+    BOOST_CHECK( check_diff( input01, input07, expected_01_07, context ) );
+
+    BOOST_CHECK( check_diff( input02, input01, expected_02_01, context ) );
+    BOOST_CHECK( check_diff( input03, input01, expected_03_01, context ) );
+    BOOST_CHECK( check_diff( {},      input01, expected_00_01, context ) );
+}


### PR DESCRIPTION
This adds a generic diff class for string vectors (taken from https://github.com/shundhammer/commented-config-file) and uses it to log only the diff of each EtcFstab change, not the whole file.

There are no unit tests for the Diff class yet, but I tested it extensively manually in the upstream project: The `diff -u` command is the reference what it should do.