### PR TITLE
- probe some uuids after on disk creation

### DIFF
--- a/integration-tests/filesystems/create-ext4.py
+++ b/integration-tests/filesystems/create-ext4.py
@@ -21,6 +21,7 @@ partition.set_id(ID_LINUX)
 ext4 = partition.create_blk_filesystem(FsType_EXT4)
 ext4.set_label("TEST")
 ext4.add_mountpoint("/test")
+ext4.set_mount_by(MountByType_UUID)
 
 print staging
 

--- a/storage/Action.h
+++ b/storage/Action.h
@@ -80,8 +80,8 @@ namespace storage
 	    /**
 	     * Returns the device of the action on the RHS devicegraph.
 	     */
-	    const Device* get_device(const Actiongraph::Impl& actiongraph) const
-		{ return actiongraph.get_devicegraph(RHS)->find_device(sid); }
+	    Device* get_device(const Actiongraph::Impl& actiongraph) const
+		{ return actiongraph.get_devicegraph_rhs()->find_device(sid); }
 
 	};
 

--- a/storage/Actiongraph.cc
+++ b/storage/Actiongraph.cc
@@ -28,7 +28,7 @@
 namespace storage
 {
 
-    Actiongraph::Actiongraph(const Storage& storage, const Devicegraph* lhs, const Devicegraph* rhs)
+    Actiongraph::Actiongraph(const Storage& storage, const Devicegraph* lhs, Devicegraph* rhs)
 	: impl(new Impl(storage, lhs, rhs))
     {
     }

--- a/storage/Actiongraph.h
+++ b/storage/Actiongraph.h
@@ -55,7 +55,7 @@ namespace storage
     {
     public:
 
-	Actiongraph(const Storage& storage, const Devicegraph* lhs, const Devicegraph* rhs);
+	Actiongraph(const Storage& storage, const Devicegraph* lhs, Devicegraph* rhs);
 	~Actiongraph();
 
 	const Storage& get_storage() const;

--- a/storage/ActiongraphImpl.cc
+++ b/storage/ActiongraphImpl.cc
@@ -104,7 +104,7 @@ namespace storage
     }
 
 
-    Actiongraph::Impl::Impl(const Storage& storage, const Devicegraph* lhs, const Devicegraph* rhs)
+    Actiongraph::Impl::Impl(const Storage& storage, const Devicegraph* lhs, Devicegraph* rhs)
 	: storage(storage), lhs(lhs), rhs(rhs)
     {
 	lhs->check();

--- a/storage/ActiongraphImpl.h
+++ b/storage/ActiongraphImpl.h
@@ -111,11 +111,14 @@ namespace storage
 
 	typedef graph_t::vertices_size_type vertices_size_type;
 
-	Impl(const Storage& storage, const Devicegraph* lhs, const Devicegraph* rhs);
+	Impl(const Storage& storage, const Devicegraph* lhs, Devicegraph* rhs);
 
 	const Storage& get_storage() const { return storage; }
 
 	const Devicegraph* get_devicegraph(Side side) const { return side == LHS ? lhs : rhs; }
+
+	Devicegraph* get_devicegraph_rhs() const { return rhs; }
+	const Devicegraph* get_devicegraph_lhs() const { return lhs; }
 
 	bool empty() const;
 
@@ -182,7 +185,7 @@ namespace storage
 	const Storage& storage;
 
 	const Devicegraph* lhs;
-	const Devicegraph* rhs;
+	Devicegraph* rhs;
 
 	typedef deque<vertex_descriptor> Order;
 

--- a/storage/Devices/DeviceImpl.cc
+++ b/storage/Devices/DeviceImpl.cc
@@ -305,7 +305,7 @@ namespace storage
 
 
     void
-    Device::Impl::do_create() const
+    Device::Impl::do_create()
     {
 	ST_THROW(LogicException("stub do_create called"));
     }

--- a/storage/Devices/DeviceImpl.h
+++ b/storage/Devices/DeviceImpl.h
@@ -160,7 +160,7 @@ namespace storage
 	virtual void print(std::ostream& out) const = 0;
 
 	virtual Text do_create_text(Tense tense) const;
-	virtual void do_create() const;
+	virtual void do_create();
 
 	virtual Text do_delete_text(Tense tense) const;
 	virtual void do_delete() const;

--- a/storage/Devices/GptImpl.cc
+++ b/storage/Devices/GptImpl.cc
@@ -210,7 +210,7 @@ namespace storage
 
 
     void
-    Gpt::Impl::do_create() const
+    Gpt::Impl::do_create()
     {
 	const Partitionable* partitionable = get_partitionable();
 

--- a/storage/Devices/GptImpl.h
+++ b/storage/Devices/GptImpl.h
@@ -83,7 +83,7 @@ namespace storage
 	virtual Region get_usable_region() const override;
 
 	virtual Text do_create_text(Tense tense) const override;
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual Text do_set_pmbr_boot_text(Tense tense) const;
 	virtual void do_set_pmbr_boot() const;

--- a/storage/Devices/LuksImpl.cc
+++ b/storage/Devices/LuksImpl.cc
@@ -119,6 +119,18 @@ namespace storage
 
 
     void
+    Luks::Impl::probe_uuid()
+    {
+	const BlkDevice* blk_device = get_blk_device();
+
+	Blkid blkid(blk_device->get_name());
+	Blkid::Entry entry;
+	if (blkid.get_sole_entry(entry))
+	    uuid = entry.luks_uuid;
+    }
+
+
+    void
     Luks::Impl::parent_has_new_region(const Device* parent)
     {
 	calculate_region();
@@ -195,7 +207,7 @@ namespace storage
 
 
     void
-    Luks::Impl::do_create() const
+    Luks::Impl::do_create()
     {
 	string cmd_line = CRYPTSETUPBIN " --batch-mode luksFormat " + quote(get_blk_device()->get_name()) +
 	    " --key-file -";
@@ -206,6 +218,8 @@ namespace storage
 	cmd.execute(cmd_line);
 	if (cmd.retcode() != 0)
 	    ST_THROW(Exception("create Luks failed"));
+
+	probe_uuid();
     }
 
 

--- a/storage/Devices/LuksImpl.h
+++ b/storage/Devices/LuksImpl.h
@@ -56,6 +56,8 @@ namespace storage
 	virtual void probe_pass_1(Devicegraph* probed, SystemInfo& systeminfo) override;
 	virtual void probe_pass_2(Devicegraph* probed, SystemInfo& systeminfo) override;
 
+	void probe_uuid();
+
 	virtual Impl* clone() const override { return new Impl(*this); }
 
 	virtual EncryptionType get_type() const override { return EncryptionType::LUKS; }
@@ -75,7 +77,7 @@ namespace storage
 
 	virtual uint64_t used_features() const override;
 
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual void do_delete() const override;
 

--- a/storage/Devices/LvmLvImpl.cc
+++ b/storage/Devices/LvmLvImpl.cc
@@ -268,7 +268,7 @@ namespace storage
 
 
     void
-    LvmLv::Impl::do_create() const
+    LvmLv::Impl::do_create()
     {
 	const LvmVg* lvm_vg = get_lvm_vg();
 

--- a/storage/Devices/LvmLvImpl.h
+++ b/storage/Devices/LvmLvImpl.h
@@ -87,7 +87,7 @@ namespace storage
 	virtual void add_modify_actions(Actiongraph::Impl& actiongraph, const Device* lhs) const override;
 
 	virtual Text do_create_text(Tense tense) const override;
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual Text do_rename_text(const Impl& lhs, Tense tense) const;
 	virtual void do_rename(const Impl& lhs) const;

--- a/storage/Devices/LvmPvImpl.cc
+++ b/storage/Devices/LvmPvImpl.cc
@@ -242,7 +242,7 @@ namespace storage
 
 
     void
-    LvmPv::Impl::do_create() const
+    LvmPv::Impl::do_create()
     {
 	const BlkDevice* blk_device = get_blk_device();
 

--- a/storage/Devices/LvmPvImpl.h
+++ b/storage/Devices/LvmPvImpl.h
@@ -85,7 +85,7 @@ namespace storage
 	virtual void print(std::ostream& out) const override;
 
 	virtual Text do_create_text(Tense tense) const override;
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual Text do_resize_text(ResizeMode resize_mode, const Device* lhs, const Device* rhs,
 				    Tense tense) const override;

--- a/storage/Devices/LvmVgImpl.cc
+++ b/storage/Devices/LvmVgImpl.cc
@@ -405,7 +405,7 @@ namespace storage
 
 
     void
-    LvmVg::Impl::do_create() const
+    LvmVg::Impl::do_create()
     {
 	string cmd_line = VGCREATEBIN " --physicalextentsize " + to_string(get_extent_size()) +
 	    "b " + quote(vg_name);

--- a/storage/Devices/LvmVgImpl.h
+++ b/storage/Devices/LvmVgImpl.h
@@ -109,7 +109,7 @@ namespace storage
 	virtual void print(std::ostream& out) const override;
 
 	virtual Text do_create_text(Tense tense) const override;
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual Text do_delete_text(Tense tense) const override;
 	virtual void do_delete() const override;

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -217,6 +217,14 @@ namespace storage
 
 
     void
+    Md::Impl::probe_uuid()
+    {
+	MdadmDetail mdadm_detail(get_name());
+	uuid = mdadm_detail.uuid;
+    }
+
+
+    void
     Md::Impl::parent_has_new_region(const Device* parent)
     {
 	calculate_region_and_topology();
@@ -503,7 +511,7 @@ namespace storage
 
 
     void
-    Md::Impl::do_create() const
+    Md::Impl::do_create()
     {
 	// Note: Changing any parameter to "mdadm --create' requires the
 	// function calculate_region_and_topology() to be checked!
@@ -557,6 +565,8 @@ namespace storage
 	SystemCmd cmd(cmd_line);
 	if (cmd.retcode() != 0)
 	    ST_THROW(Exception("create md raid failed"));
+
+	probe_uuid();
     }
 
 

--- a/storage/Devices/MdImpl.h
+++ b/storage/Devices/MdImpl.h
@@ -91,6 +91,8 @@ namespace storage
 	virtual void probe_pass_1(Devicegraph* probed, SystemInfo& systeminfo) override;
 	virtual void probe_pass_2(Devicegraph* probed, SystemInfo& systeminfo) override;
 
+	void probe_uuid();
+
 	virtual void add_create_actions(Actiongraph::Impl& actiongraph) const override;
 	virtual void add_delete_actions(Actiongraph::Impl& actiongraph) const override;
 
@@ -104,7 +106,7 @@ namespace storage
 	virtual uint64_t used_features() const override;
 
 	virtual Text do_create_text(Tense tense) const override;
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual Text do_delete_text(Tense tense) const override;
 	virtual void do_delete() const override;

--- a/storage/Devices/MsdosImpl.cc
+++ b/storage/Devices/MsdosImpl.cc
@@ -286,7 +286,7 @@ namespace storage
 
 
     void
-    Msdos::Impl::do_create() const
+    Msdos::Impl::do_create()
     {
 	const Partitionable* partitionable = get_partitionable();
 

--- a/storage/Devices/MsdosImpl.h
+++ b/storage/Devices/MsdosImpl.h
@@ -100,7 +100,7 @@ namespace storage
 	virtual Region get_usable_region() const override;
 
 	virtual Text do_create_text(Tense tense) const override;
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
     private:
 

--- a/storage/Devices/PartitionImpl.cc
+++ b/storage/Devices/PartitionImpl.cc
@@ -496,7 +496,7 @@ namespace storage
 
 
     void
-    Partition::Impl::do_create() const
+    Partition::Impl::do_create()
     {
 	const Partitionable* partitionable = get_partitionable();
 

--- a/storage/Devices/PartitionImpl.h
+++ b/storage/Devices/PartitionImpl.h
@@ -106,7 +106,7 @@ namespace storage
 	virtual void process_udev_ids(vector<string>& udev_ids) const override;
 
 	virtual Text do_create_text(Tense tense) const override;
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual Text do_set_id_text(Tense tense) const;
 	virtual void do_set_id() const;

--- a/storage/Filesystems/BlkFilesystemImpl.cc
+++ b/storage/Filesystems/BlkFilesystemImpl.cc
@@ -146,6 +146,18 @@ namespace storage
     }
 
 
+    void
+    BlkFilesystem::Impl::probe_uuid()
+    {
+	const BlkDevice* blk_device = get_blk_device();
+
+	Blkid blkid(blk_device->get_name());
+	Blkid::Entry entry;
+	if (blkid.get_sole_entry(entry))
+	    uuid = entry.fs_uuid;
+    }
+
+
     ResizeInfo
     BlkFilesystem::Impl::detect_resize_info() const
     {

--- a/storage/Filesystems/BlkFilesystemImpl.h
+++ b/storage/Filesystems/BlkFilesystemImpl.h
@@ -72,6 +72,8 @@ namespace storage
 
 	virtual void probe_pass_3(Devicegraph* probed, SystemInfo& systeminfo, const EtcFstab& etc_fstab);
 
+	virtual void probe_uuid();
+
 	vector<const BlkDevice*> get_blk_devices() const;
 	const BlkDevice* get_blk_device() const;
 

--- a/storage/Filesystems/BtrfsImpl.cc
+++ b/storage/Filesystems/BtrfsImpl.cc
@@ -227,7 +227,7 @@ namespace storage
 
 
     void
-    Btrfs::Impl::do_create() const
+    Btrfs::Impl::do_create()
     {
 	const BlkDevice* blk_device = get_blk_device();
 
@@ -239,6 +239,10 @@ namespace storage
 	SystemCmd cmd(cmd_line);
 	if (cmd.retcode() != 0)
 	    ST_THROW(Exception("create btrfs failed"));
+
+	// TODO uuid is included in mkfs output
+
+	probe_uuid();
     }
 
 

--- a/storage/Filesystems/BtrfsImpl.h
+++ b/storage/Filesystems/BtrfsImpl.h
@@ -84,7 +84,7 @@ namespace storage
 
 	virtual uint64_t used_features() const override;
 
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual void do_set_label() const override;
 

--- a/storage/Filesystems/BtrfsSubvolumeImpl.cc
+++ b/storage/Filesystems/BtrfsSubvolumeImpl.cc
@@ -418,7 +418,7 @@ namespace storage
 
 
     void
-    BtrfsSubvolume::Impl::do_create() const
+    BtrfsSubvolume::Impl::do_create()
     {
 	const BtrfsSubvolume* top_level = get_top_level_btrfs_subvolume();
 

--- a/storage/Filesystems/BtrfsSubvolumeImpl.h
+++ b/storage/Filesystems/BtrfsSubvolumeImpl.h
@@ -102,7 +102,7 @@ namespace storage
 	virtual void add_delete_actions(Actiongraph::Impl& actiongraph) const override;
 
 	virtual Text do_create_text(Tense tense) const override;
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual Text do_mount_text(const string& mountpoint, Tense tense) const;
 

--- a/storage/Filesystems/ExtImpl.cc
+++ b/storage/Filesystems/ExtImpl.cc
@@ -46,7 +46,7 @@ namespace storage
 
 
     void
-    Ext::Impl::do_create() const
+    Ext::Impl::do_create()
     {
 	const BlkDevice* blk_device = get_blk_device();
 
@@ -59,6 +59,10 @@ namespace storage
 	SystemCmd cmd(cmd_line);
 	if (cmd.retcode() != 0)
 	    ST_THROW(Exception("create Ext failed"));
+
+	// TODO uuid is included in mkfs output
+
+	probe_uuid();
     }
 
 

--- a/storage/Filesystems/ExtImpl.h
+++ b/storage/Filesystems/ExtImpl.h
@@ -57,7 +57,7 @@ namespace storage
 
 	virtual const char* get_classname() const override { return DeviceTraits<Ext>::classname; }
 
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual void do_set_label() const override;
 

--- a/storage/Filesystems/NtfsImpl.cc
+++ b/storage/Filesystems/NtfsImpl.cc
@@ -113,7 +113,7 @@ namespace storage
 
 
     void
-    Ntfs::Impl::do_create() const
+    Ntfs::Impl::do_create()
     {
 	const BlkDevice* blk_device = get_blk_device();
 
@@ -125,6 +125,8 @@ namespace storage
 	SystemCmd cmd(cmd_line);
 	if (cmd.retcode() != 0)
 	    ST_THROW(Exception("create ntfs failed"));
+
+	probe_uuid();
     }
 
 

--- a/storage/Filesystems/NtfsImpl.h
+++ b/storage/Filesystems/NtfsImpl.h
@@ -69,7 +69,7 @@ namespace storage
 
 	virtual uint64_t used_features() const override;
 
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual void do_set_label() const override;
 

--- a/storage/Filesystems/ReiserfsImpl.cc
+++ b/storage/Filesystems/ReiserfsImpl.cc
@@ -65,7 +65,7 @@ namespace storage
 
 
     void
-    Reiserfs::Impl::do_create() const
+    Reiserfs::Impl::do_create()
     {
 	const BlkDevice* blk_device = get_blk_device();
 
@@ -77,6 +77,10 @@ namespace storage
 	SystemCmd cmd(cmd_line);
 	if (cmd.retcode() != 0)
 	    ST_THROW(Exception("create Reiserfs failed"));
+
+	// uuid is included in mkfs output
+
+	probe_uuid();
     }
 
 

--- a/storage/Filesystems/ReiserfsImpl.h
+++ b/storage/Filesystems/ReiserfsImpl.h
@@ -67,7 +67,7 @@ namespace storage
 
 	virtual uint64_t used_features() const override;
 
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual void do_set_label() const override;
 

--- a/storage/Filesystems/SwapImpl.cc
+++ b/storage/Filesystems/SwapImpl.cc
@@ -79,7 +79,7 @@ namespace storage
 
 
     void
-    Swap::Impl::do_create() const
+    Swap::Impl::do_create()
     {
 	const BlkDevice* blk_device = get_blk_device();
 
@@ -91,6 +91,10 @@ namespace storage
 	SystemCmd cmd(cmd_line);
 	if (cmd.retcode() != 0)
 	    ST_THROW(Exception("create swap failed"));
+
+	// TODO uuid is included in mkswap output
+
+	probe_uuid();
     }
 
 

--- a/storage/Filesystems/SwapImpl.h
+++ b/storage/Filesystems/SwapImpl.h
@@ -71,7 +71,7 @@ namespace storage
 
 	virtual uint64_t used_features() const override;
 
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual void do_mount(CommitData& commit_data, const string& mountpoint) const override;
 

--- a/storage/Filesystems/VfatImpl.cc
+++ b/storage/Filesystems/VfatImpl.cc
@@ -82,11 +82,11 @@ namespace storage
 
 
     void
-    Vfat::Impl::do_create() const
+    Vfat::Impl::do_create()
     {
 	const BlkDevice* blk_device = get_blk_device();
 
-	string cmd_line = MKFSFATBIN " " + quote(blk_device->get_name());
+	string cmd_line = MKFSFATBIN " -v " + quote(blk_device->get_name());
 	cout << cmd_line << endl;
 
 	blk_device->get_impl().wait_for_device();
@@ -94,6 +94,10 @@ namespace storage
 	SystemCmd cmd(cmd_line);
 	if (cmd.retcode() != 0)
 	    ST_THROW(Exception("create vfat failed"));
+
+	// uuid is included in mkfs output
+
+	probe_uuid();
     }
 
 

--- a/storage/Filesystems/VfatImpl.h
+++ b/storage/Filesystems/VfatImpl.h
@@ -69,7 +69,7 @@ namespace storage
 
 	virtual uint64_t used_features() const override;
 
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual void do_set_label() const override;
 

--- a/storage/Filesystems/XfsImpl.cc
+++ b/storage/Filesystems/XfsImpl.cc
@@ -68,7 +68,7 @@ namespace storage
 
 
     void
-    Xfs::Impl::do_create() const
+    Xfs::Impl::do_create()
     {
 	const BlkDevice* blk_device = get_blk_device();
 
@@ -80,6 +80,8 @@ namespace storage
 	SystemCmd cmd(cmd_line);
 	if (cmd.retcode() != 0)
 	    ST_THROW(Exception("create xfs failed"));
+
+	probe_uuid();
     }
 
 

--- a/storage/Filesystems/XfsImpl.h
+++ b/storage/Filesystems/XfsImpl.h
@@ -68,7 +68,7 @@ namespace storage
 
 	virtual uint64_t used_features() const override;
 
-	virtual void do_create() const override;
+	virtual void do_create() override;
 
 	virtual void do_set_label() const override;
 

--- a/storage/SystemInfo/CmdBlkid.cc
+++ b/storage/SystemInfo/CmdBlkid.cc
@@ -175,6 +175,19 @@ namespace storage
 
 
     bool
+    Blkid::get_sole_entry(Entry& entry) const
+    {
+	if (data.size() == 1)
+	{
+	    entry = data.begin()->second;
+	    return true;
+	}
+
+	return false;
+    }
+
+
+    bool
     Blkid::any_md() const
     {
 	return std::any_of(data.begin(), data.end(), [](const value_type& value) { return value.second.is_md; });

--- a/storage/SystemInfo/CmdBlkid.h
+++ b/storage/SystemInfo/CmdBlkid.h
@@ -76,6 +76,12 @@ namespace storage
 
 	bool find_by_name(const string& device, Entry& entry, SystemInfo& systeminfo) const;
 
+	/**
+	 * Get the sole entry. Useful when constructor with device parameter
+	 * was used.
+	 */
+	bool get_sole_entry(Entry& entry) const;
+
 	bool any_md() const;
 	bool any_lvm() const;
 	bool any_luks() const;


### PR DESCRIPTION
For https://trello.com/c/EMKFnYiV/275-8-libstorage-ng-md-arrays and https://trello.com/c/WAGRJLgv/542-5-libstorage-ng-support-of-alternative-device-naming-schemes.