### PR TITLE
- added functions to handle default mount-by

### DIFF
--- a/doc/mount-by.md
+++ b/doc/mount-by.md
@@ -1,0 +1,6 @@
+
+The library allows to set a default mount-by method. The initial value is
+```UUID```. The library does not store the value across runs.
+
+Also see https://fate.suse.com/316204/.
+

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -185,9 +185,8 @@ namespace storage
     {
 	Partitionable::Impl::probe_pass_1(probed, systeminfo);
 
-	string tmp = get_name().substr(strlen(DEVDIR "/"));
-
-	const ProcMdstat::Entry& entry = systeminfo.getProcMdstat().get_entry(tmp);
+	string short_name = get_name().substr(strlen(DEVDIR "/"));
+	const ProcMdstat::Entry& entry = systeminfo.getProcMdstat().get_entry(short_name);
 
 	md_level = entry.md_level;
 	md_parity = entry.md_parity;

--- a/storage/Storage.cc
+++ b/storage/Storage.cc
@@ -149,6 +149,20 @@ namespace storage
     }
 
 
+    MountByType
+    Storage::get_default_mount_by() const
+    {
+	return get_impl().get_default_mount_by();
+    }
+
+
+    void
+    Storage::set_default_mount_by(MountByType default_mount_by)
+    {
+	get_impl().set_default_mount_by(default_mount_by);
+    }
+
+
     const string&
     Storage::get_rootprefix() const
     {

--- a/storage/Storage.h
+++ b/storage/Storage.h
@@ -30,6 +30,8 @@
 #include <memory>
 #include <boost/noncopyable.hpp>
 
+#include "storage/Filesystems/Mountable.h"
+
 
 namespace storage
 {
@@ -144,6 +146,16 @@ namespace storage
 	const Devicegraph* get_probed() const;
 
 	void check() const;
+
+	/**
+	 * Query the default mount-by method.
+	 */
+	MountByType get_default_mount_by() const;
+
+	/**
+	 * Set the default mount-by method.
+	 */
+	void set_default_mount_by(MountByType default_mount_by);
 
 	const std::string& get_rootprefix() const;
 	void set_rootprefix(const std::string& rootprefix);

--- a/storage/StorageImpl.cc
+++ b/storage/StorageImpl.cc
@@ -47,7 +47,8 @@ namespace storage
 {
 
     Storage::Impl::Impl(const Storage& storage, const Environment& environment)
-	: storage(storage), environment(environment), arch(false), tmp_dir("libstorage-XXXXXX")
+	: storage(storage), environment(environment), arch(false),
+	  default_mount_by(MountByType::UUID), tmp_dir("libstorage-XXXXXX")
     {
 	y2mil("constructed Storage with " << environment);
 	y2mil("libstorage-ng version " VERSION);

--- a/storage/StorageImpl.h
+++ b/storage/StorageImpl.h
@@ -73,6 +73,9 @@ namespace storage
 
 	void check() const;
 
+	MountByType get_default_mount_by() const { return default_mount_by; }
+	void set_default_mount_by(MountByType default_mount_by) { Impl::default_mount_by = default_mount_by; }
+
 	const string& get_rootprefix() const { return rootprefix; }
 	void set_rootprefix(const string& rootprefix) { Impl::rootprefix = rootprefix; }
 
@@ -97,6 +100,8 @@ namespace storage
 	Arch arch;
 
 	map<string, Devicegraph> devicegraphs;
+
+	MountByType default_mount_by;
 
 	string rootprefix;
 

--- a/storage/Utils/AsciiFile.cc
+++ b/storage/Utils/AsciiFile.cc
@@ -137,32 +137,4 @@ namespace storage
 	    y2mil(line);
     }
 
-
-    bool
-    SysconfigFile::getValue(const string& key, string& value) const
-    {
-	Regex rx('^' + Regex::ws + key + '=' + "(['\"]?)([^'\"]*)\\1" + Regex::ws + '$');
-
-	if (find_if(get_lines(), regex_matches(rx)) == get_lines().end())
-	    return false;
-
-	value = rx.cap(2);
-	y2mil("key:" << key << " value:" << value);
-	return true;
-    }
-
-
-    bool
-    InstallInfFile::getValue(const string& key, string& value) const
-    {
-	Regex rx('^' + key + ":" + Regex::ws + "([^ ]*)" + '$');
-
-	if (find_if(get_lines(), regex_matches(rx)) == get_lines().end())
-	    return false;
-
-	value = rx.cap(1);
-	y2mil("key:" << key << " value:" << value);
-	return true;
-    }
-
 }

--- a/storage/Utils/AsciiFile.h
+++ b/storage/Utils/AsciiFile.h
@@ -64,28 +64,6 @@ namespace storage
 
     };
 
-
-    class SysconfigFile : protected AsciiFile
-    {
-    public:
-
-	SysconfigFile(const char* name) : AsciiFile(name) {}
-
-	bool getValue(const string& key, string& value) const;
-
-    };
-
-
-    class InstallInfFile : protected AsciiFile
-    {
-    public:
-
-	InstallInfFile(const char* name) : AsciiFile(name) {}
-
-	bool getValue(const string& key, string& value) const;
-
-    };
-
 }
 
 


### PR DESCRIPTION
For https://trello.com/c/WAGRJLgv/542-5-libstorage-ng-support-of-alternative-device-naming-schemes.

Yes, the default mount-by value is not used so far.