### PR TITLE
- fixed human string parser

### DIFF
--- a/storage/Utils/HumanString.cc
+++ b/storage/Utils/HumanString.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2004-2014] Novell, Inc.
- * Copyright (c) 2016 SUSE LLC
+ * Copyright (c) [2016-2017] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -22,6 +22,7 @@
 
 
 #include <locale>
+#include <cmath>
 #include <boost/algorithm/string.hpp>
 
 #include "storage/Utils/Text.h"
@@ -31,7 +32,7 @@
 
 namespace storage
 {
-    using namespace std;
+    using std::string;
 
 
     int
@@ -138,7 +139,7 @@ namespace storage
     {
 	const locale loc = classic ? locale::classic() : locale();
 
-	double f = size;
+	long double f = size;
 	int i = 0;
 
 	while (f >= 1024.0 && i + 1 < num_suffixes())
@@ -170,7 +171,7 @@ namespace storage
 
 	const string str_trimmed = boost::trim_copy(str, loc);
 
-	double f = 1.0;
+	long double f = 1.0;
 
 	for (int i = 0; i < num_suffixes(); ++i)
 	{
@@ -187,7 +188,7 @@ namespace storage
 		    istringstream s(boost::trim_copy(number, loc));
 		    s.imbue(loc);
 
-		    double g;
+		    long double g;
 		    s >> g;
 
 		    if (!s.fail() && s.eof())
@@ -195,7 +196,7 @@ namespace storage
 			if (g < 0.0)
 			    ST_THROW(OverflowException());
 
-			double r = g * f;
+			long double r = std::round(g * f);
 
 			if (r > std::numeric_limits<unsigned long long>::max())
 			    ST_THROW(OverflowException());

--- a/storage/Utils/HumanString.h
+++ b/storage/Utils/HumanString.h
@@ -61,7 +61,8 @@ namespace storage
 
     /**
      * Return a pretty description of a size with required precision and using
-     * B, KiB, MiB, GiB, TiB, PiB or EiB as unit as appropriate.
+     * B, KiB, MiB, GiB, TiB, PiB or EiB as unit as appropriate. Supported
+     * range is 0 B to (16 EiB - 1 B).
      *
      * @param size size in bytes
      * @param classic use classic locale instead of global C++ locale
@@ -75,7 +76,7 @@ namespace storage
     /**
      * Converts a size description using B, KiB, KB, MiB, MB, GiB, GB, TiB,
      * TB, PiB, PB, EiB or EB into an integer. Decimal suffixes are treated as
-     * binary.
+     * binary. Supported range is 0 B to (16 EiB - 1 B).
      *
      * @param str size string
      * @param classic use classic locale instead of global C++ locale

--- a/testsuite/Utils/humanstring.cc
+++ b/testsuite/Utils/humanstring.cc
@@ -86,28 +86,28 @@ BOOST_AUTO_TEST_CASE(test_humanstring_to_byte)
     BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "42b", false), 42);
     BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "42 B", false), 42);
 
-    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "12.4GB", true), 13314398617);
-    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "12.4 GB", true), 13314398617);
+    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "12.4GB", true), 13314398618);
+    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "12.4 GB", true), 13314398618);
 
-    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "12.4GB", false), 13314398617);
-    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "12.4 gb", false), 13314398617);
-    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "12.4g", false), 13314398617);
-    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "12.4 G", false), 13314398617);
+    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "12.4GB", false), 13314398618);
+    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "12.4 gb", false), 13314398618);
+    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "12.4g", false), 13314398618);
+    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "12.4 G", false), 13314398618);
 
     BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "123,456 kB", false), 126418944);
     BOOST_CHECK_EQUAL(test("de_DE.UTF-8", "123.456 kB", false), 126418944);
     BOOST_CHECK_EQUAL(test("de_CH.UTF-8", "123'456 kB", false), 126418944);
     BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", "123 456 ko", false), 126418944);
 
-    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "123,456.789kB", false), 126419751);
-    BOOST_CHECK_EQUAL(test("de_DE.UTF-8", "123.456,789kB", false), 126419751);
-    BOOST_CHECK_EQUAL(test("de_CH.UTF-8", "123'456.789kB", false), 126419751);
-    BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", "123 456,789ko", false), 126419751);
+    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "123,456.789kB", false), 126419752);
+    BOOST_CHECK_EQUAL(test("de_DE.UTF-8", "123.456,789kB", false), 126419752);
+    BOOST_CHECK_EQUAL(test("de_CH.UTF-8", "123'456.789kB", false), 126419752);
+    BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", "123 456,789ko", false), 126419752);
 
-    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "123,456.789 kB", false), 126419751);
-    BOOST_CHECK_EQUAL(test("de_DE.UTF-8", "123.456,789 kB", false), 126419751);
-    BOOST_CHECK_EQUAL(test("de_CH.UTF-8", "123'456.789 kB", false), 126419751);
-    BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", "123 456,789 ko", false), 126419751);
+    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "123,456.789 kB", false), 126419752);
+    BOOST_CHECK_EQUAL(test("de_DE.UTF-8", "123.456,789 kB", false), 126419752);
+    BOOST_CHECK_EQUAL(test("de_CH.UTF-8", "123'456.789 kB", false), 126419752);
+    BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", "123 456,789 ko", false), 126419752);
 
     BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", "5Go", false), 5368709120);
     BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", "5 Go", false), 5368709120);
@@ -130,20 +130,22 @@ BOOST_AUTO_TEST_CASE(test_humanstring_to_byte)
 
 BOOST_AUTO_TEST_CASE(test_big_numbers)
 {
-    unsigned long long EiB = 1ULL << (10 * 6);
-
+    // 1 EiB
     BOOST_CHECK_EQUAL(test("en_GB.UTF-8", EiB, true, 2, false), "1.00 EiB");
-    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", 15 * EiB, true, 2, true), "15 EiB");
-
+    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "1 EiB", true), EiB);
     BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "1.00 EiB", true), EiB);
-    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "15 EiB", true), 15 * EiB);
+
+    // 16 EiB - 1 B
+    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", 16 * EiB - 1 * B, true, 2, true), "16.00 EiB");
+    BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "18446744073709551615 B", true), 16 * EiB - 1 * B);
+
+    // 16 EiB
+    BOOST_CHECK_THROW(test("en_GB.UTF-8", "16 EiB", true), OverflowException);
+    BOOST_CHECK_THROW(test("en_GB.UTF-8", "18446744073709551616 B", true), OverflowException);
 }
 
 
-BOOST_AUTO_TEST_CASE(test_overflow)
+BOOST_AUTO_TEST_CASE(test_negative_numbers)
 {
-    BOOST_CHECK_THROW(test("en_GB.UTF-8", "-1B", false), OverflowException);
-
-    BOOST_CHECK_THROW(test("en_GB.UTF-8", "16.5 EiB", true), OverflowException);
-    BOOST_CHECK_THROW(test("en_GB.UTF-8", "-16.5 EiB", false), OverflowException);
+    BOOST_CHECK_THROW(test("en_GB.UTF-8", "-1 B", false), OverflowException);
 }


### PR DESCRIPTION
So far parsing "16 EiB" did not raise an overflow exception but returned "0".