### PR TITLE
- provide definition of data member

### DIFF
--- a/storage/Devices/PartitionableImpl.cc
+++ b/storage/Devices/PartitionableImpl.cc
@@ -49,6 +49,8 @@ namespace storage
 
     const char* DeviceTraits<Partitionable>::classname = "Partitionable";
 
+    const unsigned int Partitionable::Impl::default_range;
+
 
     Partitionable::Impl::Impl(const xmlNode* node)
 	: BlkDevice::Impl(node), topology(), range(0)


### PR DESCRIPTION
This is required when compiling with -fno-inline or -O0.
