### PR TITLE
Expose Alignment#grain

### DIFF
--- a/storage/Utils/Alignment.cc
+++ b/storage/Utils/Alignment.cc
@@ -85,6 +85,13 @@ namespace storage
     }
 
 
+    long
+    Alignment::offset() const
+    {
+	return get_impl().offset();
+    }
+
+
     unsigned long
     Alignment::grain() const
     {

--- a/storage/Utils/Alignment.cc
+++ b/storage/Utils/Alignment.cc
@@ -85,6 +85,13 @@ namespace storage
     }
 
 
+    unsigned long
+    Alignment::grain() const
+    {
+	return get_impl().calculate_grain();
+    }
+
+
     std::ostream&
     operator<<(std::ostream& s, const Alignment& alignment)
     {

--- a/storage/Utils/Alignment.h
+++ b/storage/Utils/Alignment.h
@@ -91,6 +91,8 @@ namespace storage
 	 * @throw AlignError
 	 */
 	Region align(const Region& region, AlignPolicy align_policy = AlignPolicy::ALIGN_END) const;
+	
+	unsigned long grain() const;
 
     public:
 

--- a/storage/Utils/Alignment.h
+++ b/storage/Utils/Alignment.h
@@ -92,6 +92,8 @@ namespace storage
 	 */
 	Region align(const Region& region, AlignPolicy align_policy = AlignPolicy::ALIGN_END) const;
 	
+	long offset() const;
+
 	unsigned long grain() const;
 
     public:

--- a/storage/Utils/AlignmentImpl.cc
+++ b/storage/Utils/AlignmentImpl.cc
@@ -29,6 +29,13 @@
 namespace storage
 {
 
+    long
+    Alignment::Impl::offset() const
+    {
+	return topology.get_alignment_offset();
+    }
+
+
     unsigned long
     Alignment::Impl::calculate_grain() const
     {
@@ -53,7 +60,7 @@ namespace storage
     Alignment::Impl::align_block_in_place(unsigned long long& block, unsigned long block_size,
 					  Location location) const
     {
-	long alignment_offset_in_blocks = topology.get_alignment_offset() / block_size;
+	long alignment_offset_in_blocks = offset() / block_size;
 	unsigned long grain_in_blocks = calculate_grain() / block_size;
 
 	block -= alignment_offset_in_blocks;

--- a/storage/Utils/AlignmentImpl.h
+++ b/storage/Utils/AlignmentImpl.h
@@ -48,6 +48,8 @@ namespace storage
 
 	void set_extra_grain(unsigned long extra_grain) { Impl::extra_grain = extra_grain; }
 
+	long offset() const;
+
 	unsigned long calculate_grain() const;
 
 	bool can_be_aligned(const Region& region, AlignPolicy align_policy) const;


### PR DESCRIPTION
Needed for PBI: https://trello.com/c/UBCLA6Qo/651-2-storageng-and-s-390-partitions-not-aligned.

The Proposal needs to know in advance the grain for alignment. With this info, the proposal is able to always generate aligned partitions, even for DASD. 

This PR should be merged before this one https://github.com/yast/yast-storage-ng/pull/312.