### PR TITLE
Add .snapshots subvolume directly to /etc/fstab

### DIFF
--- a/storage/Filesystems/BtrfsImpl.cc
+++ b/storage/Filesystems/BtrfsImpl.cc
@@ -337,7 +337,7 @@ namespace storage
         BlkFilesystem::Impl::do_add_to_etc_fstab(commit_data, mount_point);
 
         if (snapper_config)
-            snapper_config->post_add_to_etc_fstab();
+            snapper_config->post_add_to_etc_fstab(commit_data.get_etc_fstab());
     }
 
 

--- a/storage/Utils/CommentedConfigFile.cc
+++ b/storage/Utils/CommentedConfigFile.cc
@@ -157,6 +157,9 @@ bool CommentedConfigFile::write( const string & new_filename )
     for ( size_t i=0; i < lines.size(); ++i )
         file << lines[i] << "\n"; // no endl: Don't flush after every line
 
+    if ( diff_enabled )
+        save_orig( lines );
+
     return true;
 }
 

--- a/storage/Utils/SnapperConfig.cc
+++ b/storage/Utils/SnapperConfig.cc
@@ -117,7 +117,7 @@ SnapperConfig::post_add_to_etc_fstab( EtcFstab & etc_fstab )
     mount_opts.append( string( "subvol=/" ) + get_snapshots_subvol_name() );
     entry->set_mount_opts( mount_opts );
 
-    etc_fstab.write(); // Just to make the next logged diff shorter
+    etc_fstab.save_orig(); // Reset reference for diff
     y2mil( "Adding .snapshots subvolume to /etc/fstab:" );
     etc_fstab.add( entry );
     etc_fstab.log_diff();

--- a/storage/Utils/SnapperConfig.cc
+++ b/storage/Utils/SnapperConfig.cc
@@ -111,7 +111,7 @@ SnapperConfig::post_add_to_etc_fstab( EtcFstab & etc_fstab )
 
     entry->set_device( get_device_name() );
     entry->set_mount_point( "/" SNAPSHOTS_DIR );
-    entry->set_mount_opts( MountOpts( string( "subvol=" ) + get_snapshots_subvol_name() ) );
+    entry->set_mount_opts( MountOpts( string( "subvol=/" ) + get_snapshots_subvol_name() ) );
     entry->set_fs_type( FsType::BTRFS );
 
     y2mil( "Adding snapshots dir to /etc/fstab:" );

--- a/storage/Utils/SnapperConfig.cc
+++ b/storage/Utils/SnapperConfig.cc
@@ -104,17 +104,21 @@ SnapperConfig::post_add_to_etc_fstab( EtcFstab & etc_fstab )
 
     // Sample fstab entry:
     //
-    // UUID=5acfd198-963a-4740-a33e-030b7f305d67 /.snapshots btrfs subvol=@/.snapshots 0 0
+    // UUID=5acfd198-963a-4740-a33e-030b7f305d67 /.snapshots btrfs subvol=/@/.snapshots 0 0
 
 
     FstabEntry * entry = new FstabEntry();
 
     entry->set_device( get_device_name() );
     entry->set_mount_point( "/" SNAPSHOTS_DIR );
-    entry->set_mount_opts( MountOpts( string( "subvol=/" ) + get_snapshots_subvol_name() ) );
     entry->set_fs_type( FsType::BTRFS );
 
-    y2mil( "Adding snapshots dir to /etc/fstab:" );
+    MountOpts mount_opts = btrfs->get_impl().get_mount_options();
+    mount_opts.append( string( "subvol=/" ) + get_snapshots_subvol_name() );
+    entry->set_mount_opts( mount_opts );
+
+    etc_fstab.write(); // Just to make the next logged diff shorter
+    y2mil( "Adding .snapshots subvolume to /etc/fstab:" );
     etc_fstab.add( entry );
     etc_fstab.log_diff();
     etc_fstab.write();

--- a/storage/Utils/SnapperConfig.h
+++ b/storage/Utils/SnapperConfig.h
@@ -34,6 +34,7 @@ namespace storage
     using std::vector;
 
     class Btrfs;
+    class EtcFstab;
 
 
     /**
@@ -73,10 +74,9 @@ namespace storage
          * Hook to be called after the Btrfs root filesystem is added to
          * /etc/fstab.
          *
-         * This executes installation-helper step 3:
-         * Add @/.snapshots or .snapshots to /etc/fstab.
+         * This adds @/.snapshots or .snapshots to /etc/fstab.
          **/
-        void post_add_to_etc_fstab();
+        void post_add_to_etc_fstab( EtcFstab & etc_fstab );
 
         /**
          * Return the Btrfs filesystem this object works on.
@@ -138,6 +138,17 @@ namespace storage
          * the new root filesystem of the target is or will be mounted).
          **/
         string get_root_prefix() const;
+
+        /**
+         * Return the device name for the btrfs.
+         **/
+        string get_device_name() const;
+
+        /**
+         * Return the subvolume name of the ".snapshots" subvolume
+         * (prepended by the default subvolume if that is configured).
+         **/
+        string get_snapshots_subvol_name() const;
 
 
     private:


### PR DESCRIPTION
https://trello.com/c/ytK5Yoe4/554-5-storageng-installation-to-root-subvolume

https://bugzilla.suse.com/show_bug.cgi?id=1057443

Now doing what `installation-helper --step 3` did directly in the C++ code to keep /etc/fstab on the target in sync; previously it was overwritten by the next action in libstorage-ng.