### PR TITLE
- call efibootmgr before deleting partitions

### DIFF
--- a/storage/Devices/PartitionImpl.h
+++ b/storage/Devices/PartitionImpl.h
@@ -121,6 +121,8 @@ namespace storage
 	virtual Text do_delete_text(Tense tense) const override;
 	virtual void do_delete() const override;
 
+	void do_delete_efi_boot_mgr() const;
+
 	virtual Text do_resize_text(ResizeMode resize_mode, const Device* lhs, const Device* rhs,
 				    Tense tense) const override;
 	virtual void do_resize(ResizeMode resize_mode, const Device* rhs) const override;

--- a/storage/Utils/StorageDefines.h
+++ b/storage/Utils/StorageDefines.h
@@ -100,6 +100,8 @@
 #define RPCBINDBIN     "/sbin/rpcbind"
 #define RPCSTATDBIN    "/usr/sbin/rpc.statd"
 
+#define EFIBOOTMGRBIN "/usr/sbin/efibootmgr"
+
 #define NTFSRESIZEBIN "/usr/sbin/ntfsresize"
 #define XFSGROWFSBIN  "/usr/sbin/xfs_growfs"
 #define REISERFSRESIZEBIN "/sbin/resize_reiserfs"


### PR DESCRIPTION
For https://trello.com/c/bFWkAqjE/725-out-of-scrum-libstorage-ng-call-efibootmgr-when-deleting-partitions-on-gpt.