### PR TITLE
Don't sort disks and dasds by default

### DIFF
--- a/storage/Devices/Dasd.cc
+++ b/storage/Devices/Dasd.cc
@@ -164,14 +164,14 @@ namespace storage
     vector<Dasd*>
     Dasd::get_all(Devicegraph* devicegraph)
     {
-	return devicegraph->get_impl().get_devices_of_type<Dasd>(compare_by_name);
+	return devicegraph->get_impl().get_devices_of_type<Dasd>();
     }
 
 
     vector<const Dasd*>
     Dasd::get_all(const Devicegraph* devicegraph)
     {
-	return devicegraph->get_impl().get_devices_of_type<const Dasd>(compare_by_name);
+	return devicegraph->get_impl().get_devices_of_type<const Dasd>();
     }
 
 

--- a/storage/Devices/Disk.cc
+++ b/storage/Devices/Disk.cc
@@ -137,14 +137,14 @@ namespace storage
     vector<Disk*>
     Disk::get_all(Devicegraph* devicegraph)
     {
-	return devicegraph->get_impl().get_devices_of_type<Disk>(compare_by_name);
+	return devicegraph->get_impl().get_devices_of_type<Disk>();
     }
 
 
     vector<const Disk*>
     Disk::get_all(const Devicegraph* devicegraph)
     {
-	return devicegraph->get_impl().get_devices_of_type<const Disk>(compare_by_name);
+	return devicegraph->get_impl().get_devices_of_type<const Disk>();
     }
 
 


### PR DESCRIPTION
Part of https://trello.com/c/6szyiBWI/763-2-sle15-storage-ng-select-the-disk-to-use-consistently

This should not break the yast2-storage-ng testsuite IF this other PR is already merged there: https://github.com/yast/yast-storage-ng/pull/428