### PR TITLE
Leave enough space even for 'reiserfs'

### DIFF
--- a/storage/EtcFstab.cc
+++ b/storage/EtcFstab.cc
@@ -285,7 +285,7 @@ namespace storage
 	int col = 0;
 	set_max_column_width( col++, 45 ); // device; just enough for UUID=...
 	set_max_column_width( col++, 25 ); // mount point
-	set_max_column_width( col++,  7 ); // fs type
+	set_max_column_width( col++, 10 ); // fs type
 	set_max_column_width( col++, 30 ); // mount options
 	set_max_column_width( col++,  1 ); // dump pass
 	set_max_column_width( col++,  1 ); // fsck pass


### PR DESCRIPTION
When using filesystem type "reiserfs" the formatting looked ragged because it exceeded the previous max column width of 7. Now leaving some more room. Remember that this is only the maximum column width; if less width is required, it will use less width.