### PR TITLE
remove LIBVERSION_MAJOR macro from spec.in

### DIFF
--- a/libstorage-ng.spec.in
+++ b/libstorage-ng.spec.in
@@ -16,7 +16,7 @@
 #
 
 
-%define libname %{name}@LIBVERSION_MAJOR@
+%define libname %{name}1
 Name:           libstorage-ng
 Version:        @VERSION@
 Release:        0


### PR DESCRIPTION
LIBVERSION_MAJOR will be 1 for the forseeable future.

Without this macro *.spec.in can be used directly as spec file for our
auto-submission process.