### PR TITLE
- find crypttab entries by correct block device

### DIFF
--- a/storage/Devices/EncryptionImpl.cc
+++ b/storage/Devices/EncryptionImpl.cc
@@ -428,7 +428,7 @@ namespace storage
 
 
     void
-    Encryption::Impl::do_rename_in_etc_crypttab(CommitData& commit_data, const Device* lhs) const
+    Encryption::Impl::do_rename_in_etc_crypttab(CommitData& commit_data) const
     {
         ST_THROW(LogicException("stub do_rename_in_etc_crypttab called"));
     }
@@ -496,9 +496,8 @@ namespace storage
 	void
 	RenameInEtcCrypttab::commit(CommitData& commit_data, const CommitOptions& commit_options) const
 	{
-	    const Encryption* encryption_lhs = to_encryption(get_device(commit_data.actiongraph, LHS));
-	    const Encryption* encryption_rhs = to_encryption(get_device(commit_data.actiongraph, RHS));
-	    encryption_rhs->get_impl().do_rename_in_etc_crypttab(commit_data, encryption_lhs);
+	    const Encryption* encryption = to_encryption(get_device(commit_data.actiongraph, RHS));
+	    encryption->get_impl().do_rename_in_etc_crypttab(commit_data);
 	}
 
 

--- a/storage/Devices/EncryptionImpl.h
+++ b/storage/Devices/EncryptionImpl.h
@@ -74,6 +74,13 @@ namespace storage
 	bool is_in_etc_crypttab() const { return in_etc_crypttab; }
 	void set_in_etc_crypttab(bool in_etc_crypttab) { Impl::in_etc_crypttab = in_etc_crypttab; }
 
+	/**
+	 * Get the block device name that was used in /etc/crypttab. This is
+	 * empty if this encryption was not in /etc/crypttab during probing.
+	 */
+        const string& get_crypttab_blk_device_name() const { return crypttab_blk_device_name; }
+        void set_crypttab_blk_device_name(const string& name) { Impl::crypttab_blk_device_name = name; }
+
 	const BlkDevice* get_blk_device() const;
 
 	virtual Impl* clone() const override { return new Impl(*this); }
@@ -118,6 +125,8 @@ namespace storage
 	CryptOpts crypt_options;
 
 	bool in_etc_crypttab;
+
+	string crypttab_blk_device_name; // block device name as found in /etc/crypttab
 
     };
 

--- a/storage/Devices/EncryptionImpl.h
+++ b/storage/Devices/EncryptionImpl.h
@@ -111,7 +111,7 @@ namespace storage
 	virtual void do_add_to_etc_crypttab(CommitData& commit_data) const;
 
 	virtual Text do_rename_in_etc_crypttab_text(const Device* lhs, Tense tense) const;
-	virtual void do_rename_in_etc_crypttab(CommitData& commit_data, const Device* lhs) const;
+	virtual void do_rename_in_etc_crypttab(CommitData& commit_data) const;
 
 	virtual Text do_remove_from_etc_crypttab_text(Tense tense) const;
 	virtual void do_remove_from_etc_crypttab(CommitData& commit_data) const;

--- a/storage/Devices/LuksImpl.cc
+++ b/storage/Devices/LuksImpl.cc
@@ -517,12 +517,12 @@ namespace storage
 	EtcCrypttab& etc_crypttab = commit_data.get_etc_crypttab();
 
 	CrypttabEntry* entry = etc_crypttab.find_block_device(get_crypttab_blk_device_name());
-        if (entry)
-        {
-            entry->set_block_device(get_mount_by_name(get_mount_by()));
-            etc_crypttab.log();
-            etc_crypttab.write();
-        }
+	if (entry)
+	{
+	    entry->set_block_device(get_mount_by_name(get_mount_by()));
+	    etc_crypttab.log();
+	    etc_crypttab.write();
+	}
     }
 
 
@@ -532,12 +532,12 @@ namespace storage
 	EtcCrypttab& etc_crypttab = commit_data.get_etc_crypttab();
 
 	CrypttabEntry* entry = etc_crypttab.find_block_device(get_crypttab_blk_device_name());
-        if (entry)
-        {
-            etc_crypttab.remove(entry);
-            etc_crypttab.log();
-            etc_crypttab.write();
-        }
+	if (entry)
+	{
+	    etc_crypttab.remove(entry);
+	    etc_crypttab.log();
+	    etc_crypttab.write();
+	}
     }
 
 }

--- a/storage/Devices/LuksImpl.cc
+++ b/storage/Devices/LuksImpl.cc
@@ -297,6 +297,7 @@ namespace storage
 	    {
 		luks->set_mount_by(crypttab_entry->get_mount_by());
 		luks->get_impl().set_crypt_options(crypttab_entry->get_crypt_opts());
+		luks->get_impl().set_crypttab_blk_device_name(crypttab_entry->get_block_device());
 	    }
 
 	    prober.add_holder(blk_device, luks, [](Devicegraph* probed, Device* a, Device* b) {
@@ -513,15 +514,9 @@ namespace storage
     void
     Luks::Impl::do_rename_in_etc_crypttab(CommitData& commit_data, const Device* lhs) const
     {
-	const Luks* luks_lhs = to_luks(lhs);
-
 	EtcCrypttab& etc_crypttab = commit_data.get_etc_crypttab();
 
-	// TODO find entry by different names
-
-        string old_block_device = luks_lhs->get_blk_device()->get_name();
-        CrypttabEntry* entry = etc_crypttab.find_block_device(old_block_device);
-
+	CrypttabEntry* entry = etc_crypttab.find_block_device(get_crypttab_blk_device_name());
         if (entry)
         {
             entry->set_block_device(get_mount_by_name(get_mount_by()));
@@ -536,10 +531,7 @@ namespace storage
     {
 	EtcCrypttab& etc_crypttab = commit_data.get_etc_crypttab();
 
-	// TODO find entry by different names
-
-        CrypttabEntry* entry = etc_crypttab.find_block_device(get_blk_device()->get_name());
-
+	CrypttabEntry* entry = etc_crypttab.find_block_device(get_crypttab_blk_device_name());
         if (entry)
         {
             etc_crypttab.remove(entry);

--- a/storage/Devices/LuksImpl.cc
+++ b/storage/Devices/LuksImpl.cc
@@ -512,7 +512,7 @@ namespace storage
 
 
     void
-    Luks::Impl::do_rename_in_etc_crypttab(CommitData& commit_data, const Device* lhs) const
+    Luks::Impl::do_rename_in_etc_crypttab(CommitData& commit_data) const
     {
 	EtcCrypttab& etc_crypttab = commit_data.get_etc_crypttab();
 

--- a/storage/Devices/LuksImpl.h
+++ b/storage/Devices/LuksImpl.h
@@ -104,8 +104,7 @@ namespace storage
 
 	virtual void do_add_to_etc_crypttab(CommitData& commit_data) const override;
 
-	virtual void do_rename_in_etc_crypttab(CommitData& commit_data, const Device* lhs)
-	    const override;
+	virtual void do_rename_in_etc_crypttab(CommitData& commit_data) const override;
 
 	virtual void do_remove_from_etc_crypttab(CommitData& commit_data) const override;
 

--- a/storage/Filesystems/BlkFilesystemImpl.cc
+++ b/storage/Filesystems/BlkFilesystemImpl.cc
@@ -697,7 +697,7 @@ namespace storage
 
 
     void
-    BlkFilesystem::Impl::do_rename_in_etc_fstab(CommitData& commit_data, const Device* lhs) const
+    BlkFilesystem::Impl::do_rename_in_etc_fstab(CommitData& commit_data) const
     {
 	EtcFstab& etc_fstab = commit_data.get_etc_fstab();
 
@@ -864,9 +864,8 @@ namespace storage
 	void
 	RenameInEtcFstab::commit(CommitData& commit_data, const CommitOptions& commit_options) const
 	{
-	    const BlkFilesystem* blk_filesystem_lhs = to_blk_filesystem(get_device(commit_data.actiongraph, LHS));
-	    const BlkFilesystem* blk_filesystem_rhs = to_blk_filesystem(get_device(commit_data.actiongraph, RHS));
-	    blk_filesystem_rhs->get_impl().do_rename_in_etc_fstab(commit_data, blk_filesystem_lhs);
+	    const BlkFilesystem* blk_filesystem = to_blk_filesystem(get_device(commit_data.actiongraph, RHS));
+	    blk_filesystem->get_impl().do_rename_in_etc_fstab(commit_data);
 	}
 
 

--- a/storage/Filesystems/BlkFilesystemImpl.h
+++ b/storage/Filesystems/BlkFilesystemImpl.h
@@ -120,7 +120,7 @@ namespace storage
 	virtual void do_set_tune_options() const;
 
 	virtual Text do_rename_in_etc_fstab_text(const Device* lhs, Tense tense) const;
-	virtual void do_rename_in_etc_fstab(CommitData& commit_data, const Device* lhs) const;
+	virtual void do_rename_in_etc_fstab(CommitData& commit_data) const;
 
 	virtual Text do_resize_text(ResizeMode resize_mode, const Device* lhs, const Device* rhs,
 				    Tense tense) const override;


### PR DESCRIPTION
For https://trello.com/c/R5gCe53x/215-3-libstorage-ng-use-fstab-crypttab-and-proc-or-sys-during-probing.