### PR TITLE
- distinguish between mounted and unounted in supports_shrink/grow

### DIFF
--- a/storage/Filesystems/BlkFilesystemImpl.h
+++ b/storage/Filesystems/BlkFilesystemImpl.h
@@ -52,8 +52,14 @@ namespace storage
 	virtual unsigned long long min_size() const = 0;
 	virtual unsigned long long max_size() const = 0;
 
-	virtual bool supports_shrink() const = 0;
-	virtual bool supports_grow() const = 0;
+	bool supports_shrink() const { return supports_mounted_shrink() || supports_unmounted_shrink(); }
+	bool supports_grow() const { return supports_mounted_grow() || supports_unmounted_grow(); }
+
+	virtual bool supports_mounted_shrink() const = 0;
+	virtual bool supports_mounted_grow() const = 0;
+
+	virtual bool supports_unmounted_shrink() const = 0;
+	virtual bool supports_unmounted_grow() const = 0;
 
 	virtual bool supports_label() const = 0;
 	virtual unsigned int max_labelsize() const = 0;

--- a/storage/Filesystems/BtrfsImpl.h
+++ b/storage/Filesystems/BtrfsImpl.h
@@ -49,8 +49,11 @@ namespace storage
 	virtual unsigned long long min_size() const override { return 256 * MiB; }
 	virtual unsigned long long max_size() const override { return 16 * EiB - 1 * B; }
 
-	virtual bool supports_shrink() const override { return true; }
-	virtual bool supports_grow() const override { return true; }
+	virtual bool supports_mounted_shrink() const override { return true; }
+	virtual bool supports_mounted_grow() const override { return true; }
+
+	virtual bool supports_unmounted_shrink() const override { return false; }
+	virtual bool supports_unmounted_grow() const override { return false; }
 
 	virtual bool supports_label() const override { return true; }
 	virtual unsigned int max_labelsize() const override { return 256; }

--- a/storage/Filesystems/ExtImpl.h
+++ b/storage/Filesystems/ExtImpl.h
@@ -43,8 +43,11 @@ namespace storage
 
     public:
 
-	virtual bool supports_shrink() const override { return true; }
-	virtual bool supports_grow() const override { return true; }
+	virtual bool supports_mounted_shrink() const override { return false; }
+	virtual bool supports_mounted_grow() const override { return true; }
+
+	virtual bool supports_unmounted_shrink() const override { return true; }
+	virtual bool supports_unmounted_grow() const override { return true; }
 
 	virtual bool supports_label() const override { return true; }
 	virtual unsigned int max_labelsize() const override { return 16; }

--- a/storage/Filesystems/Iso9660Impl.h
+++ b/storage/Filesystems/Iso9660Impl.h
@@ -46,8 +46,11 @@ namespace storage
 	virtual unsigned long long min_size() const override { return 0 * B; }
 	virtual unsigned long long max_size() const override { return 2 * TiB; }
 
-	virtual bool supports_shrink() const override { return false; }
-	virtual bool supports_grow() const override { return false; }
+	virtual bool supports_mounted_shrink() const override { return false; }
+	virtual bool supports_mounted_grow() const override { return false; }
+
+	virtual bool supports_unmounted_shrink() const override { return false; }
+	virtual bool supports_unmounted_grow() const override { return false; }
 
 	virtual bool supports_label() const override { return true; }
 	virtual unsigned int max_labelsize() const override { return 30; }

--- a/storage/Filesystems/NtfsImpl.h
+++ b/storage/Filesystems/NtfsImpl.h
@@ -47,8 +47,11 @@ namespace storage
 	virtual unsigned long long min_size() const override { return 1 * MiB; }
 	virtual unsigned long long max_size() const override { return 256 * TiB - 64 * KiB; }
 
-	virtual bool supports_shrink() const override { return true; }
-	virtual bool supports_grow() const override { return true; }
+	virtual bool supports_mounted_shrink() const override { return false; }
+	virtual bool supports_mounted_grow() const override { return false; }
+
+	virtual bool supports_unmounted_shrink() const override { return true; }
+	virtual bool supports_unmounted_grow() const override { return true; }
 
 	virtual bool supports_label() const override { return true; }
 	virtual unsigned int max_labelsize() const override { return 128; }

--- a/storage/Filesystems/ReiserfsImpl.h
+++ b/storage/Filesystems/ReiserfsImpl.h
@@ -46,8 +46,11 @@ namespace storage
 	virtual unsigned long long min_size() const override { return 64 * MiB; }
 	virtual unsigned long long max_size() const override { return 16 * TiB; }
 
-	virtual bool supports_shrink() const override { return true; }
-	virtual bool supports_grow() const override { return true; }
+	virtual bool supports_mounted_shrink() const override { return false; }
+	virtual bool supports_mounted_grow() const override { return true; }
+
+	virtual bool supports_unmounted_shrink() const override { return true; }
+	virtual bool supports_unmounted_grow() const override { return true; }
 
 	virtual bool supports_label() const override { return true; }
 	virtual unsigned int max_labelsize() const override { return 16; }

--- a/storage/Filesystems/SwapImpl.h
+++ b/storage/Filesystems/SwapImpl.h
@@ -47,8 +47,11 @@ namespace storage
 	virtual unsigned long long min_size() const override { return 40 * KiB; }
 	virtual unsigned long long max_size() const override { return 1 * TiB; }
 
-	virtual bool supports_shrink() const override { return true; }
-	virtual bool supports_grow() const override { return true; }
+	virtual bool supports_mounted_shrink() const override { return false; }
+	virtual bool supports_mounted_grow() const override { return false; }
+
+	virtual bool supports_unmounted_shrink() const override { return true; }
+	virtual bool supports_unmounted_grow() const override { return true; }
 
 	virtual bool supports_label() const override { return true; }
 	virtual unsigned int max_labelsize() const override { return 15; }

--- a/storage/Filesystems/UdfImpl.h
+++ b/storage/Filesystems/UdfImpl.h
@@ -46,8 +46,11 @@ namespace storage
 	virtual unsigned long long min_size() const override { return 0 * B; }
 	virtual unsigned long long max_size() const override { return 2 * TiB; }
 
-	virtual bool supports_shrink() const override { return false; }
-	virtual bool supports_grow() const override { return false; }
+	virtual bool supports_mounted_shrink() const override { return false; }
+	virtual bool supports_mounted_grow() const override { return false; }
+
+	virtual bool supports_unmounted_shrink() const override { return false; }
+	virtual bool supports_unmounted_grow() const override { return false; }
 
 	virtual bool supports_label() const override { return true; }
 	virtual unsigned int max_labelsize() const override { return 30; }

--- a/storage/Filesystems/VfatImpl.h
+++ b/storage/Filesystems/VfatImpl.h
@@ -47,8 +47,11 @@ namespace storage
 	virtual unsigned long long min_size() const override { return 64 * KiB; }
 	virtual unsigned long long max_size() const override { return 2 * TiB; }
 
-	virtual bool supports_shrink() const override { return false; }
-	virtual bool supports_grow() const override { return false; }
+	virtual bool supports_mounted_shrink() const override { return false; }
+	virtual bool supports_mounted_grow() const override { return false; }
+
+	virtual bool supports_unmounted_shrink() const override { return false; }
+	virtual bool supports_unmounted_grow() const override { return false; }
 
 	virtual bool supports_label() const override { return true; }
 	virtual unsigned int max_labelsize() const override { return 11; }

--- a/storage/Filesystems/XfsImpl.h
+++ b/storage/Filesystems/XfsImpl.h
@@ -47,8 +47,11 @@ namespace storage
 	virtual unsigned long long min_size() const override { return 40 * MiB; }
 	virtual unsigned long long max_size() const override { return 8 * EiB - 1 * B; }
 
-	virtual bool supports_shrink() const override { return false; }
-	virtual bool supports_grow() const override { return true; }
+	virtual bool supports_mounted_shrink() const override { return false; }
+	virtual bool supports_mounted_grow() const override { return true; }
+
+	virtual bool supports_unmounted_shrink() const override { return false; }
+	virtual bool supports_unmounted_grow() const override { return false; }
 
 	virtual bool supports_label() const override { return true; }
 	virtual unsigned int max_labelsize() const override { return 12; }


### PR DESCRIPTION
For https://trello.com/c/s3Q03YDp/53-5-libstorage-ng-resizing-add-mount-handling.