### PR TITLE
test: Run 'test_big_numbers' only if 'long double' is supported

### DIFF
--- a/testsuite/Utils/humanstring.cc
+++ b/testsuite/Utils/humanstring.cc
@@ -128,6 +128,7 @@ BOOST_AUTO_TEST_CASE(test_humanstring_to_byte)
 }
 
 
+#ifndef __NO_LONG_DOUBLE_MATH
 BOOST_AUTO_TEST_CASE(test_big_numbers)
 {
     // 1 EiB
@@ -143,6 +144,7 @@ BOOST_AUTO_TEST_CASE(test_big_numbers)
     BOOST_CHECK_THROW(test("en_GB.UTF-8", "16 EiB", true), OverflowException);
     BOOST_CHECK_THROW(test("en_GB.UTF-8", "18446744073709551616 B", true), OverflowException);
 }
+#endif
 
 
 BOOST_AUTO_TEST_CASE(test_negative_numbers)


### PR DESCRIPTION
It fixes ARM check: #440 
boo#1078997