### PR TITLE
Ensure not to write malformed /etc/fstab entries (bsc#1066763)

### DIFF
--- a/storage/EtcFstab.cc
+++ b/storage/EtcFstab.cc
@@ -209,6 +209,26 @@ namespace storage
     }
 
 
+    bool FstabEntry::validate()
+    {
+        bool ok = true;
+
+        if ( device.empty() )
+        {
+            ok = false;
+            y2err( "No device specified for entry " << mount_point );
+        }
+
+        if ( mount_point.empty() )
+        {
+            ok = false;
+            y2err( "No mount point specified for entry " << device );
+        }
+
+        return ok;
+    }
+
+
     void FstabEntry::populate_columns()
     {
 	set_column_count( FSTAB_COLUMN_COUNT );

--- a/storage/EtcFstab.h
+++ b/storage/EtcFstab.h
@@ -219,10 +219,23 @@ namespace storage
 
 	virtual ~FstabEntry();
 
+        /**
+         * Validate this entry just prior to formatting/writing it back to
+         * file: Return 'true' if okay, 'false' if not.
+         *
+         * If this returns 'false', the entry is not formatted/written -
+         * neither the entry itself nor the comments that belong to it. Error
+         * handling such as logging an error or whatever is this function's
+         * responsibility.
+         *
+	 * Reimplemented from CommentedConfigFile.
+         **/
+        virtual bool validate() override;
+
 	/**
 	 * Populate the columns with content from the member variables.
 	 *
-	 * Reimplemented from CommentedConfigFile.
+	 * Reimplemented from ColumnConfigFile.
 	 **/
 	virtual void populate_columns() override;
 

--- a/storage/Utils/CommentedConfigFile.cc
+++ b/storage/Utils/CommentedConfigFile.cc
@@ -298,15 +298,18 @@ string_vec CommentedConfigFile::format_lines()
     {
         Entry * entry = entries[i];
 
-        for ( size_t j=0; j < entry->get_comment_before().size(); ++j )
-            lines.push_back( entry->get_comment_before()[j] );
+        if ( entry->validate() )
+        {
+            for ( size_t j=0; j < entry->get_comment_before().size(); ++j )
+                lines.push_back( entry->get_comment_before()[j] );
 
-        string line = entry->format();
+            string line = entry->format();
 
-        if ( ! entry->get_line_comment().empty() )
-            line += " " + entry->get_line_comment();
+            if ( ! entry->get_line_comment().empty() )
+                line += " " + entry->get_line_comment();
 
-        lines.push_back( line );
+            lines.push_back( line );
+        }
     }
 
     for ( size_t i=0; i < footer_comments.size(); ++i )

--- a/storage/Utils/CommentedConfigFile.h
+++ b/storage/Utils/CommentedConfigFile.h
@@ -135,6 +135,19 @@ public:
 	 **/
 	virtual string format() { return content; }
 
+        /**
+         * Validate this entry just prior to formatting/writing it back to
+         * file: Return 'true' if okay, 'false' if not.
+         *
+         * If this returns 'false', the entry is not formatted/written -
+         * neither the entry itself nor the comments that belong to it. Error
+         * handling such as logging an error or whatever is this function's
+         * responsibility.
+         *
+         * This default implementation always returns 'true'.
+         **/
+        virtual bool validate() { return true; }
+
 	/**
 	 * Parse a content line. Return 'true' on success, 'false' on error.
          * 'line_no' (if >0) is the line number in the current file. This can


### PR DESCRIPTION
This is the low-level fix to avoid writing /etc/fstab entries if vital things are missing. In this implementation, the offending entries are just not written to /etc/fstab, and an error is logged instead.