### PR TITLE
Removed unit tests that clash with new glibc number formatting

### DIFF
--- a/testsuite/Utils/humanstring.cc
+++ b/testsuite/Utils/humanstring.cc
@@ -78,7 +78,6 @@ BOOST_AUTO_TEST_CASE(test_byte_to_humanstring)
     BOOST_CHECK_EQUAL(test("en_GB.UTF-8", 1000*1024, false, 2, false), "1,000.00 KiB");
     BOOST_CHECK_EQUAL(test("de_DE.UTF-8", 1000*1024, false, 2, false), "1.000,00 KiB");
     BOOST_CHECK_EQUAL(test("de_CH.UTF-8", 1000*1024, false, 2, false), "1'000.00 KiB");
-    BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", 1000*1024, false, 2, false), "1 000,00 Kio");
 
     BOOST_CHECK_EQUAL(test("en_GB.UTF-8", 50 * MiB, false, 2, false), "50.00 MiB");
     BOOST_CHECK_EQUAL(test("de_DE.UTF-8", 50 * MiB, false, 2, false), "50,00 MiB");
@@ -114,17 +113,14 @@ BOOST_AUTO_TEST_CASE(test_humanstring_to_byte)
     BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "123,456 kB", false), 126418944);
     BOOST_CHECK_EQUAL(test("de_DE.UTF-8", "123.456 kB", false), 126418944);
     BOOST_CHECK_EQUAL(test("de_CH.UTF-8", "123'456 kB", false), 126418944);
-    BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", "123 456 ko", false), 126418944);
 
     BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "123,456.789kB", false), 126419752);
     BOOST_CHECK_EQUAL(test("de_DE.UTF-8", "123.456,789kB", false), 126419752);
     BOOST_CHECK_EQUAL(test("de_CH.UTF-8", "123'456.789kB", false), 126419752);
-    BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", "123 456,789ko", false), 126419752);
 
     BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "123,456.789 kB", false), 126419752);
     BOOST_CHECK_EQUAL(test("de_DE.UTF-8", "123.456,789 kB", false), 126419752);
     BOOST_CHECK_EQUAL(test("de_CH.UTF-8", "123'456.789 kB", false), 126419752);
-    BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", "123 456,789 ko", false), 126419752);
 
     BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", "5Go", false), 5368709120);
     BOOST_CHECK_EQUAL(test("fr_FR.UTF-8", "5 Go", false), 5368709120);
@@ -132,7 +128,6 @@ BOOST_AUTO_TEST_CASE(test_humanstring_to_byte)
     BOOST_CHECK_THROW(test("en_US.UTF-8", "5 G B", false), ParseException);
     BOOST_CHECK_THROW(test("de_DE.UTF-8", "12.34 kB", false), ParseException);
     BOOST_CHECK_THROW(test("de_DE.UTF-8", "12'34 kB", false), ParseException);
-    BOOST_CHECK_THROW(test("fr_FR.UTF-8", "12 34 Go", false), ParseException);
 
     BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "3.14 G", false), 3371549327);
     BOOST_CHECK_EQUAL(test("en_GB.UTF-8", "3.14 GB", false), 3371549327);


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1079855

Glibc now uses a narrow non-breakable space character (`U+202F`) as a thousands separator in certain locales. This makes some unit tests we did in the libstorage-ng  `humanstring()` function dependent on the version of glibc that it is linked against, and, worse, it's not even well-defined how to get that non-ASCII character properly to the compiler and through the unit test framework we use.

We decided to just drop those few unit tests for now. The important thing about testing that function is to check for proper use of Byte/kB/MB/GB etc. for most locales and Octet/kO/MO/GO etc. in French. We need to be able to trust glibc to format numbers correctly in general; all we add is the unit suffix.