### PR TITLE
- use system devicegraph during probe

### DIFF
--- a/storage/Devices/BlkDeviceImpl.cc
+++ b/storage/Devices/BlkDeviceImpl.cc
@@ -254,7 +254,7 @@ namespace storage
     BlkDevice::Impl::exists_by_any_name(const Devicegraph* devicegraph, const string& name,
 					SystemInfo& system_info)
     {
-	if (!devicegraph->get_impl().is_probed())
+	if (!devicegraph->get_impl().is_system() && !devicegraph->get_impl().is_probed())
 	    ST_THROW(Exception("function called on wrong devicegraph"));
 
 	for (Devicegraph::Impl::vertex_descriptor vertex : devicegraph->get_impl().vertices())
@@ -287,7 +287,7 @@ namespace storage
     BlkDevice::Impl::find_by_any_name(Devicegraph* devicegraph, const string& name,
 				      SystemInfo& system_info)
     {
-	if (!devicegraph->get_impl().is_probed())
+	if (!devicegraph->get_impl().is_system() && !devicegraph->get_impl().is_probed())
 	    ST_THROW(Exception("function called on wrong devicegraph"));
 
 	for (Devicegraph::Impl::vertex_descriptor vertex : devicegraph->get_impl().vertices())
@@ -320,7 +320,7 @@ namespace storage
     BlkDevice::Impl::find_by_any_name(const Devicegraph* devicegraph, const string& name,
 				      SystemInfo& system_info)
     {
-	if (!devicegraph->get_impl().is_probed())
+	if (!devicegraph->get_impl().is_system() && !devicegraph->get_impl().is_probed())
 	    ST_THROW(Exception("function called on wrong devicegraph"));
 
 	for (Devicegraph::Impl::vertex_descriptor vertex : devicegraph->get_impl().vertices())

--- a/storage/Devices/LvmLvImpl.cc
+++ b/storage/Devices/LvmLvImpl.cc
@@ -560,13 +560,13 @@ namespace storage
 
 	    case LvType::THIN_POOL:
 	    {
-		if (exists_in_probed())
+		if (exists_in_system())
 		{
 		    // Shrinking thin pools is not supported by LVM. Since the
 		    // metadata is already on disk and does not get resized no
 		    // need to handle them here.
 
-		    const LvmLv* tmp_lvm_lv = to_lvm_lv(redirect_to_probed(get_non_impl()));
+		    const LvmLv* tmp_lvm_lv = to_lvm_lv(redirect_to_system(get_non_impl()));
 
 		    unsigned long long data_size = (lvm_vg->get_impl().number_of_free_extents() +
 						    number_of_extents()) * extent_size;

--- a/storage/Devices/LvmPvImpl.cc
+++ b/storage/Devices/LvmPvImpl.cc
@@ -173,7 +173,7 @@ namespace storage
 	// Currently we only support growing if the physical volume is already
 	// on disk - shrinking is more complicated.
 
-	if (exists_in_probed())
+	if (exists_in_system())
 	{
 	    resize_info.min_size = get_blk_device()->get_size();
 	}

--- a/storage/Devices/LvmVgImpl.cc
+++ b/storage/Devices/LvmVgImpl.cc
@@ -177,7 +177,7 @@ namespace storage
 	    // metadata size. For thin pools that do exist in probed the
 	    // metadata size is included in reserved_extents.
 
-	    if (lvm_lv->get_lv_type() == LvType::THIN_POOL && !lvm_lv->exists_in_probed())
+	    if (lvm_lv->get_lv_type() == LvType::THIN_POOL && !lvm_lv->exists_in_system())
 	    {
 		unsigned long long metadata_size = lvm_lv->get_impl().default_metadata_size();
 		unsigned long long metadata_extents = metadata_size / extent_size;

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -677,7 +677,7 @@ namespace storage
 	// action to be generated. Operations changing the RAID size are not
 	// supported.
 
-	if (exists_in_probed())
+	if (exists_in_system())
 	    return;
 
 	vector<BlkDevice*> devices = get_devices();

--- a/storage/Devices/PartitionTableImpl.cc
+++ b/storage/Devices/PartitionTableImpl.cc
@@ -159,7 +159,7 @@ namespace storage
 		unsigned int number = tmp->get_number();
 
 		if ((type == PartitionType::PRIMARY || type == PartitionType::EXTENDED) &&
-		    number > old_number && !tmp->exists_in_probed())
+		    number > old_number && !tmp->exists_in_system())
 		{
 		    tmp->get_impl().set_number(old_number);
 		    old_number = number;

--- a/storage/EtcMdadm.cc
+++ b/storage/EtcMdadm.cc
@@ -214,7 +214,7 @@ namespace storage
     bool
     EtcMdadm::has_iscsi(const Storage* storage) const
     {
-	for (const Disk* disk : Disk::get_all(storage->get_probed()))
+	for (const Disk* disk : Disk::get_all(storage->get_system()))
 	{
 	    if (disk->get_transport() == Transport::ISCSI)
 		return true;

--- a/storage/Filesystems/BlkFilesystemImpl.cc
+++ b/storage/Filesystems/BlkFilesystemImpl.cc
@@ -210,14 +210,14 @@ namespace storage
 	 * reporting min and max size would be nice (LOL).
 	 */
 
-	if (!exists_in_probed())
+	if (!exists_in_system())
 	{
 	    return ResizeInfo(true, min_size(), max_size());
 	}
 
 	if (!resize_info.has_value())
 	{
-	    const BlkFilesystem* tmp_blk_filesystem = redirect_to_probed(get_non_impl());
+	    const BlkFilesystem* tmp_blk_filesystem = redirect_to_system(get_non_impl());
 
 	    ResizeInfo tmp_resize_info = tmp_blk_filesystem->get_impl().detect_resize_info_on_disk();
 
@@ -235,7 +235,7 @@ namespace storage
     {
 	// TODO only in real probe mode allowed
 
-	if (!get_devicegraph()->get_impl().is_probed())
+	if (!get_devicegraph()->get_impl().is_system() && !get_devicegraph()->get_impl().is_probed())
 	    ST_THROW(Exception("function called on wrong device"));
 
 	ResizeInfo resize_info(true, min_size(), max_size());

--- a/storage/Filesystems/BtrfsImpl.cc
+++ b/storage/Filesystems/BtrfsImpl.cc
@@ -325,7 +325,7 @@ namespace storage
     ResizeInfo
     Btrfs::Impl::detect_resize_info_on_disk() const
     {
-	if (!get_devicegraph()->get_impl().is_probed())
+	if (!get_devicegraph()->get_impl().is_system() && !get_devicegraph()->get_impl().is_probed())
 	    ST_THROW(Exception("function called on wrong device"));
 
 	// TODO btrfs provides a command to query the min size (btrfs

--- a/storage/Filesystems/NtfsImpl.cc
+++ b/storage/Filesystems/NtfsImpl.cc
@@ -60,7 +60,7 @@ namespace storage
     ResizeInfo
     Ntfs::Impl::detect_resize_info_on_disk() const
     {
-	if (!get_devicegraph()->get_impl().is_probed())
+	if (!get_devicegraph()->get_impl().is_system() && !get_devicegraph()->get_impl().is_probed())
 	    ST_THROW(Exception("function called on wrong device"));
 
 	const BlkDevice* blk_device = get_blk_device();

--- a/storage/Redirect.h
+++ b/storage/Redirect.h
@@ -58,18 +58,6 @@ namespace storage
 
 
     /**
-     * Finds the device corresponding to original in the probed devicegraph.
-     */
-    template<class Type>
-    const Type*
-    redirect_to_probed(const Type* original)
-    {
-	const Devicegraph* probed = original->get_impl().get_storage()->get_probed();
-	return redirect_to<Type>(probed, original);
-    }
-
-
-    /**
      * Finds the device corresponding to original in the system devicegraph.
      */
     template<class Type>

--- a/storage/StorageImpl.cc
+++ b/storage/StorageImpl.cc
@@ -156,7 +156,15 @@ namespace storage
 	remove_devicegraph("staging");
 	remove_devicegraph("system");
 
-	Devicegraph* probed = create_devicegraph("probed");
+	// The system devicegraph is created and used for probing since it is
+	// needed in EnsureMounted.
+
+	// TODO The change from using probed to using system should be
+	// reflected at many places, e.g. variable names and file
+	// names. Ideally probed should just be a read-only copy of system not
+	// further used in the library. Or find a better solution.
+
+	Devicegraph* probed = create_devicegraph("system");
 
 	switch (environment.get_probe_mode())
 	{
@@ -196,8 +204,8 @@ namespace storage
 	y2mil(*probed);
 	y2mil("probed devicegraph end");
 
-	copy_devicegraph("probed", "staging");
-	copy_devicegraph("probed", "system");
+	copy_devicegraph("system", "staging");
+	copy_devicegraph("system", "probed");
     }
 
 

--- a/testsuite/freeinfo/lvm1.cc
+++ b/testsuite/freeinfo/lvm1.cc
@@ -90,8 +90,8 @@ BOOST_AUTO_TEST_CASE(test2)
 
     lvm_vg->get_impl().set_reserved_extents(2);
 
-    storage.remove_devicegraph("probed");
-    storage.copy_devicegraph("staging", "probed");
+    storage.remove_devicegraph("system");
+    storage.copy_devicegraph("staging", "system");
 
     {
 	ResizeInfo resize_info = normal->detect_resize_info();

--- a/testsuite/freeinfo/test4.cc
+++ b/testsuite/freeinfo/test4.cc
@@ -47,8 +47,8 @@ BOOST_AUTO_TEST_CASE(test_msdos)
     Partition* sda3 = msdos->create_partition("/dev/sda3", Region(80 * spg, 40 * spg, 512), PartitionType::PRIMARY);
     sda3->create_blk_filesystem(FsType::SWAP);
 
-    storage.remove_devicegraph("probed");
-    storage.copy_devicegraph("staging", "probed");
+    storage.remove_devicegraph("system");
+    storage.copy_devicegraph("staging", "system");
 
     {
 	ResizeInfo resize_info = sda1->detect_resize_info();

--- a/testsuite/partitions/gpt-delete1.cc
+++ b/testsuite/partitions/gpt-delete1.cc
@@ -35,8 +35,8 @@ BOOST_AUTO_TEST_CASE(test_delete)
 
     gpt->create_partition("/dev/sda2", Region(2099200, 2097152, 512), PartitionType::PRIMARY);
 
-    storage.remove_devicegraph("probed");
-    storage.copy_devicegraph("staging", "probed");
+    storage.remove_devicegraph("system");
+    storage.copy_devicegraph("staging", "system");
 
     staging = storage.get_staging();
     sda = Disk::find_by_name(staging, "/dev/sda");


### PR DESCRIPTION
For https://trello.com/c/s3Q03YDp/53-5-libstorage-ng-resizing-add-mount-handling. Fixes a regression caused by https://github.com/openSUSE/libstorage-ng/commit/698e409053c94c8017984f74fa528930874a5c20.