### PR TITLE
- always allow to activate multipath (see bsc#1082542)

### DIFF
--- a/integration-tests/misc/activate.py
+++ b/integration-tests/misc/activate.py
@@ -15,9 +15,9 @@ class MyActivateCallbacks(ActivateCallbacks):
     def __init__(self):
         super(MyActivateCallbacks, self).__init__()
 
-    def multipath(self):
+    def multipath(self, looks_like_real_multipath):
         print("multipath callback")
-        return True
+        return looks_like_real_multipath
 
     def luks(self, uuid, attempt):
         print("luks callback uuid:%s attempt:%d" % (uuid, attempt))

--- a/storage/Devices/MultipathImpl.cc
+++ b/storage/Devices/MultipathImpl.cc
@@ -108,13 +108,9 @@ namespace storage
 
 	try
 	{
-	    if (!CmdMultipath(true).looks_like_real_multipath())
-	    {
-		y2mil("does not look like real multipath");
-		return false;
-	    }
+	    bool looks_like_real_multipath = CmdMultipath(true).looks_like_real_multipath();
 
-	    if (!activate_callbacks->multipath())
+	    if (!activate_callbacks->multipath(looks_like_real_multipath))
 	    {
 		y2mil("user canceled activation of multipath");
 		return false;

--- a/storage/Storage.h
+++ b/storage/Storage.h
@@ -91,8 +91,16 @@ namespace storage
 
 	virtual ~ActivateCallbacks() {}
 
-	virtual bool multipath() const = 0;
+	/**
+	 * Decide whether multipath should be activated.
+	 *
+	 * The looks_like_real_multipath paramter is not reliable.
+	 */
+	virtual bool multipath(bool looks_like_real_multipath) const = 0;
 
+	/**
+	 * Decide whether the LUKS with uuid should be activated.
+	 */
 	virtual std::pair<bool, std::string> luks(const std::string& uuid, int attempt) const = 0;
 
     };


### PR DESCRIPTION
Requires small adjustments in yast2-storage-ng and yast2-autoinstallation.