### PR TITLE
- added functions to copy devices and holders between devicegraphs

### DIFF
--- a/bindings/storage-catches.i
+++ b/bindings/storage-catches.i
@@ -150,6 +150,7 @@
 %catches(storage::DeviceNotFound, storage::DeviceHasWrongType) storage::Dasd::find_by_name(Devicegraph *devicegraph, const std::string &name);
 %catches(storage::DeviceNotFound, storage::DeviceHasWrongType) storage::Dasd::find_by_name(const Devicegraph *devicegraph, const std::string &name);
 %catches(storage::Exception) storage::Device::compare_by_name(const Device *lhs, const Device *rhs);
+%catches(storage::Exception) storage::Device::copy_to_devicegraph(Devicegraph *devicegraph) const;
 %catches(storage::Exception) storage::Device::detect_resize_info() const;
 %catches(storage::Exception) storage::Devicegraph::check(const CheckCallbacks *check_callbacks=nullptr) const;
 %catches(storage::DeviceNotFoundBySid) storage::Devicegraph::find_device(sid_t sid);
@@ -165,6 +166,7 @@
 %catches(storage::DeviceNotFound, storage::DeviceHasWrongType) storage::DmRaid::find_by_name(Devicegraph *devicegraph, const std::string &name);
 %catches(storage::DeviceNotFound, storage::DeviceHasWrongType) storage::DmRaid::find_by_name(const Devicegraph *devicegraph, const std::string &name);
 %catches(storage::Exception) storage::Filesystem::detect_space_info() const;
+%catches(storage::Exception) storage::Holder::copy_to_devicegraph(Devicegraph *devicegraph) const;
 %catches(storage::Exception) storage::ImplicitPt::create_implicit_partition();
 %catches(storage::Exception) storage::LvmLv::create_lvm_lv(const std::string &lv_name, LvType lv_type, unsigned long long size);
 %catches(storage::Exception) storage::LvmLv::get_lvm_lv(const std::string &lv_name);

--- a/storage/Devices/Device.cc
+++ b/storage/Devices/Device.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) [2016-2017] SUSE LLC
+ * Copyright (c) [2016-2018] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -70,6 +70,13 @@ namespace storage
     Device::operator!=(const Device& rhs) const
     {
 	return get_impl().operator!=(rhs.get_impl());
+    }
+
+
+    Device*
+    Device::copy_to_devicegraph(Devicegraph* devicegraph) const
+    {
+	return get_impl().copy_to_devicegraph(devicegraph);
     }
 
 

--- a/storage/Devices/Device.h
+++ b/storage/Devices/Device.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) [2016-2017] SUSE LLC
+ * Copyright (c) [2016-2018] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -83,6 +83,20 @@ namespace storage
 
 	bool operator==(const Device& rhs) const;
 	bool operator!=(const Device& rhs) const;
+
+	/**
+	 * Copies the device to the devicegraph. Does not copy holders. The
+	 * purpose of the function is to restore parts of the probed
+	 * devicegraph in the staging devicegraph that were previously
+	 * deleted.
+	 *
+	 * Device must not exist in devicegraph.
+	 *
+	 * @see Holder::copy_to_devicegraph()
+	 *
+	 * @throw Exception
+	 */
+	Device* copy_to_devicegraph(Devicegraph* devicegraph) const;
 
 	/**
 	 * Checks if the device exists in the devicegraph.

--- a/storage/Devices/DeviceImpl.cc
+++ b/storage/Devices/DeviceImpl.cc
@@ -66,6 +66,21 @@ namespace storage
     }
 
 
+    Device*
+    Device::Impl::copy_to_devicegraph(Devicegraph* devicegraph) const
+    {
+	if (exists_in_devicegraph(devicegraph))
+	    ST_THROW(Exception("device already exists"));
+
+	Device* device = get_non_impl()->clone();
+
+	Devicegraph::Impl::vertex_descriptor vertex = devicegraph->get_impl().add_vertex(device);
+	device->get_impl().set_devicegraph_and_vertex(devicegraph, vertex);
+
+	return device;
+    }
+
+
     bool
     Device::Impl::exists_in_devicegraph(const Devicegraph* devicegraph) const
     {

--- a/storage/Devices/DeviceImpl.h
+++ b/storage/Devices/DeviceImpl.h
@@ -102,6 +102,8 @@ namespace storage
 	bool operator==(const Impl& rhs) const;
 	bool operator!=(const Impl& rhs) const { return !(*this == rhs); }
 
+	Device* copy_to_devicegraph(Devicegraph* dest) const;
+
 	bool exists_in_devicegraph(const Devicegraph* devicegraph) const;
 	bool exists_in_probed() const;
 	bool exists_in_staging() const;

--- a/storage/Holders/Holder.cc
+++ b/storage/Holders/Holder.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) [2016-2017] SUSE LLC
+ * Copyright (c) [2016-2018] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -60,6 +60,13 @@ namespace storage
     Holder::operator!=(const Holder& rhs) const
     {
 	return get_impl().operator!=(rhs.get_impl());
+    }
+
+
+    Holder*
+    Holder::copy_to_devicegraph(Devicegraph* devicegraph) const
+    {
+	return get_impl().copy_to_devicegraph(devicegraph);
     }
 
 

--- a/storage/Holders/Holder.h
+++ b/storage/Holders/Holder.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) [2017-2018] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -66,6 +66,21 @@ namespace storage
 
 	bool operator==(const Holder& rhs) const;
 	bool operator!=(const Holder& rhs) const;
+
+	/**
+	 * Copies the holder to the devicegraph. Does not copy devices. The
+	 * purpose of the function is to restore parts of the probed
+	 * devicegraph in the staging devicegraph that were previously
+	 * deleted.
+	 *
+	 * Source and target devices must already exist in devicegraph. Holder
+	 * must not exist in devicegraph.
+	 *
+	 * @see Device::copy_to_devicegraph()
+	 *
+	 * @throw Exception
+	 */
+	Holder* copy_to_devicegraph(Devicegraph* devicegraph) const;
 
     public:
 

--- a/storage/Holders/HolderImpl.cc
+++ b/storage/Holders/HolderImpl.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) [2016-2017] SUSE LLC
+ * Copyright (c) [2016-2018] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -48,6 +48,33 @@ namespace storage
 	    return false;
 
 	return equal(rhs);
+    }
+
+
+    Holder*
+    Holder::Impl::copy_to_devicegraph(Devicegraph* devicegraph) const
+    {
+	sid_t source_sid = get_source_sid();
+	sid_t target_sid = get_target_sid();
+
+	if (!devicegraph->device_exists(source_sid))
+	    ST_THROW(Exception("source device does not exist"));
+
+	if (!devicegraph->device_exists(target_sid))
+	    ST_THROW(Exception("target device does not exist"));
+
+	if (devicegraph->holder_exists(source_sid, target_sid))
+	    ST_THROW(Exception("holder already exists"));
+
+	Devicegraph::Impl::vertex_descriptor source = devicegraph->get_impl().find_vertex(source_sid);
+	Devicegraph::Impl::vertex_descriptor target = devicegraph->get_impl().find_vertex(target_sid);
+
+	Holder* holder = get_non_impl()->clone();
+
+	Devicegraph::Impl::edge_descriptor edge = devicegraph->get_impl().add_edge(source, target, holder);
+	holder->get_impl().set_devicegraph_and_edge(devicegraph, edge);
+
+	return holder;
     }
 
 

--- a/storage/Holders/HolderImpl.h
+++ b/storage/Holders/HolderImpl.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2014-2015] Novell, Inc.
- * Copyright (c) [2016-2017] SUSE LLC
+ * Copyright (c) [2016-2018] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -50,6 +50,8 @@ namespace storage
 	bool operator==(const Impl& rhs) const;
 	bool operator!=(const Impl& rhs) const { return !(*this == rhs); }
 
+	Holder* copy_to_devicegraph(Devicegraph* dest) const;
+
 	virtual Impl* clone() const = 0;
 
 	virtual const char* get_classname() const = 0;
@@ -65,6 +67,9 @@ namespace storage
 	const Devicegraph* get_devicegraph() const { return devicegraph; }
 
 	Devicegraph::Impl::edge_descriptor get_edge() const { return edge; }
+
+	virtual Holder* get_non_impl() { return devicegraph->get_impl()[edge]; }
+	virtual const Holder* get_non_impl() const { return devicegraph->get_impl()[edge]; }
 
 	Device* get_source();
 	const Device* get_source() const;

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -15,7 +15,8 @@ check_PROGRAMS =								\
 	dynamic.test environment.test find-vertex.test fstab.test crypttab.test \
 	output.test probe.test range.test stable.test relatives.test 		\
 	mount-opts.test etc-mdadm.test mount-by.test btrfs.test md1.test	\
-	md2.test md3.test md4.test encryption1.test lvm1.test graphviz.test
+	md2.test md3.test md4.test encryption1.test lvm1.test graphviz.test	\
+	copy-individual.test
 
 AM_DEFAULT_SOURCE_EXT = .cc
 

--- a/testsuite/copy-individual.cc
+++ b/testsuite/copy-individual.cc
@@ -1,0 +1,47 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE libstorage
+
+#include <boost/test/unit_test.hpp>
+
+#include "storage/Devices/Disk.h"
+#include "storage/Devices/Gpt.h"
+#include "storage/Holders/User.h"
+#include "storage/Environment.h"
+#include "storage/Storage.h"
+#include "storage/Devicegraph.h"
+
+
+using namespace storage;
+
+
+BOOST_AUTO_TEST_CASE(copy_individual)
+{
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+
+    Storage storage(environment);
+
+    Devicegraph* a = storage.create_devicegraph("a");
+
+    Disk* sda = Disk::create(a, "/dev/sda");
+    Gpt* gpt = to_gpt(sda->create_partition_table(PtType::GPT));
+
+    User* user = to_user(a->find_holder(sda->get_sid(), gpt->get_sid()));
+
+    BOOST_CHECK_EQUAL(a->num_devices(), 2);
+    BOOST_CHECK_EQUAL(a->num_holders(), 1);
+
+    Devicegraph* b = storage.create_devicegraph("b");
+
+    sda->copy_to_devicegraph(b);
+    gpt->copy_to_devicegraph(b);
+
+    user->copy_to_devicegraph(b);
+
+    BOOST_CHECK_EQUAL(b->num_devices(), 2);
+    BOOST_CHECK_EQUAL(b->num_holders(), 1);
+
+    BOOST_CHECK(storage.equal_devicegraph("a", "b"));
+
+    storage.check();
+}


### PR DESCRIPTION
For https://trello.com/c/DIOx0i1I/176-partitioner-prevent-data-loss-by-honoring-previous-state-when-editing,