### PR TITLE
Enable Region#end exception

### DIFF
--- a/storage/Utils/RegionImpl.cc
+++ b/storage/Utils/RegionImpl.cc
@@ -71,10 +71,8 @@ namespace storage
     unsigned long long
     Region::Impl::get_end() const
     {
-#if 0
 	if (empty())
 	    ST_THROW(Exception("empty region"));
-#endif
 
 	return start + length - 1;
     }


### PR DESCRIPTION
Part of PBI: https://trello.com/c/jPe9PnBi/308-3-sles15-p1-1083887-zero-size-disks-not-able-to-find-the-scsi-disks-while-trying-to-install-sles-15-on-vmax-luns