### PR TITLE
Simplified supplements for lang subpkg (bsc#1081454)

### DIFF
--- a/libstorage-ng.spec.in
+++ b/libstorage-ng.spec.in
@@ -61,7 +61,7 @@ This package contains libstorage-ng, a library for storage management.
 %package lang
 Summary:        Languages for package %{name}
 Group:          System/Localization
-Supplements:    packageand(bundle-lang-other:%{name})
+Supplements:    %{name}
 Provides:       %{name}-lang-all = %{version}
 BuildArch:      noarch
 


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1081454

Keep it simple: Use a very plain "supplements" to get the lang subpackage installed by default (the user can still choose to not install it without getting a dependency conflict).

