### PR TITLE
- handle pid_t in bindings

### DIFF
--- a/bindings/storage.i
+++ b/bindings/storage.i
@@ -12,6 +12,8 @@
 %rename("==") "operator==";
 %rename("!=") "operator!=";
 
+%typedef int pid_t;
+
 use_ostream(storage::Devicegraph);
 use_ostream(storage::Device);
 use_ostream(storage::Holder);

--- a/integration-tests/misc/probe.py
+++ b/integration-tests/misc/probe.py
@@ -28,9 +28,14 @@ set_logger(get_logfile_logger())
 
 my_probe_callbacks = MyProbeCallbacks()
 
-environment = Environment(False)
+environment = Environment(True)
 
-storage = Storage(environment)
+try:
+    storage = Storage(environment)
+except LockException as exception:
+    print(exception.what())
+    print("locker pid %d" % exception.get_locker_pid())
+    exit(1)
 
 try:
     storage.probe(my_probe_callbacks)


### PR DESCRIPTION
For https://trello.com/c/jItiacnG/335-readd-system-wide-lock-in-libstorage-ng.