### PR TITLE
Add MountPoint#mount_type to XML format (follow up on bsc#1088426)

### DIFF
--- a/storage/Filesystems/MountPointImpl.cc
+++ b/storage/Filesystems/MountPointImpl.cc
@@ -73,6 +73,11 @@ namespace storage
 	if (getChildValue(node, "mount-options", tmp))
 	    mount_options.parse(tmp);
 
+	if (getChildValue(node, "mount-type", tmp))
+	    mount_type = toValueWithFallback(tmp, FsType::UNKNOWN);
+	else
+	    mount_type = FsType::UNKNOWN;
+
 	getChildValue(node, "active", active);
 	getChildValue(node, "in-etc-fstab", in_etc_fstab);
 
@@ -101,6 +106,7 @@ namespace storage
 	if (!mount_options.empty())
 	    setChildValue(node, "mount-options", mount_options.format());
 
+	setChildValue(node, "mount-type", toString(mount_type));
 	setChildValue(node, "active", active);
 	setChildValue(node, "in-etc-fstab", in_etc_fstab);
 


### PR DESCRIPTION
Related to #510 (in the scope of https://trello.com/c/kXnNLZPd/244-5-nfsv4x-support). That pull request added the field in the class. This makes it available in the XML format.