### PR TITLE
- keep exception type (bsc#1088570)

### DIFF
--- a/storage/SystemInfo/SystemInfo.h
+++ b/storage/SystemInfo/SystemInfo.h
@@ -142,7 +142,7 @@ namespace storage
 		    }
 		    catch (const std::exception& e)
 		    {
-			ep = std::make_exception_ptr(e);
+			ep = std::current_exception();
 			std::rethrow_exception(ep);
 		    }
 		}


### PR DESCRIPTION
For https://trello.com/c/BY8D3eLT/354-sles15-p1-1088570-build-5502-openqa-test-fails-in-yast2bootloader-sbin-yast2-report-core-dump.