### PR TITLE
Use stricter NTFS max label size (bsc#1084867)

### DIFF
--- a/storage/Filesystems/NtfsImpl.h
+++ b/storage/Filesystems/NtfsImpl.h
@@ -54,7 +54,7 @@ namespace storage
 	virtual bool supports_unmounted_grow() const override { return true; }
 
 	virtual bool supports_label() const override { return true; }
-	virtual unsigned int max_labelsize() const override { return 128; }
+	virtual unsigned int max_labelsize() const override { return 32; }
 
 	virtual bool supports_uuid() const override { return true; }
 


### PR DESCRIPTION
This is for https://trello.com/c/pVvQMTRq/313-2-sles15-p3-1084867-installer-does-not-handle-xfs-label-length-limitations

to fix https://bugzilla.suse.com/show_bug.cgi?id=1084867 and possibly others that might be upcoming

`man ntfslabel` says max label size is 128 for NTFS, but all other sources I found say it's just 32:

- https://www.lifewire.com/volume-label-2626045 (found by locilka)
- https://en.wikipedia.org/wiki/Volume_(computing)#Volume_label
- https://stackoverflow.com/questions/3704109/what-is-the-maximum-length-of-a-windows-xp-drive-label