### PR TITLE
Use proper exception

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -6,7 +6,7 @@
 .PHONY: package
 package: obs-package-from-git
 	./$^ \
-		-P YaST:storage-ng -p libstorage-ng \
+		-P YaST:Head -p libstorage-ng \
 		-o .obsdir \
 		-c 'make -f Makefile.repo && make package'
 

--- a/storage/Devices/BlkDeviceImpl.cc
+++ b/storage/Devices/BlkDeviceImpl.cc
@@ -307,26 +307,33 @@ namespace storage
 	if (!devicegraph->get_impl().is_system() && !devicegraph->get_impl().is_probed())
 	    ST_THROW(Exception("function called on wrong devicegraph"));
 
-	for (Devicegraph::Impl::vertex_descriptor vertex : devicegraph->get_impl().vertices())
+	try
 	{
-	    BlkDevice* blk_device = dynamic_cast<BlkDevice*>(devicegraph->get_impl()[vertex]);
-	    if (blk_device)
+	    for (Devicegraph::Impl::vertex_descriptor vertex : devicegraph->get_impl().vertices())
 	    {
-		if (blk_device->get_name() == name)
-		    return blk_device;
+		BlkDevice* blk_device = dynamic_cast<BlkDevice*>(devicegraph->get_impl()[vertex]);
+		if (blk_device)
+		{
+		    if (blk_device->get_name() == name)
+			return blk_device;
+		}
+	    }
+
+	    dev_t majorminor = system_info.getCmdUdevadmInfo(name).get_majorminor();
+
+	    for (Devicegraph::Impl::vertex_descriptor vertex : devicegraph->get_impl().vertices())
+	    {
+		BlkDevice* blk_device = dynamic_cast<BlkDevice*>(devicegraph->get_impl()[vertex]);
+		if (blk_device && blk_device->get_impl().active)
+		{
+		    if (system_info.getCmdUdevadmInfo(blk_device->get_name()).get_majorminor() == majorminor)
+			return blk_device;
+		}
 	    }
 	}
-
-	dev_t majorminor = system_info.getCmdUdevadmInfo(name).get_majorminor();
-
-	for (Devicegraph::Impl::vertex_descriptor vertex : devicegraph->get_impl().vertices())
+	catch (const Exception& exception)
 	{
-	    BlkDevice* blk_device = dynamic_cast<BlkDevice*>(devicegraph->get_impl()[vertex]);
-	    if (blk_device && blk_device->get_impl().active)
-	    {
-		if (system_info.getCmdUdevadmInfo(blk_device->get_name()).get_majorminor() == majorminor)
-		    return blk_device;
-	    }
+	    ST_THROW(DeviceNotFoundByName(name));
 	}
 
 	ST_THROW(DeviceNotFoundByName(name));
@@ -340,26 +347,33 @@ namespace storage
 	if (!devicegraph->get_impl().is_system() && !devicegraph->get_impl().is_probed())
 	    ST_THROW(Exception("function called on wrong devicegraph"));
 
-	for (Devicegraph::Impl::vertex_descriptor vertex : devicegraph->get_impl().vertices())
+	try
 	{
-	    const BlkDevice* blk_device = dynamic_cast<const BlkDevice*>(devicegraph->get_impl()[vertex]);
-	    if (blk_device)
+	    for (Devicegraph::Impl::vertex_descriptor vertex : devicegraph->get_impl().vertices())
 	    {
-		if (blk_device->get_name() == name)
-		    return blk_device;
+		const BlkDevice* blk_device = dynamic_cast<const BlkDevice*>(devicegraph->get_impl()[vertex]);
+		if (blk_device)
+		{
+		    if (blk_device->get_name() == name)
+			return blk_device;
+		}
+	    }
+
+	    dev_t majorminor = system_info.getCmdUdevadmInfo(name).get_majorminor();
+
+	    for (Devicegraph::Impl::vertex_descriptor vertex : devicegraph->get_impl().vertices())
+	    {
+		const BlkDevice* blk_device = dynamic_cast<const BlkDevice*>(devicegraph->get_impl()[vertex]);
+		if (blk_device && blk_device->get_impl().active)
+		{
+		    if (system_info.getCmdUdevadmInfo(blk_device->get_name()).get_majorminor() == majorminor)
+			return blk_device;
+		}
 	    }
 	}
-
-	dev_t majorminor = system_info.getCmdUdevadmInfo(name).get_majorminor();
-
-	for (Devicegraph::Impl::vertex_descriptor vertex : devicegraph->get_impl().vertices())
+	catch (const Exception& exception)
 	{
-	    const BlkDevice* blk_device = dynamic_cast<const BlkDevice*>(devicegraph->get_impl()[vertex]);
-	    if (blk_device && blk_device->get_impl().active)
-	    {
-		if (system_info.getCmdUdevadmInfo(blk_device->get_name()).get_majorminor() == majorminor)
-		    return blk_device;
-	    }
+	    ST_THROW(DeviceNotFoundByName(name));
 	}
 
 	ST_THROW(DeviceNotFoundByName(name));


### PR DESCRIPTION
Needed for PBI: https://trello.com/c/OGssTRzO/393-osdistribution-p2p1-1094963-opensuse-150-installation-or-upgrade-fails-if-disk-contains-encrypted-partition-luks

Now, a `DeviceNotFoundByName` is raised when `BlkDevice#find_by_any_name` fails. General `Exception` could still be raised when a wrong devicegraph is used.