### PR TITLE
Support to fix bug#1094157 and bug#1094963

### DIFF
--- a/storage/Devices/BlkDeviceImpl.h
+++ b/storage/Devices/BlkDeviceImpl.h
@@ -98,7 +98,7 @@ namespace storage
 	string get_mount_by_name(MountByType mount_by_type) const;
 
 	const string& get_dm_table_name() const { return dm_table_name; }
-	void set_dm_table_name(const string& dm_table_name) { Impl::dm_table_name = dm_table_name; }
+	virtual void set_dm_table_name(const string& dm_table_name) { Impl::dm_table_name = dm_table_name; }
 
 	BlkFilesystem* create_blk_filesystem(FsType fs_type);
 

--- a/storage/Devices/Device.cc
+++ b/storage/Devices/Device.cc
@@ -418,4 +418,18 @@ namespace storage
 	return out;
     }
 
+
+    Devicegraph*
+    Device::get_devicegraph()
+    {
+	return get_impl().get_devicegraph();
+    }
+
+
+    const Devicegraph*
+    Device::get_devicegraph() const
+    {
+	return get_impl().get_devicegraph();
+    }
+
 }

--- a/storage/Devices/Device.h
+++ b/storage/Devices/Device.h
@@ -196,6 +196,9 @@ namespace storage
 	 */
 	static bool compare_by_name(const Device* lhs, const Device* rhs);
 
+	Devicegraph* get_devicegraph();
+	const Devicegraph* get_devicegraph() const;
+
     public:
 
 	class Impl;

--- a/storage/Devices/EncryptionImpl.cc
+++ b/storage/Devices/EncryptionImpl.cc
@@ -87,6 +87,13 @@ namespace storage
 	set_mount_by(get_storage()->get_default_mount_by());
     }
 
+    void
+    Encryption::Impl::set_dm_table_name(const string& dm_table_name)
+    {
+	BlkDevice::Impl::set_dm_table_name(dm_table_name);
+	BlkDevice::Impl::set_name(DEV_MAPPER_DIR "/" + dm_table_name);
+    }
+
 
     void
     Encryption::Impl::set_crypt_options(const CryptOpts& crypt_options)

--- a/storage/Devices/EncryptionImpl.h
+++ b/storage/Devices/EncryptionImpl.h
@@ -61,7 +61,7 @@ namespace storage
 	 * with the DeviceMapper name, since the kernel device names for
 	 * Encryption devices are inferred from their DeviceMapper names.
 	 */
-	void set_dm_table_name(const string& dm_table_name);
+	virtual void set_dm_table_name(const string& dm_table_name);
 
 	virtual EncryptionType get_type() const { return EncryptionType::UNKNOWN; }
 

--- a/storage/Devices/EncryptionImpl.h
+++ b/storage/Devices/EncryptionImpl.h
@@ -61,7 +61,7 @@ namespace storage
 	 * with the DeviceMapper name, since the kernel device names for
 	 * Encryption devices are inferred from their DeviceMapper names.
 	 */
-	virtual void set_dm_table_name(const string& dm_table_name);
+	virtual void set_dm_table_name(const string& dm_table_name) override;
 
 	virtual EncryptionType get_type() const { return EncryptionType::UNKNOWN; }
 

--- a/storage/Devices/EncryptionImpl.h
+++ b/storage/Devices/EncryptionImpl.h
@@ -56,6 +56,13 @@ namespace storage
 
 	virtual string get_displayname() const override { return get_dm_table_name(); }
 
+	/**
+	 * Redefined from BlkDeviceImpl to ensure the device name is in sync
+	 * with the DeviceMapper name, since the kernel device names for
+	 * Encryption devices are inferred from their DeviceMapper names.
+	 */
+	void set_dm_table_name(const string& dm_table_name);
+
 	virtual EncryptionType get_type() const { return EncryptionType::UNKNOWN; }
 
 	const string& get_password() const { return password; }


### PR DESCRIPTION
Both bugs are about adapting the DeviceMapper names of the encrypted devices. These changes will allow us to proceed on https://github.com/yast/yast-storage-ng/pull/660 and https://github.com/yast/yast-storage-ng/pull/659