### PR TITLE
- added special handling when creating udev ids starting with dm-uuid for partitions on multipath (bsc#1099394)

### DIFF
--- a/storage/Devices/PartitionImpl.cc
+++ b/storage/Devices/PartitionImpl.cc
@@ -21,6 +21,8 @@
  */
 
 
+#include <boost/algorithm/string.hpp>
+
 #include "storage/Utils/AppUtil.h"
 #include "storage/Utils/SystemCmd.h"
 #include "storage/Utils/StorageDefines.h"
@@ -457,16 +459,28 @@ namespace storage
     {
 	const Partitionable* partitionable = get_partitionable();
 
-	string postfix = "-part" + to_string(get_number());
+	string addition = "-part" + to_string(get_number());
 
 	vector<string> udev_paths;
 	for (const string& udev_path : partitionable->get_udev_paths())
-	    udev_paths.push_back(udev_path + postfix);
+	{
+	    udev_paths.push_back(udev_path + addition);
+	}
 	set_udev_paths(udev_paths);
 
 	vector<string> udev_ids;
 	for (const string& udev_id : partitionable->get_udev_ids())
-	    udev_ids.push_back(udev_id + postfix);
+	{
+	    // The partition link for udev id links starting with dm-uuid is
+	    // special for multipath and dmraid (see bsc #1099394). Handling
+	    // dmraid here is optional since the links are not whitelisted.
+
+	    if (boost::starts_with(udev_id, "dm-uuid-mpath") ||
+		boost::starts_with(udev_id, "dm-uuid-DMRAID"))
+		udev_ids.push_back("dm-uuid" + addition + udev_id.substr(7));
+	    else
+		udev_ids.push_back(udev_id + addition);
+	}
 	set_udev_ids(udev_ids);
     }
 

--- a/storage/Devices/PartitionImpl.cc
+++ b/storage/Devices/PartitionImpl.cc
@@ -477,7 +477,7 @@ namespace storage
 
 	    if (boost::starts_with(udev_id, "dm-uuid-mpath") ||
 		boost::starts_with(udev_id, "dm-uuid-DMRAID"))
-		udev_ids.push_back("dm-uuid" + addition + udev_id.substr(7));
+		udev_ids.push_back("dm-uuid" + addition + udev_id.substr(strlen("dm-uuid")));
 	    else
 		udev_ids.push_back(udev_id + addition);
 	}

--- a/testsuite/partitions/udev1.cc
+++ b/testsuite/partitions/udev1.cc
@@ -6,7 +6,9 @@
 #include <boost/test/unit_test.hpp>
 
 #include "storage/Devices/DiskImpl.h"
+#include "storage/Devices/MultipathImpl.h"
 #include "storage/Devices/Msdos.h"
+#include "storage/Devices/Gpt.h"
 #include "storage/Devices/Partition.h"
 #include "storage/Devicegraph.h"
 #include "storage/Storage.h"
@@ -18,7 +20,7 @@ using namespace std;
 using namespace storage;
 
 
-BOOST_AUTO_TEST_CASE(test_create)
+BOOST_AUTO_TEST_CASE(test_create1)
 {
     set_logger(get_stdout_logger());
 
@@ -48,4 +50,39 @@ BOOST_AUTO_TEST_CASE(test_create)
     BOOST_REQUIRE_EQUAL(partitions[0]->get_udev_ids().size(), 2);
     BOOST_CHECK_EQUAL(partitions[0]->get_udev_ids()[0], "ata-WDC_WD10EADS-00M2B0_WD-WCAV52321683-part1");
     BOOST_CHECK_EQUAL(partitions[0]->get_udev_ids()[1], "scsi-350014ee203733bb5-part1");
+}
+
+
+BOOST_AUTO_TEST_CASE(test_create2)
+{
+    set_logger(get_stdout_logger());
+
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+
+    Storage storage(environment);
+
+    Devicegraph* devicegraph = storage.get_staging();
+
+    Multipath* multipath = Multipath::create(devicegraph, "/dev/mapper/36005076305ffc73a00000000000013b4", Region(0, 1000000, 512));
+    multipath->get_impl().set_udev_paths({ });
+    multipath->get_impl().set_udev_ids({ "scsi-36005076305ffc73a00000000000013b4", "wwn-0x6005076305ffc73a00000000000013b4",
+		"dm-name-36005076305ffc73a00000000000013b4", "dm-uuid-mpath-36005076305ffc73a00000000000013b4" });
+
+    PartitionTable* gpt = multipath->create_partition_table(PtType::GPT);
+
+    gpt->create_partition("/dev/mapper/36005076305ffc73a00000000000013b4-part1", Region(1 * 2048, 10 * 2048, 512), PartitionType::PRIMARY);
+
+    vector<Partition*> partitions = gpt->get_partitions();
+
+    BOOST_REQUIRE_EQUAL(partitions.size(), 1);
+
+    BOOST_CHECK_EQUAL(partitions[0]->get_name(), "/dev/mapper/36005076305ffc73a00000000000013b4-part1");
+
+    BOOST_REQUIRE_EQUAL(partitions[0]->get_udev_paths().size(), 0);
+
+    BOOST_REQUIRE_EQUAL(partitions[0]->get_udev_ids().size(), 4);
+    BOOST_CHECK_EQUAL(partitions[0]->get_udev_ids()[0], "scsi-36005076305ffc73a00000000000013b4-part1");
+    BOOST_CHECK_EQUAL(partitions[0]->get_udev_ids()[1], "wwn-0x6005076305ffc73a00000000000013b4-part1");
+    BOOST_CHECK_EQUAL(partitions[0]->get_udev_ids()[2], "dm-name-36005076305ffc73a00000000000013b4-part1");
+    BOOST_CHECK_EQUAL(partitions[0]->get_udev_ids()[3], "dm-uuid-part1-mpath-36005076305ffc73a00000000000013b4");
 }


### PR DESCRIPTION
For https://trello.com/c/Ncr2zQi3/126-sles12-sp3-p2-l3-1099394-yast-constructs-wrong-udev-name-for-dm-uuid-names.