### PR TITLE
Do not crash when displaying summary for an encrypted but not mounted disk (bsc#1099181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requirements
 
 Some required tools for compiling and testing libstorage-ng are:
 
-gcc-c++ boost-devel libxml2-devel libtool doxygen graphviz python3-devel ruby
+gcc-c++ boost-devel libjson-c-devel libxml2-devel libtool doxygen graphviz python3-devel ruby
 ruby-devel rubygem-test-unit swig >= 3.0.3 and != 3.0.8 (from
 [YaST:storage-ng](https://build.opensuse.org/project/show/YaST:storage-ng))
 

--- a/Rakefile
+++ b/Rakefile
@@ -29,3 +29,14 @@ desc 'Build a tarball for OBS'
 task :tarball do
   sh "make -f Makefile.ci package"
 end
+
+task :update_package_location do
+  # read the spec file from "package" dir if ".obsdir" does not exist yet
+  if !File.exist?(".obsdir")
+    Packaging.configuration { |conf| conf.package_dir = "package" }
+  end
+end
+
+# update the "build_dependencies:*" tasks to read the alternative spec file
+task :"build_dependencies:list" => :update_package_location
+task :"build_dependencies:install" => :update_package_location

--- a/configure.ac
+++ b/configure.ac
@@ -34,11 +34,16 @@ LT_INIT([disable-static pic-only])
 PKG_CHECK_MODULES(XML, libxml-2.0 >= 2.4)
 AC_SUBST([XML_CFLAGS])
 AC_SUBST([XML_LIBS])
-CXXFLAGS="${CXXFLAGS} ${XML_CFLAGS}"
-CFLAGS="${CFLAGS} ${XML_CFLAGS}"
 
 AC_CHECK_HEADER([boost/config.hpp],[],
 		[AC_MSG_ERROR([boost/config.hpp not found, install e.g. boost-devel])])
+
+PKG_CHECK_MODULES(JSON_C, json-c, , [AC_MSG_ERROR([json-c library not found, install e.g. libjson-c-devel])])
+AC_SUBST([JSON_C_CFLAGS])
+AC_SUBST([JSON_C_LIBS])
+
+CXXFLAGS="${CXXFLAGS} ${XML_CFLAGS} ${JSON_C_CFLAGS}"
+CFLAGS="${CFLAGS} ${XML_CFLAGS} ${JSON_C_CFLAGS}"
 
 AC_SUBST(VERSION)
 AC_SUBST(LIBVERSION)

--- a/storage/CompoundAction/Formatter/Partition.cc
+++ b/storage/CompoundAction/Formatter/Partition.cc
@@ -350,7 +350,6 @@ namespace storage
 	return sformat(text,
 		       partition->get_name().c_str(),
 		       partition->get_size_string().c_str(),
-		       filesystem->get_mount_point()->get_path().c_str(),
 		       filesystem->get_displayname().c_str());
     }
 

--- a/storage/Makefile.am
+++ b/storage/Makefile.am
@@ -42,7 +42,7 @@ libstorage_ng_la_LIBADD =			\
 	Utils/libutils.la			\
 	SystemInfo/libsystem-info.la		\
 	$(XML_LIBS)				\
-	-ljson-c
+	$(JSON_C_LIBS)
 
 pkgincludedir = $(includedir)/storage
 

--- a/testsuite/CompoundAction/Makefile.am
+++ b/testsuite/CompoundAction/Makefile.am
@@ -11,7 +11,7 @@ AM_CPPFLAGS = -I$(top_srcdir)
 LDADD = ../../storage/libstorage-ng.la libcompoundactionfixture.la -lboost_unit_test_framework
 
 check_PROGRAMS = btrfs-subvolume-sentence.test lvm-vg-sentence.test lvm-lv-sentence.test \
-		 nfs-sentence.test partition-sentence.test is-delete.test
+		 nfs-sentence.test partition-sentence.test is-delete.test encrypted-sentence.test
 		 
 AM_DEFAULT_SOURCE_EXT = .cc
 

--- a/testsuite/CompoundAction/encrypted-sentence.cc
+++ b/testsuite/CompoundAction/encrypted-sentence.cc
@@ -1,0 +1,35 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE libstorage
+
+#include <boost/test/unit_test.hpp>
+
+#include "storage/Filesystems/Ext4.h"
+#include "storage/Devices/Encryption.h"
+
+#include "testsuite/CompoundAction/Fixture.h"
+
+using namespace storage;
+
+BOOST_FIXTURE_TEST_SUITE(btrfs_subvolume_sentence, test::CompoundActionFixture)
+
+// test for https://bugzilla.suse.com/show_bug.cgi?id=1099181
+BOOST_AUTO_TEST_CASE(test_sentence_on_entrypted_not_mounted)
+{
+    initialize_with_devicegraph("devicegraph.xml");
+
+    auto partition = Partition::find_by_name(staging, "/dev/sda1");
+    partition->remove_descendants();
+
+    auto encryption = partition->create_encryption("cr_sda2");
+    encryption->create_blk_filesystem(FsType::EXT4);
+
+    const auto actiongraph = storage->calculate_actiongraph();
+    auto compound_action = find_compound_action_by_target(actiongraph, partition);
+
+    BOOST_REQUIRE(compound_action);
+    BOOST_CHECK_EQUAL(compound_action->sentence(), "Encrypt partition /dev/sda1 (2.01 GiB) with ext4");
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/CompoundAction/encrypted-sentence.cc
+++ b/testsuite/CompoundAction/encrypted-sentence.cc
@@ -14,7 +14,7 @@ using namespace storage;
 BOOST_FIXTURE_TEST_SUITE(btrfs_subvolume_sentence, test::CompoundActionFixture)
 
 // test for https://bugzilla.suse.com/show_bug.cgi?id=1099181
-BOOST_AUTO_TEST_CASE(test_sentence_on_entrypted_not_mounted)
+BOOST_AUTO_TEST_CASE(test_sentence_on_encrypted_not_mounted)
 {
     initialize_with_devicegraph("devicegraph.xml");
 


### PR DESCRIPTION
## Fix

- Do not call `filesystem->get_mount_point()->get_path()`, it throws an exception when the mount point is not defined. Moreover the parameter is not used in the formatted message.
- Added unit test

### Additional Improvements

When I wanted to compile libstorage-ng locally I got a compile error about a missing JSON header file. It was not obvious what was missing in my system. It turned out that `libjson-c-devel` package is needed for compiling.

- Added `libjson-c-devel` package to the main README.md
- Added an autoconf check to fail early, it also prints a suggestion which package to install
- Use the compiler and linker flags from the `json-c` pkgconfig
- Updated the `build_dependencies:*` Rake tasks to read the alternative spec file when `.obsdir` does not exist yet

## The Original Crash

![storage_summary_crash](https://user-images.githubusercontent.com/907998/43581760-610bb422-965a-11e8-8811-94db6996e6da.gif)

## With the Fix Applied

![storage_summary_fixed](https://user-images.githubusercontent.com/907998/43581777-6d101100-965a-11e8-8d8a-a44f34e2dcc9.gif)
