### PR TITLE
[WIP] Document all classes

### DIFF
--- a/doc/autodocs/doxygen.conf
+++ b/doc/autodocs/doxygen.conf
@@ -12,27 +12,13 @@ TAB_SIZE = 8
 # Input options
 
 INPUT = ../../storage
-FILE_PATTERNS = Actiongraph.h Devicegraph.h Environment.h FreeInfo.h Graphviz.h	\
-	SimpleEtcFstab.h SimpleEtcCrypttab.h Storage.h UsedFeatures.h Version.h
-
+INPUT += ../../storage/CompoundAction
 INPUT += ../../storage/Devices
-FILE_PATTERNS += BcacheCset.h Bcache.h BlkDevice.h Dasd.h DasdPt.h Device.h	\
-	Disk.h DmRaid.h	Encryption.h Gpt.h ImplicitPt.h Luks.h LvmLv.h LvmPv.h 	\
-	LvmVg.h Md.h MdContainer.h MdMember.h Msdos.h Multipath.h      		\
-	Partitionable.h Partition.h PartitionTable.h
-
 INPUT += ../../storage/Filesystems
-FILE_PATTERNS += BlkFilesystem.h Btrfs.h BtrfsSubvolume.h Ext2.h Ext3.h Ext4.h	\
-	Ext.h F2fs.h Filesystem.h Iso9660.h Jfs.h Mountable.h MountPoint.h	\
-	Nfs.h Ntfs.h Reiserfs.h Swap.h Udf.h Vfat.h Xfs.h
-
 INPUT += ../../storage/Holders
-FILE_PATTERNS += FilesystemUser.h Holder.h MdSubdevice.h MdUser.h Subdevice.h	\
-	User.h
-
+INPUT += ../../storage/SystemInfo
 INPUT += ../../storage/Utils
-FILE_PATTERNS += Alignment.h Exception.h HumanString.h Lock.h Logger.h		\
-	Region.h Remote.h Swig.h Topology.h LightProbe.h
+#FILE_PATTERNS = *.h
 
 JAVADOC_AUTOBRIEF = YES
 


### PR DESCRIPTION
Currently  the Doxygen documentation only shows the external API. But while learning the internals it is useful to browse everything, all classes.
https://trello.com/c/8hWPNhdH/84-two-versions-of-generated-documentation

This simply changes the Doxygen options to show everything, not distinguishing what is API and what is internal. TODO: distinguish:
- either by marking with `\internal` in the code
- or by having an `autodocs-all` directory