### PR TITLE
Inactive raid

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# https://EditorConfig.org  -*- ini -*-
+# This is a unified way to tell all your editors
+# about the proper indentation style in this repo.
+#
+# Emacs:   https://github.com/editorconfig/editorconfig-emacs#readme
+# Vim:     https://github.com/editorconfig/editorconfig-vim#readme
+# VS Code: https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
+
+# don't continue looking in upper directories, this is the top level
+root = true
+
+[*.{h,cc}]
+indent_style = tab
+indent_size = 4
+tab_width = 8

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -375,6 +375,7 @@ namespace storage
     Md::Impl::probe_mds(Prober& prober)
     {
 	SystemInfo& system_info = prober.get_system_info();
+	const MdLinks& md_links = system_info.getMdLinks();
 
 	for (const string& short_name : prober.get_sys_block_entries().mds)
 	{
@@ -383,8 +384,20 @@ namespace storage
 	    try
 	    {
 		const MdadmDetail& mdadm_detail = system_info.getMdadmDetail(name);
+
 		if (!mdadm_detail.devname.empty())
-		    name = DEV_MD_DIR "/" + mdadm_detail.devname;
+		{
+		    MdLinks::const_iterator it = md_links.find(short_name);
+		    if (it != md_links.end())
+		    {
+			// the mapping is backwards so we must iterate the result
+			const vector<string>& links = it->second;
+			if (std::find(links.begin(), links.end(), mdadm_detail.devname) != links.end())
+			{
+			    name = DEV_MD_DIR "/" + mdadm_detail.devname;
+			}
+		    }
+		}
 
 		const ProcMdstat::Entry& entry = system_info.getProcMdstat().get_entry(short_name);
 

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -414,6 +414,7 @@ namespace storage
 		else
 		{
 		    Md* md = Md::create(prober.get_system(), name);
+		    md->get_impl().set_active(!entry.inactive);
 		    md->get_impl().probe_pass_1a(prober);
 		}
 	    }

--- a/storage/SystemInfo/CmdBlkid.h
+++ b/storage/SystemInfo/CmdBlkid.h
@@ -42,6 +42,9 @@ namespace storage
     class SystemInfo;
 
 
+    /**
+     * Run and parse the "blkid" command.
+     */
     class Blkid
     {
     public:

--- a/storage/SystemInfo/DevAndSys.cc
+++ b/storage/SystemInfo/DevAndSys.cc
@@ -221,7 +221,16 @@ namespace storage
 
     MdLinks::MdLinks()
     {
-	map<string, string> links = getDirLinks("/dev/md");
+        map<string, string> links;
+	try
+	{
+	    links = getDirLinks("/dev/md");
+	}
+	catch (const Exception&)
+	{
+	    // OK, no /dev/md at all
+	}
+
 	for (const map<string, string>::value_type& it : links)
 	{
 	    string::size_type pos = it.second.find_first_not_of("./");

--- a/storage/SystemInfo/DevAndSys.h
+++ b/storage/SystemInfo/DevAndSys.h
@@ -41,6 +41,9 @@ namespace storage
     using std::map;
 
 
+    /**
+     * A sequence of file names found in a pathname.
+     */
     class Dir
     {
     public:
@@ -67,6 +70,11 @@ namespace storage
     };
 
 
+    /**
+     * A sequence of lines, constructed from a pathname.
+     *
+     * Trailing newlines are not included.
+     */
     class File
     {
     public:

--- a/storage/SystemInfo/ProcMdstat.cc
+++ b/storage/SystemInfo/ProcMdstat.cc
@@ -113,10 +113,6 @@ namespace storage
 	    if( (pos=line.find_first_not_of( app_ws ))!=string::npos && pos!=0 )
 		line.erase( 0, pos );
 	}
-	else
-	{
-	    entry.is_container = true;
-	}
 
 	while( (pos=line.find_first_not_of( app_ws ))==0 )
 	{
@@ -161,6 +157,10 @@ namespace storage
 	    string::size_type pos2 = line2.find_first_of(app_ws, pos1);
 	    entry.super = string(line2, pos1, pos2 - pos1);
 
+	    if (entry.super == "external:ddf" || entry.super == "external:imsm")
+	    {
+		entry.is_container = true;
+	    }
 	    if (!entry.is_container && boost::starts_with(entry.super, "external:"))
 	    {
 		string::size_type pos1 = entry.super.find_first_of("/");

--- a/storage/SystemInfo/ProcMdstat.h
+++ b/storage/SystemInfo/ProcMdstat.h
@@ -110,7 +110,9 @@ namespace storage
 
     };
 
-
+    /**
+     * Parse (the --export variant of) mdadm --detail
+     */
     class MdadmDetail
     {
     public:

--- a/storage/SystemInfo/SystemInfo.h
+++ b/storage/SystemInfo/SystemInfo.h
@@ -55,7 +55,9 @@ namespace storage
 {
     using std::map;
 
-
+    /**
+     * Encapsulates system access, also for testsuite mocking
+     */
     class SystemInfo : private boost::noncopyable
     {
 

--- a/storage/Utils/Remote.h
+++ b/storage/Utils/Remote.h
@@ -34,6 +34,9 @@
 namespace storage
 {
 
+    /**
+     * A result of an unnamed command: stdout + stderr + exit_code.
+     */
     struct RemoteCommand
     {
 	RemoteCommand() : stdout(), stderr(), exit_code(0) {}
@@ -49,6 +52,9 @@ namespace storage
     };
 
 
+    /**
+     * Contents of an unnamed file (vector of lines)
+     */
     struct RemoteFile
     {
 	RemoteFile() : content() {}

--- a/testsuite/SystemInfo/proc-mdstat.cc
+++ b/testsuite/SystemInfo/proc-mdstat.cc
@@ -138,3 +138,25 @@ BOOST_AUTO_TEST_CASE(parse5)
 
     check(input, output);
 }
+
+BOOST_AUTO_TEST_CASE(parse_inactive_noncontainer)
+{
+    vector<string> input = {
+	"Personalities : [raid6] [raid5] [raid4] ",
+	"md126 : inactive sde1[0](S)",
+	"      101340 blocks super 1.0",
+	"       ",
+	"md127 : active raid5 sdb1[5] sdc1[1] sda1[4]",
+	"      2094848 blocks super 1.0 level 5, 128k chunk, algorithm 2 [3/3] [UUU]",
+	"      bitmap: 0/1 pages [0KB], 65536KB chunk",
+	"",
+	"unused devices: <none>"
+    };
+
+    vector<string> output = {
+	"data[md126] -> md-level:unknown super:1.0 size:103772160 read-only inactive devices:</dev/sde1(S)>",
+	"data[md127] -> md-level:RAID5 md-parity:left-symmetric super:1.0 chunk-size:131072 size:2145124352 devices:</dev/sda1 /dev/sdb1 /dev/sdc1>"
+    };
+
+    check(input, output);
+}

--- a/testsuite/probe/md-ddf1-mockup.xml
+++ b/testsuite/probe/md-ddf1-mockup.xml
@@ -14,6 +14,13 @@
       <stdout>sda</stdout>
     </Command>
     <Command>
+      <name>/bin/ls -1l --sort=none '/dev/md'</name>
+      <stdout>total 0</stdout>
+      <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:41 a -> ../md126</stdout>
+      <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:41 b -> ../md125</stdout>
+      <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:31 ddf0 -> ../md127</stdout>
+    </Command>
+    <Command>
       <name>/sbin/blkid -c '/dev/null'</name>
       <stdout>/dev/sda1: UUID="691eb75f-2f8f-4ec9-8515-60b34237bd6d" TYPE="swap" PARTUUID="321b4d22-01"</stdout>
       <stdout>/dev/sda2: UUID="4d2e6fde-d105-4f15-b8e1-4173badc8c66" TYPE="ext4" PTTYPE="dos" PARTUUID="321b4d22-02"</stdout>

--- a/testsuite/probe/md-imsm1-mockup.xml
+++ b/testsuite/probe/md-imsm1-mockup.xml
@@ -14,6 +14,13 @@
       <stdout>sda</stdout>
     </Command>
     <Command>
+      <name>/bin/ls -1l --sort=none '/dev/md'</name>
+      <stdout>total 0</stdout>
+      <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:41 a -> ../md126</stdout>
+      <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:41 b -> ../md125</stdout>
+      <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:41 imsm0 -> ../md127</stdout>
+    </Command>
+    <Command>
       <name>/sbin/blkid -c '/dev/null'</name>
       <stdout>/dev/sda1: UUID="691eb75f-2f8f-4ec9-8515-60b34237bd6d" TYPE="swap" PARTUUID="321b4d22-01"</stdout>
       <stdout>/dev/sda2: UUID="4d2e6fde-d105-4f15-b8e1-4173badc8c66" TYPE="ext4" PTTYPE="dos" PARTUUID="321b4d22-02"</stdout>

--- a/testsuite/probe/md3-mockup.xml
+++ b/testsuite/probe/md3-mockup.xml
@@ -15,6 +15,16 @@
       <stdout>md1</stdout>
     </Command>
     <Command>
+      <name>/bin/ls -1l --sort=none '/dev/md'</name>
+      <stdout>total 0</stdout>
+      <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:31 test2 -> ../md127</stdout>
+      <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:41 test3 -> ../md126</stdout>
+      <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:41 test3p1 -> ../md126p1</stdout>
+      <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:31 test4 -> ../md_test4</stdout>
+      <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:31 test5 -> ../md_test5</stdout>
+      <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:31 test5p1 -> ../md_test5p1</stdout>
+    </Command>
+    <Command>
       <name>/sbin/blkid -c '/dev/null'</name>
       <stdout>/dev/sda1: UUID="2fd6a519-1b93-42dc-bc8f-99ac033a17a9" TYPE="ext4" PTTYPE="dos" PARTLABEL="primary" PARTUUID="7ec989ba-839c-4991-8a13-b66eab52c828"</stdout>
       <stdout>/dev/sda2: PARTLABEL="primary" PARTUUID="2a68a80b-94f7-4770-abf5-058f9660e791"</stdout>


### PR DESCRIPTION
- https://trello.com/c/8kPdHfZR
- https://bugzilla.suse.com/show_bug.cgi?id=1090010

#### Situation

2 of 3 devices in a RAID5 array have gone missing. So, the RAID is "inactive", and it is only available as /dev/md*NUMBER*, not as /dev/md/*NAME*.

#### Before this PR:
![raid-inactive-before1](https://user-images.githubusercontent.com/102056/44528706-7f1d8800-a6ea-11e8-9c8e-01e10375e144.png)
Details:
 ![raid-inactive-before2](https://user-images.githubusercontent.com/102056/44528713-82b10f00-a6ea-11e8-8e3f-5f3894791e47.png)

#### With this PR
Here's an inactive RAID (made of /dev/sde1 and some other, missing, devices)
![raid-inactive](https://user-images.githubusercontent.com/102056/44527901-7a57d480-a6e8-11e8-997e-f157a17da7fe.png)

For comparison, here is a regular active RAID (made of /dev/sd[abc]1)
![raid-active](https://user-images.githubusercontent.com/102056/44528003-bdb24300-a6e8-11e8-8f18-19f0697e7c5f.png)

The "Active: Yes/No" field under the RAID heading is done in https://github.com/yast/yast-storage-ng/pull/717
