### PR TITLE
detect correctly whether a file system is currently mounted (bsc#1105227)

### DIFF
--- a/storage/EtcFstab.h
+++ b/storage/EtcFstab.h
@@ -249,7 +249,7 @@ namespace storage
 	// Getters; see man fstab(5)
 
 	const string &	  get_device()	    const { return device;	}
-	const string &	  get_mount_point() const { return mount_point; }
+	const string &	  get_mount_point() const { return _mount_point; }
 	FsType		  get_fs_type()	    const { return fs_type;	}
 	const MountOpts & get_mount_opts()  const { return mount_opts;	}
 	int		  get_dump_pass()   const { return dump_pass;	}
@@ -258,7 +258,7 @@ namespace storage
 	// Setters
 
 	void set_device	    ( const string &	new_val ) { device	= new_val; }
-	void set_mount_point( const string &	new_val ) { mount_point = new_val; }
+	void set_mount_point( const string &	new_val );
 	void set_fs_type    ( FsType		new_val ) { fs_type	= new_val; }
 	void set_mount_opts ( const MountOpts & new_val ) { mount_opts	= new_val; }
 	void set_dump_pass  ( int		new_val ) { dump_pass	= new_val; }
@@ -272,7 +272,7 @@ namespace storage
     private:
 
 	string	  device;	// including UUID= or LABEL=
-	string	  mount_point;
+	string	  _mount_point;	// always use get/set_mount_point()
 	FsType	  fs_type;	// see Filesystems/Filesystem.h
 	MountOpts mount_opts;
 	int	  dump_pass;	// historic

--- a/storage/Filesystems/MountPoint.cc
+++ b/storage/Filesystems/MountPoint.cc
@@ -74,6 +74,33 @@ namespace storage
     }
 
 
+    // Notes
+    //
+    // - boost::filesystem::path::canonical() is not what we want as this
+    //   works with existing files (ours might not yet exist) and resolves
+    //   symlinks (which is too restrictive)
+    //
+    // - boost::filesystem::path::lexically_normal() is also not what we
+    //   want as it behaves a bit weird for our purpose; it changes e.g.
+    //   '/foo/' into '/foo/.'
+    //
+    // - if you change this function keep in mind that 'swap' is a special
+    //   valid path argument in libstorage-ng
+    //
+    string
+    MountPoint::normalize_path(const string& path)
+    {
+        string tmp = regex_replace(path, regex("/+"), "/");
+
+        if (tmp != "/")
+        {
+            tmp = regex_replace(tmp, regex("/$"), "");
+        }
+
+	return tmp;
+    }
+
+
     MountByType
     MountPoint::get_mount_by() const
     {

--- a/storage/Filesystems/MountPoint.h
+++ b/storage/Filesystems/MountPoint.h
@@ -67,6 +67,11 @@ namespace storage
 	void set_path(const std::string& path);
 
 	/**
+	 * Return normalized form of path.
+	 */
+	static std::string normalize_path(const std::string& path);
+
+	/**
 	 * Get the mount-by method.
 	 */
 	MountByType get_mount_by() const;

--- a/storage/Filesystems/MountPointImpl.cc
+++ b/storage/Filesystems/MountPointImpl.cc
@@ -49,13 +49,14 @@ namespace storage
 
 
     MountPoint::Impl::Impl(const string& path)
-	: Device::Impl(), path(path), mount_by(MountByType::DEVICE), mount_type(FsType::UNKNOWN),
+	: Device::Impl(), mount_by(MountByType::DEVICE), mount_type(FsType::UNKNOWN),
 	  freq(0), passno(0), active(true), in_etc_fstab(true)
     {
 #if 0
 	if (!valid_path(path))
 	    ST_THROW(InvalidMountPointPath(path));
 #endif
+	set_path(path);
     }
 
 
@@ -65,7 +66,8 @@ namespace storage
     {
 	string tmp;
 
-	getChildValue(node, "path", path);
+	if (getChildValue(node, "path", tmp))
+	    set_path(tmp);
 
 	if (getChildValue(node, "mount-by", tmp))
 	    mount_by = toValueWithFallback(tmp, MountByType::DEVICE);
@@ -136,7 +138,7 @@ namespace storage
 	    ST_THROW(InvalidMountPointPath(path));
 #endif
 
-	Impl::path = path;
+	Impl::path = normalize_path(path);
     }
 
 
@@ -144,13 +146,6 @@ namespace storage
     MountPoint::Impl::valid_path(const string& path)
     {
 	return path == "swap" || boost::starts_with(path, "/");
-    }
-
-
-    string
-    MountPoint::Impl::normalize_path(const string& path)
-    {
-	return path;		// TODO
     }
 
 

--- a/storage/Filesystems/MountPointImpl.h
+++ b/storage/Filesystems/MountPointImpl.h
@@ -57,7 +57,6 @@ namespace storage
 	virtual ResizeInfo detect_resize_info() const override;
 
 	static bool valid_path(const string& path);
-	static string normalize_path(const string& path);
 
 	const string& get_path() const { return path; }
 	void set_path(const string& path);

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -16,7 +16,7 @@ check_PROGRAMS =								\
 	output.test probe.test range.test stable.test relatives.test 		\
 	mount-opts.test etc-mdadm.test mount-by.test btrfs.test md1.test	\
 	md2.test md3.test md4.test encryption1.test lvm1.test graphviz.test	\
-	copy-individual.test
+	copy-individual.test mountpoint.test
 
 AM_DEFAULT_SOURCE_EXT = .cc
 

--- a/testsuite/mountpoint.cc
+++ b/testsuite/mountpoint.cc
@@ -12,22 +12,22 @@ using namespace storage;
 
 BOOST_AUTO_TEST_CASE(normalize_path)
 {
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path(""), "" );
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("swap"), "swap" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "" ), "" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "swap" ), "swap" );
 
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("/"), "/" );
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("/foo"), "/foo" );
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("/foo/bar"), "/foo/bar" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "/" ), "/" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "/foo" ), "/foo" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "/foo/bar" ), "/foo/bar" );
 
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("///foo"), "/foo" );
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("///foo/"), "/foo" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "///foo" ), "/foo" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "///foo/" ), "/foo" );
 
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("//foo/bar"), "/foo/bar" );
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("///foo///bar"), "/foo/bar" );
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("///foo///bar//"), "/foo/bar" );
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("///foo///bar//"), "/foo/bar" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "//foo/bar" ), "/foo/bar" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "///foo///bar" ), "/foo/bar" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "///foo///bar//" ), "/foo/bar" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "///foo///bar//" ), "/foo/bar" );
 
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("////foo///bar/."), "/foo/bar/." );
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("////foo///bar/.."), "/foo/bar/.." );
-    BOOST_CHECK_EQUAL( MountPoint::normalize_path("////foo//..///./bar//"), "/foo/.././bar" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "////foo///bar/." ), "/foo/bar/." );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "////foo///bar/.." ), "/foo/bar/.." );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path( "////foo//..///./bar//" ), "/foo/.././bar" );
 }

--- a/testsuite/mountpoint.cc
+++ b/testsuite/mountpoint.cc
@@ -1,0 +1,33 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE libstorage
+
+#include <boost/test/unit_test.hpp>
+
+#include "storage/Filesystems/MountPoint.h"
+
+
+using namespace storage;
+
+
+BOOST_AUTO_TEST_CASE(normalize_path)
+{
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path(""), "" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("swap"), "swap" );
+
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("/"), "/" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("/foo"), "/foo" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("/foo/bar"), "/foo/bar" );
+
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("///foo"), "/foo" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("///foo/"), "/foo" );
+
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("//foo/bar"), "/foo/bar" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("///foo///bar"), "/foo/bar" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("///foo///bar//"), "/foo/bar" );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("///foo///bar//"), "/foo/bar" );
+
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("////foo///bar/."), "/foo/bar/." );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("////foo///bar/.."), "/foo/bar/.." );
+    BOOST_CHECK_EQUAL( MountPoint::normalize_path("////foo//..///./bar//"), "/foo/.././bar" );
+}


### PR DESCRIPTION
This patch basically ensures that the mount point is in 'canonical' form.