### PR TITLE
- added luks label to blkid parser

### DIFF
--- a/storage/SystemInfo/CmdBlkid.cc
+++ b/storage/SystemInfo/CmdBlkid.cc
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2004-2014] Novell, Inc.
- * Copyright (c) [2016-2017] SUSE LLC
+ * Copyright (c) [2016-2018] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -127,6 +127,10 @@ namespace storage
 		it1 = m.find("UUID");
 		if (it1 != m.end())
 		    entry.luks_uuid = it1->second;
+
+		it1 = m.find("LABEL");
+		if (it1 != m.end())
+		    entry.luks_label = it1->second;
 	    }
 
 	    if (entry.is_bcache)
@@ -250,6 +254,8 @@ namespace storage
 	    s << "is-luks:" << entry.is_luks;
 	    if (!entry.luks_uuid.empty())
 		s << " luks-uuid:" << entry.luks_uuid;
+	    if (!entry.luks_label.empty())
+		s << " luks-label:" << entry.luks_label;
 	}
 
 	if (entry.is_bcache)

--- a/storage/SystemInfo/CmdBlkid.h
+++ b/storage/SystemInfo/CmdBlkid.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2004-2014] Novell, Inc.
- * Copyright (c) [2016-2017] SUSE LLC
+ * Copyright (c) [2016-2018] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -56,7 +56,7 @@ namespace storage
 	{
 	    Entry() : is_fs(false), fs_type(FsType::UNKNOWN), fs_uuid(), fs_label(), fs_journal_uuid(),
 		      is_journal(false), journal_uuid(), is_md(false), is_lvm(false),
-		      is_luks(false), luks_uuid(), is_bcache(false), bcache_uuid() {}
+		      is_luks(false), luks_uuid(), luks_label(), is_bcache(false), bcache_uuid() {}
 
 	    bool is_fs;
 	    FsType fs_type;
@@ -73,6 +73,7 @@ namespace storage
 
 	    bool is_luks;
 	    string luks_uuid;
+	    string luks_label;
 
 	    bool is_bcache;
 	    string bcache_uuid;

--- a/testsuite/SystemInfo/blkid.cc
+++ b/testsuite/SystemInfo/blkid.cc
@@ -209,3 +209,19 @@ BOOST_AUTO_TEST_CASE(parse_ddf)
 
     check(input, output);
 }
+
+
+BOOST_AUTO_TEST_CASE(parse_luks)
+{
+    vector<string> input = {
+	"/dev/sdb1: UUID=\"b329b40b-e5f0-4f8e-814d-b6afb7f0ce64\" TYPE=\"crypto_LUKS\" PARTUUID=\"02cabc90-ca73-4302-928e-a924cda495bc\"",
+	"/dev/sdb2: UUID=\"332cd185-9d1b-479c-ade6-a9fb6e4e536d\" LABEL=\"master-plan\" TYPE=\"crypto_LUKS\" PARTUUID=\"20e9945b-1b57-4f46-89d8-b6321be05df3\""
+    };
+
+    vector<string> output = {
+	"data[/dev/sdb1] -> is-luks:true luks-uuid:b329b40b-e5f0-4f8e-814d-b6afb7f0ce64",
+	"data[/dev/sdb2] -> is-luks:true luks-uuid:332cd185-9d1b-479c-ade6-a9fb6e4e536d luks-label:master-plan"
+    };
+
+    check(input, output);
+}


### PR DESCRIPTION
With openSUSE Tumbleweed 2018-08-31 blkid can now show the label for LUKS (starting with version 2). Using the label in /etc/crypttab does not work yet since no link in /dev/disk/by-label is generated. So adding more support is currently not productive.
