### PR TITLE
Use ccache in Travis builds (up to 4x faster)

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -5,8 +5,17 @@
 # exit on error immediately, print the executed commands
 set -e -x
 
+# use ccache for faster rebuilds
+export PATH="/usr/lib64/ccache:$PATH"
+# set 2GB cache size
+ccache --set-config=max_size=2.0G
+# print the initial ccache statistics
+ccache -s
+
 # fetch the full history so the log can be generated correctly
-git fetch --unshallow
+if [ `git rev-parse --is-shallow-repository` = "true" ]; then
+  git fetch --unshallow
+fi
 
 # generate the .tar.xz source tarball and the *.changes file
 utils/make_package
@@ -27,3 +36,6 @@ rpm -iv --force --nodeps /usr/src/packages/RPMS/**/*.rpm
 rpm -Uv --force --nodeps /usr/src/packages/RPMS/**/*.rpm
 # get the plain package names and remove all packages at once
 rpm -ev --nodeps `rpm -q --qf '%{NAME} ' -p /usr/src/packages/RPMS/**/*.rpm`
+
+# print the final ccache statistics
+ccache -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,15 @@ language: bash
 services:
   - docker
 
+# cache the .ccache directory between the builds
+# see https://docs.travis-ci.com/user/caching/
+cache:
+  directories:
+    - $HOME/.ccache
+
 before_install:
   - docker build -t libstorage-ng-image .
 script:
   # run the travis script
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" libstorage-ng-image ./.travis.sh
+  # mount the ccache as a volume (bind-mount) so the changes are available later outside the container
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -v $HOME/.ccache:/root/.ccache libstorage-ng-image ./.travis.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,2 @@
-FROM yastdevel/cpp
-RUN zypper --non-interactive install swig graphviz python3-devel libxml2-devel libjson-c-devel libboost_test-devel
+FROM yastdevel/libstorage-ng
 COPY . /usr/src/app


### PR DESCRIPTION
## Faster Rebuilds at Travis

- Use `ccache` to make the rebuilds faster
  - The `~/.ccache` directory is cached by Travis, see the Travis [documentation](https://docs.travis-ci.com/user/caching/) about caching
  - Downloading the cache at Travis is quite fast, in this case it's ~15 seconds
  - If the source is found in the cache the cached result is returned immediately without need for recompiling
- Improved Git unshallowing - check if the repository is actually a shallow clone, this avoids a failure when running locally with a full clone
- Use a specific Docker image for building, reusing big YaST image and adapting it to libstorage-ng takes some extra time, this saves ~40 seconds for each build

### Speed Up

- The usual time to build the libstorage-ng in Travis was almost half an hour (~29minutes, see the [history](https://travis-ci.org/openSUSE/libstorage-ng/builds))
- With the ccache the rebuild takes ~6:30 (an example [log](https://travis-ci.org/lslezak/libstorage-ng/builds/431359330)), that's **about 4x times faster** in the ideal case when there is no code change at all.

#### Disclaimer :wink: 

Obviously the speedup depends how much the code or the environment has been changed since the last build. If there is a just small change the cache will help a lot, if there is a major change, for example updated some base class which is often used the speed up will be smaller. If some dependent library (boost) or the compiler itself is updated then the cache might not help at all and the build will take again full time (i.e. up to 1/2 hour).

But the next rebuild should again take the advantage of the cached files and should be faster again.

Let's see how much it helps in reality...