### PR TITLE
Use for bcache cset as display name string "bcache cache" (fate#325346)

### DIFF
--- a/storage/Devices/BcacheCsetImpl.h
+++ b/storage/Devices/BcacheCsetImpl.h
@@ -52,7 +52,7 @@ namespace storage
 
 	virtual const char* get_classname() const override { return DeviceTraits<BcacheCset>::classname; }
 
-	virtual string get_displayname() const override { return get_uuid(); }
+	virtual string get_displayname() const override { return "bcache cache"; }
 
 	virtual string get_pretty_classname() const override;
 


### PR DESCRIPTION
Reason is that previously it use uuid which has two drawbacks:

1. it is too long
2. it is not known when cset is not yet commited, so result is empty
string which is confusing

screenshot how it looks now ( previously there was empty box instead of "bcache caching set" )

![cset_name](https://user-images.githubusercontent.com/478871/46478418-38dd3d80-c7ed-11e8-9b03-20d1eb4df989.png)


and to compare old look:

![cset_old](https://user-images.githubusercontent.com/478871/46478408-35e24d00-c7ed-11e8-902c-64aaa5dbd8c7.png)

