### PR TITLE
 Fixed blkid output parser to honor escaped quotes

### DIFF
--- a/storage/SystemInfo/CmdBlkid.h
+++ b/storage/SystemInfo/CmdBlkid.h
@@ -27,6 +27,7 @@
 
 #include <string>
 #include <map>
+#include <list>
 #include <vector>
 
 #include "storage/Filesystems/Filesystem.h"
@@ -36,6 +37,7 @@ namespace storage
 {
     using std::string;
     using std::map;
+    using std::list;
     using std::vector;
 
 
@@ -102,6 +104,8 @@ namespace storage
 	bool any_lvm() const;
 	bool any_luks() const;
 	bool any_bcache() const;
+
+        static list<string> split_line( const string & line );
 
     private:
 

--- a/storage/Utils/AppUtil.cc
+++ b/storage/Utils/AppUtil.cc
@@ -52,60 +52,60 @@ namespace storage
     using namespace std;
 
 
-void createPath(const string& Path_Cv)
-{
-  string::size_type Pos_ii = 0;
-  while ((Pos_ii = Path_Cv.find('/', Pos_ii + 1)) != string::npos)
+    void createPath(const string& Path_Cv)
     {
-      string Tmp_Ci = Path_Cv.substr(0, Pos_ii);
-      mkdir(Tmp_Ci.c_str(), 0777);
+        string::size_type Pos_ii = 0;
+        while ((Pos_ii = Path_Cv.find('/', Pos_ii + 1)) != string::npos)
+        {
+            string Tmp_Ci = Path_Cv.substr(0, Pos_ii);
+            mkdir(Tmp_Ci.c_str(), 0777);
+        }
+        mkdir(Path_Cv.c_str(), 0777);
     }
-  mkdir(Path_Cv.c_str(), 0777);
-}
 
 
-bool
-checkDir(const string& Path_Cv)
-{
-  struct stat Stat_ri;
+    bool
+    checkDir(const string& Path_Cv)
+    {
+        struct stat Stat_ri;
 
-  return (stat(Path_Cv.c_str(), &Stat_ri) >= 0 &&
-	  S_ISDIR(Stat_ri.st_mode));
-}
-
-
-bool
-getStatMode(const string& Path_Cv, mode_t& val )
-{
-  struct stat Stat_ri;
-  int ret_ii = stat(Path_Cv.c_str(), &Stat_ri);
-
-  if( ret_ii==0 )
-    val = Stat_ri.st_mode;
-  else
-    y2mil( "stat " << Path_Cv << " ret:" << ret_ii );
-
-  return (ret_ii==0);
-}
-
-bool
-setStatMode(const string& Path_Cv, mode_t val )
-{
-  int ret_ii = chmod( Path_Cv.c_str(), val );
-  if( ret_ii!=0 )
-    y2mil( "chmod " << Path_Cv << " ret:" << ret_ii );
-  return( ret_ii==0 );
-}
+        return (stat(Path_Cv.c_str(), &Stat_ri) >= 0 &&
+                S_ISDIR(Stat_ri.st_mode));
+    }
 
 
-bool
-checkNormalFile(const string& Path_Cv)
-{
-  struct stat Stat_ri;
+    bool
+    getStatMode(const string& Path_Cv, mode_t& val )
+    {
+        struct stat Stat_ri;
+        int ret_ii = stat(Path_Cv.c_str(), &Stat_ri);
 
-  return (stat(Path_Cv.c_str(), &Stat_ri) >= 0 &&
-	  S_ISREG(Stat_ri.st_mode));
-}
+        if( ret_ii==0 )
+            val = Stat_ri.st_mode;
+        else
+            y2mil( "stat " << Path_Cv << " ret:" << ret_ii );
+
+        return (ret_ii==0);
+    }
+
+    bool
+    setStatMode(const string& Path_Cv, mode_t val )
+    {
+        int ret_ii = chmod( Path_Cv.c_str(), val );
+        if( ret_ii!=0 )
+            y2mil( "chmod " << Path_Cv << " ret:" << ret_ii );
+        return( ret_ii==0 );
+    }
+
+
+    bool
+    checkNormalFile(const string& Path_Cv)
+    {
+        struct stat Stat_ri;
+
+        return (stat(Path_Cv.c_str(), &Stat_ri) >= 0 &&
+                S_ISREG(Stat_ri.st_mode));
+    }
 
 
     string
@@ -197,129 +197,129 @@ checkNormalFile(const string& Path_Cv)
     }
 
 
-string extractNthWord(int Num_iv, const string& Line_Cv, bool GetRest_bi)
-  {
-  string::size_type pos;
-  int I_ii=0;
-  string Ret_Ci = Line_Cv;
+    string extractNthWord(int Num_iv, const string& Line_Cv, bool GetRest_bi)
+    {
+        string::size_type pos;
+        int I_ii=0;
+        string Ret_Ci = Line_Cv;
 
-  if( Ret_Ci.find_first_of(app_ws)==0 )
-    {
-    pos = Ret_Ci.find_first_not_of(app_ws);
-    if( pos != string::npos )
+        if( Ret_Ci.find_first_of(app_ws)==0 )
         {
-        Ret_Ci.erase(0, pos );
-        }
-    else
-        {
-        Ret_Ci.erase();
-        }
-    }
-  while( I_ii<Num_iv && Ret_Ci.length()>0 )
-    {
-    pos = Ret_Ci.find_first_of(app_ws);
-    if( pos != string::npos )
-        {
-        Ret_Ci.erase(0, pos );
-        }
-    else
-        {
-        Ret_Ci.erase();
-        }
-    if( Ret_Ci.find_first_of(app_ws)==0 )
-        {
-        pos = Ret_Ci.find_first_not_of(app_ws);
-        if( pos != string::npos )
+            pos = Ret_Ci.find_first_not_of(app_ws);
+            if( pos != string::npos )
             {
-            Ret_Ci.erase(0, pos );
+                Ret_Ci.erase(0, pos );
             }
-        else
+            else
             {
-            Ret_Ci.erase();
+                Ret_Ci.erase();
             }
         }
-    I_ii++;
-    }
-  if (!GetRest_bi && (pos=Ret_Ci.find_first_of(app_ws))!=string::npos )
-      Ret_Ci.erase(pos);
-  return Ret_Ci;
-  }
-
-list<string> splitString( const string& s, const string& delChars,
-		          bool multipleDelim, bool skipEmpty,
-			  const string& quotes )
-    {
-    string::size_type pos;
-    string::size_type cur = 0;
-    string::size_type nfind = 0;
-    list<string> ret;
-
-    while( cur<s.size() && (pos=s.find_first_of(delChars,nfind))!=string::npos )
-	{
-	if( pos==cur )
-	    {
-	    if( !skipEmpty )
-		ret.push_back( "" );
-	    }
-	else
-	    ret.push_back( s.substr( cur, pos-cur ));
-	if( multipleDelim )
-	    {
-	    cur = s.find_first_not_of(delChars,pos);
-	    }
-	else
-	    cur = pos+1;
-	nfind = cur;
-	if( !quotes.empty() )
-	    {
-	    string::size_type qpos=s.find_first_of(quotes,cur);
-	    string::size_type lpos=s.find_first_of(delChars,cur);
-	    if( qpos!=string::npos && qpos<lpos &&
-	        (qpos=s.find_first_of(quotes,qpos+1))!=string::npos )
-		{
-		nfind = qpos;
-		}
-	    }
-	}
-    if( cur<s.size() )
-	ret.push_back( s.substr( cur ));
-    if( !skipEmpty && !s.empty() && s.find_last_of(delChars)==s.size()-1 )
-	ret.push_back( "" );
-    //y2mil( "ret:" << ret );
-    return( ret );
+        while( I_ii<Num_iv && Ret_Ci.length()>0 )
+        {
+            pos = Ret_Ci.find_first_of(app_ws);
+            if( pos != string::npos )
+            {
+                Ret_Ci.erase(0, pos );
+            }
+            else
+            {
+                Ret_Ci.erase();
+            }
+            if( Ret_Ci.find_first_of(app_ws)==0 )
+            {
+                pos = Ret_Ci.find_first_not_of(app_ws);
+                if( pos != string::npos )
+                {
+                    Ret_Ci.erase(0, pos );
+                }
+                else
+                {
+                    Ret_Ci.erase();
+                }
+            }
+            I_ii++;
+        }
+        if (!GetRest_bi && (pos=Ret_Ci.find_first_of(app_ws))!=string::npos )
+            Ret_Ci.erase(pos);
+        return Ret_Ci;
     }
 
-
-map<string,string>
-makeMap( const list<string>& l, const string& delim, const string& removeSur )
+    list<string> splitString( const string& s, const string& delChars,
+                              bool multipleDelim, bool skipEmpty,
+                              const string& quotes )
     {
-    map<string,string> ret;
-    for( list<string>::const_iterator i=l.begin(); i!=l.end(); ++i )
-	{
-	string k, v;
-	string::size_type pos;
-	if( (pos=i->find_first_of( delim ))!=string::npos )
-	    {
-	    k = i->substr( 0, pos );
-	    string::size_type pos2 = i->find_first_not_of( delim, pos+1 );
-	    if( pos2 != string::npos )
-		v = i->substr( pos2 );
-	    }
-	if( !removeSur.empty() )
-	    {
-	    if( (pos=k.find_first_of(removeSur)) != string::npos )
-		k.erase( 0, k.find_first_not_of(removeSur) );
-	    if( !k.empty() && (pos=k.find_last_of(removeSur))==k.size()-1 )
-		k.erase( k.find_last_not_of(removeSur)+1 );
-	    if( (pos=v.find_first_of(removeSur)) != string::npos )
-		v.erase( 0, v.find_first_not_of(removeSur) );
-	    if( !v.empty() && (pos=v.find_last_of(removeSur))==v.size()-1 )
-		v.erase( v.find_last_not_of(removeSur)+1 );
-	    }
-	if( !k.empty() && !v.empty() )
-	    ret[k] = v;
-	}
-    return( ret );
+        string::size_type pos;
+        string::size_type cur = 0;
+        string::size_type nfind = 0;
+        list<string> ret;
+
+        while( cur<s.size() && (pos=s.find_first_of(delChars,nfind))!=string::npos )
+        {
+            if( pos==cur )
+            {
+                if( !skipEmpty )
+                    ret.push_back( "" );
+            }
+            else
+                ret.push_back( s.substr( cur, pos-cur ));
+            if( multipleDelim )
+            {
+                cur = s.find_first_not_of(delChars,pos);
+            }
+            else
+                cur = pos+1;
+            nfind = cur;
+            if( !quotes.empty() )
+            {
+                string::size_type qpos=s.find_first_of(quotes,cur);
+                string::size_type lpos=s.find_first_of(delChars,cur);
+                if( qpos!=string::npos && qpos<lpos &&
+                    (qpos=s.find_first_of(quotes,qpos+1))!=string::npos )
+                {
+                    nfind = qpos;
+                }
+            }
+        }
+        if( cur<s.size() )
+            ret.push_back( s.substr( cur ));
+        if( !skipEmpty && !s.empty() && s.find_last_of(delChars)==s.size()-1 )
+            ret.push_back( "" );
+        //y2mil( "ret:" << ret );
+        return( ret );
+    }
+
+
+    map<string,string>
+    makeMap( const list<string>& l, const string& delim, const string& removeSur )
+    {
+        map<string,string> ret;
+        for( list<string>::const_iterator i=l.begin(); i!=l.end(); ++i )
+        {
+            string k, v;
+            string::size_type pos;
+            if( (pos=i->find_first_of( delim ))!=string::npos )
+            {
+                k = i->substr( 0, pos );
+                string::size_type pos2 = i->find_first_not_of( delim, pos+1 );
+                if( pos2 != string::npos )
+                    v = i->substr( pos2 );
+            }
+            if( !removeSur.empty() )
+            {
+                if( (pos=k.find_first_of(removeSur)) != string::npos )
+                    k.erase( 0, k.find_first_not_of(removeSur) );
+                if( !k.empty() && (pos=k.find_last_of(removeSur))==k.size()-1 )
+                    k.erase( k.find_last_not_of(removeSur)+1 );
+                if( (pos=v.find_first_of(removeSur)) != string::npos )
+                    v.erase( 0, v.find_first_not_of(removeSur) );
+                if( !v.empty() && (pos=v.find_last_of(removeSur))==v.size()-1 )
+                    v.erase( v.find_last_not_of(removeSur)+1 );
+            }
+            if( !k.empty() && !v.empty() )
+                ret[k] = v;
+        }
+        return( ret );
     }
 
 
@@ -456,7 +456,7 @@ makeMap( const list<string>& l, const string& delim, const string& removeSur )
     }
 
 
-const string app_ws = " \t\n";
+    const string app_ws = " \t\n";
 
 
     /**

--- a/storage/Utils/AppUtil.h
+++ b/storage/Utils/AppUtil.h
@@ -50,11 +50,11 @@ namespace storage
     class SystemInfo;
 
 
-void createPath(const string& Path_Cv);
-bool checkNormalFile(const string& Path_Cv);
-bool checkDir(const string& Path_Cv);
-bool getStatMode(const string& Path_Cv, mode_t& val );
-bool setStatMode(const string& Path_Cv, mode_t val );
+    void createPath(const string& Path_Cv);
+    bool checkNormalFile(const string& Path_Cv);
+    bool checkDir(const string& Path_Cv);
+    bool getStatMode(const string& Path_Cv, mode_t& val );
+    bool setStatMode(const string& Path_Cv, mode_t val );
 
     string dirname(const string& name);
     string basename(const string& name);
@@ -81,15 +81,15 @@ bool setStatMode(const string& Path_Cv, mode_t val );
      */
     bool has_kernel_holders(const string& name, SystemInfo& system_info);
 
-string extractNthWord(int Num_iv, const string& Line_Cv, bool GetRest_bi = false);
+    string extractNthWord(int Num_iv, const string& Line_Cv, bool GetRest_bi = false);
 
-std::list<string> splitString( const string& s, const string& delChars=" \t\n",
-                          bool multipleDelim=true, bool skipEmpty=true,
-			  const string& quotes="" );
+    std::list<string> splitString( const string& s, const string& delChars=" \t\n",
+                                   bool multipleDelim=true, bool skipEmpty=true,
+                                   const string& quotes="" );
 
-std::map<string,string> makeMap( const std::list<string>& l,
-                                 const string& delim = "=",
-				 const string& removeSur = " \t\n" );
+    std::map<string,string> makeMap( const std::list<string>& l,
+                                     const string& delim = "=",
+                                     const string& removeSur = " \t\n" );
 
     string udev_encode(const string&);
     string udev_decode(const string&);
@@ -97,11 +97,11 @@ std::map<string,string> makeMap( const std::list<string>& l,
     string normalizeDevice(const string& dev);
 
 
-template<class StreamType>
-void classic(StreamType& stream)
-{
-    stream.imbue(std::locale::classic());
-}
+    template<class StreamType>
+    void classic(StreamType& stream)
+    {
+        stream.imbue(std::locale::classic());
+    }
 
 
     string hostname();
@@ -162,7 +162,7 @@ void classic(StreamType& stream)
     format_to_name_schemata(const string& s, const vector<NameSchema>& name_schemata);
 
 
-extern const string app_ws;
+    extern const string app_ws;
 
 }
 

--- a/testsuite/SystemInfo/blkid.cc
+++ b/testsuite/SystemInfo/blkid.cc
@@ -33,6 +33,35 @@ check(const vector<string>& input, const vector<string>& output)
 }
 
 
+void
+check_split_line( const string & input, const string & output )
+{
+    string result = boost::join( Blkid::split_line( input ), "|" );
+
+    BOOST_CHECK_EQUAL( result, output );
+}
+
+
+BOOST_AUTO_TEST_CASE(split_line)
+{
+    check_split_line( "aaa bbb ccc", "aaa|bbb|ccc" );
+    check_split_line( "  aaa   bbb   ccc  ", "aaa|bbb|ccc" );
+    check_split_line( "", "" );
+    check_split_line( "aa=\"xxx\" bb=\"yyy\" cc=\"zzz\"", "aa=\"xxx\"|bb=\"yyy\"|cc=\"zzz\"" );
+    check_split_line( "  aa=\"xxx\"   bb=\"yyy\"   cc=\"zzz\"  ", "aa=\"xxx\"|bb=\"yyy\"|cc=\"zzz\"" );
+
+    // Whitespace in quoted strings
+    check_split_line( "aa=\"x  x x\" bb=\"yy y\" cc=\"zzz\"", "aa=\"x  x x\"|bb=\"yy y\"|cc=\"zzz\"" );
+    check_split_line( "aa=\"x  x x\" bb=\"yy y", "aa=\"x  x x\"|bb=\"yy y" );
+
+    // Escaped quote in string
+    check_split_line( "aa=\"x\\\"xx\" bb=\"yyy\"", "aa=\"x\\\"xx\"|bb=\"yyy\"");
+
+    // Escaped quote in string and at the end and not properly terminated
+    check_split_line( "aa=\"x\\\"xx\" bb=\"yyy\\\"", "aa=\"x\\\"xx\"|bb=\"yyy\\\"");
+}
+
+
 BOOST_AUTO_TEST_CASE(parse1)
 {
     vector<string> input = {
@@ -224,6 +253,16 @@ BOOST_AUTO_TEST_CASE(parse_luks)
     };
 
     check(input, output);
+}
+
+
+BOOST_AUTO_TEST_CASE(split_weird_uuid_line)
+{
+    // bsc#1102572
+    string input  = "/dev/sdb: UUID=\"LSI     M-^@M-^FM-!^F^W4^R\\\"HM-^@M- ^XM-.kwM-T\" TYPE=\"ddf_raid_member\"";
+    string output = "/dev/sdb:|UUID=\"LSI     M-^@M-^FM-!^F^W4^R\\\"HM-^@M- ^XM-.kwM-T\"|TYPE=\"ddf_raid_member\"";
+
+    check_split_line( input, output );
 }
 
 

--- a/testsuite/SystemInfo/blkid.cc
+++ b/testsuite/SystemInfo/blkid.cc
@@ -225,3 +225,27 @@ BOOST_AUTO_TEST_CASE(parse_luks)
 
     check(input, output);
 }
+
+
+BOOST_AUTO_TEST_CASE(weird_uuid)
+{
+     // bsc#1102572
+    vector<string> input = {
+        "/dev/sdb: UUID=\"LSI     M-^@M-^FM-!^F^W4^R\\\"HM-^@M- ^XM-.kwM-T\" TYPE=\"ddf_raid_member\"",
+        "/dev/sda: UUID=\"LSI     M-^@M-^FM-!^F^W4^R\\\"HM-^@M- ^XM-.kwM-T\" TYPE=\"ddf_raid_member\"",
+        "/dev/md126: PTUUID=\"361b9912\" PTTYPE=\"dos\"",
+        "/dev/md126p1: LABEL=\"LINSERV\" UUID=\"88B5-20E8\" TYPE=\"vfat\" PARTUUID=\"361b9912-01\"",
+        "/dev/md126p2: LABEL=\"RAID1\" UUID=\"BAE2-F35E\" TYPE=\"vfat\" PARTUUID=\"361b9912-02\""
+    };
+
+    vector<string> output = {
+        // Alpha-sorted by map key, thus the different order than in the input
+	"data[/dev/md126p1] -> is-fs:true fs-type:vfat fs-uuid:88B5-20E8 fs-label:LINSERV",
+	"data[/dev/md126p2] -> is-fs:true fs-type:vfat fs-uuid:BAE2-F35E fs-label:RAID1",
+        // No output for /dev/md126 because it's irrelevant (partitionable device, nothing else)
+	"data[/dev/sda] -> is-md:true",
+	"data[/dev/sdb] -> is-md:true"
+    };
+
+    check(input, output);
+}


### PR DESCRIPTION
## Trello

https://trello.com/c/spdBxnv9/371-betasles-15-p3-1102572-probing-fails-while-parsing-a-uuid-with-protected-quote

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1102572

## Problem

When a UUID has weird characters, the _blkid_ command's output may contain escaped quotes `\"` which broke the old parser that was left over from the old libstorage.

## Solution

Wrote a new parser to split one line of the output. Since the generic `splitString()` parser from `Utils/AppUtil.cpp` is too generic to allow for that, that old one could not really be adapted while keeping it as generic as it is.

Also added quite a few unit tests for that new low-level `split_line()` parser to test fringe cases.