### PR TITLE
- mark LICENSE file as license

### DIFF
--- a/libstorage-ng.spec.in
+++ b/libstorage-ng.spec.in
@@ -183,7 +183,7 @@ touch %{buildroot}/run/libstorage-ng/lock
 
 %files -n %{libname}
 %defattr(-,root,root)
-%doc AUTHORS LICENSE
+%license AUTHORS LICENSE
 %{_libdir}/libstorage-ng.so.*
 %ghost /run/libstorage-ng
 


### PR DESCRIPTION
Otherwise 'osc build' complains:

(W) found COPYING or LICENSE file marked as %doc, please mark as %license instead
