### PR TITLE
New CompoundActions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,7 @@ AC_OUTPUT(
 	storage/Makefile
 	storage/Version.h:storage/Version.h.in
 	storage/CompoundAction/Makefile
+	storage/CompoundAction/Formatter/Makefile
 	storage/Devices/Makefile
 	storage/Filesystems/Makefile
 	storage/Holders/Makefile

--- a/storage/CompoundAction/Formatter.cc
+++ b/storage/CompoundAction/Formatter.cc
@@ -143,10 +143,7 @@ namespace storage
     {
 	std::vector<const BlkDevice *> sorted_devices = devices;
 	std::sort( sorted_devices.begin(), sorted_devices.end(),
-		   [](const BlkDevice * a, const BlkDevice * b) -> bool
-		       {
-			   return a->get_name() < b->get_name();
-		       });
+                   BlkDevice::compare_by_name );
 
 	Text text;
 

--- a/storage/CompoundAction/Formatter.cc
+++ b/storage/CompoundAction/Formatter.cc
@@ -22,6 +22,7 @@
 
 #include "storage/CompoundAction/Formatter.h"
 #include "storage/Filesystems/MountPoint.h"
+#include "storage/Devices/DeviceImpl.h"
 
 
 namespace storage
@@ -29,8 +30,17 @@ namespace storage
 
     using std::string;
 
-    CompoundAction::Formatter::Formatter(const CompoundAction::Impl* compound_action)
-    : compound_action(compound_action) {}
+    CompoundAction::Formatter::Formatter(const CompoundAction::Impl* compound_action,
+                                         const string & device_classname)
+    : _compound_action(compound_action)
+    , _device_classname(device_classname)
+    {
+        _creating   = has_create(_device_classname);
+        _deleting   = has_delete(_device_classname);
+        _formatting = has_create<storage::BlkFilesystem>();
+        _encrypting = has_create<storage::Encryption>();
+        _mounting   = has_create<storage::MountPoint>();
+    }
 
 
     CompoundAction::Formatter::~Formatter() {}
@@ -42,6 +52,53 @@ namespace storage
 	return text().translated;
     }
 
+
+    bool
+    CompoundAction::Formatter::has_create(const string &device_classname) const
+    {
+        if (device_classname.empty())
+            return false;
+
+        for (const Action::Base * action : _compound_action->get_commit_actions())
+        {
+            const Action::Create * create_action = dynamic_cast<const Action::Create *>(action);
+
+            if (create_action)
+            {
+                const Device * device = create_action->get_device(_compound_action->get_actiongraph()->get_impl());
+
+                if (device &&  device->get_impl().get_classname() == device_classname)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    bool
+    CompoundAction::Formatter::has_delete(const string &device_classname) const
+    {
+        if (device_classname.empty())
+            return false;
+
+        for (const Action::Base * action : _compound_action->get_commit_actions())
+        {
+            const Action::Delete * delete_action = dynamic_cast<const Action::Delete *>(action);
+
+            if (delete_action)
+            {
+                Device * device = delete_action->get_device(_compound_action->get_actiongraph()->get_impl());
+
+                if (device &&  device->get_impl().get_classname() == device_classname)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+
     const BlkFilesystem*
     CompoundAction::Formatter::get_created_filesystem() const
     {
@@ -49,7 +106,7 @@ namespace storage
 
 	if (action)
 	{
-	    auto device = CompoundAction::Impl::device(compound_action->get_actiongraph(), action);
+	    auto device = CompoundAction::Impl::device(_compound_action->get_actiongraph(), action);
 	    return to_blk_filesystem(device);
 	}
 
@@ -64,7 +121,7 @@ namespace storage
 
 	if (action)
 	{
-	    auto device = CompoundAction::Impl::device(compound_action->get_actiongraph(), action);
+	    auto device = CompoundAction::Impl::device(_compound_action->get_actiongraph(), action);
 	    return to_mount_point(device);
 	}
 
@@ -75,8 +132,8 @@ namespace storage
     Text
     CompoundAction::Formatter::default_text() const
     {
-	const CommitData commit_data(compound_action->get_actiongraph()->get_impl(), Tense::SIMPLE_PRESENT);
-	auto first_action = compound_action->get_commit_actions().front();
+	const CommitData commit_data(_compound_action->get_actiongraph()->get_impl(), Tense::SIMPLE_PRESENT);
+	auto first_action = _compound_action->get_commit_actions().front();
 	return first_action->text(commit_data);
     }
 

--- a/storage/CompoundAction/Formatter.cc
+++ b/storage/CompoundAction/Formatter.cc
@@ -137,4 +137,35 @@ namespace storage
 	return first_action->text(commit_data);
     }
 
+
+    Text
+    CompoundAction::Formatter::format_devices_text(const std::vector<const BlkDevice *> &devices)
+    {
+	std::vector<const BlkDevice *> sorted_devices = devices;
+	std::sort( sorted_devices.begin(), sorted_devices.end(),
+		   [](const BlkDevice * a, const BlkDevice * b) -> bool
+		       {
+			   return a->get_name() < b->get_name();
+		       });
+
+	Text text;
+
+	for ( const BlkDevice * device: sorted_devices )
+	{
+	    if ( ! text.translated.empty() )
+		text += Text( ", ", ", " );
+
+	    // TRANSLATORS:
+	    // %1$s is replaced with the the device name (e.g. /dev/sdc1),
+	    // %2$s is replaced with the the size (e.g. 60 GiB)
+	    Text dev_text = _( "%1$s (%2$s)" );
+
+	    text += sformat( dev_text,
+			     device->get_name().c_str(),
+			     device->get_size_string().c_str() );
+	}
+
+	return text;
+    }
+
 }

--- a/storage/CompoundAction/Formatter.h
+++ b/storage/CompoundAction/Formatter.h
@@ -49,6 +49,7 @@ namespace storage
 	class LvmLv;
 	class LvmVg;
 	class Nfs;
+        class Md;
 	class Partition;
 	class StrayBlkDevice;
 

--- a/storage/CompoundAction/Formatter.h
+++ b/storage/CompoundAction/Formatter.h
@@ -47,6 +47,7 @@ namespace storage
 	class LvmVg;
 	class Nfs;
 	class Partition;
+	class StrayBlkDevice;
 
 	Formatter(const CompoundAction::Impl* compound_action);
 	virtual ~Formatter();

--- a/storage/CompoundAction/Formatter.h
+++ b/storage/CompoundAction/Formatter.h
@@ -43,6 +43,7 @@ namespace storage
 
     public:
 
+	class Bcache;
 	class Btrfs;
 	class BtrfsSubvolume;
 	class LvmLv;
@@ -52,7 +53,7 @@ namespace storage
 	class StrayBlkDevice;
 
 	Formatter(const CompoundAction::Impl* compound_action,
-                  const string & device_classname = string() );
+		  const string & device_classname = string() );
 	virtual ~Formatter();
 
 	string string_representation() const;
@@ -67,15 +68,15 @@ namespace storage
 
 	const MountPoint* get_created_mount_point() const;
 
-        const char * get_device_classname() const;
+	const char * get_device_classname() const;
 
 	Text default_text() const;
 
-        // See also the template has_create()
-        bool has_create(const string &classname) const;
+	// See also the template has_create()
+	bool has_create(const string &classname) const;
 
-        // See also the template has_delete()
-        bool has_delete(const string &classname) const;
+	// See also the template has_delete()
+	bool has_delete(const string &classname) const;
 
 	template <typename Type>
 	bool has_action() const
@@ -97,7 +98,7 @@ namespace storage
 	}
 
 
-        // See also has_create(const string&)
+	// See also has_create(const string&)
 	template <typename Type>
 	bool has_create() const
 	{
@@ -119,7 +120,7 @@ namespace storage
 	}
 
 
-        // See also has_delete(const string&)
+	// See also has_delete(const string&)
 	template <typename Type>
 	bool has_delete() const
 	{
@@ -141,28 +142,28 @@ namespace storage
 	}
 
 
-        // Predicates
+	// Predicates
 
-        virtual bool creating()   const { return _creating;   }
-        virtual bool deleting()   const { return _deleting;   }
-        virtual bool encrypting() const { return _encrypting; }
-        virtual bool formatting() const { return _formatting; }
-        virtual bool mounting()   const { return _mounting;   }
+	virtual bool creating()	  const { return _creating;   }
+	virtual bool deleting()	  const { return _deleting;   }
+	virtual bool encrypting() const { return _encrypting; }
+	virtual bool formatting() const { return _formatting; }
+	virtual bool mounting()	  const { return _mounting;   }
 
-        // Getters
+	// Getters
 
-        string get_mount_point()     const { return get_created_filesystem()->get_mount_point()->get_path(); }
-        string get_filesystem_type() const { return get_created_filesystem()->get_displayname(); }
+	string get_mount_point()     const { return get_created_filesystem()->get_mount_point()->get_path(); }
+	string get_filesystem_type() const { return get_created_filesystem()->get_displayname(); }
 
     protected:
 
 	const CompoundAction::Impl* _compound_action;
-        string     _device_classname;
-        bool       _creating;
-        bool       _deleting;
-        bool       _encrypting;
-        bool       _formatting;
-        bool       _mounting;
+	string  _device_classname;
+	bool	_creating;
+	bool	_deleting;
+	bool	_encrypting;
+	bool	_formatting;
+	bool	_mounting;
     };
 
 }

--- a/storage/CompoundAction/Formatter.h
+++ b/storage/CompoundAction/Formatter.h
@@ -59,6 +59,8 @@ namespace storage
 
 	string string_representation() const;
 
+        static Text format_devices_text(const std::vector<const BlkDevice *> &devices);
+
     private:
 
 	virtual Text text() const = 0;

--- a/storage/CompoundAction/Formatter.h
+++ b/storage/CompoundAction/Formatter.h
@@ -32,6 +32,8 @@
 #include "storage/Devices/Encryption.h"
 #include "storage/Utils/Text.h"
 
+using std::string;
+
 
 namespace storage
 {
@@ -49,10 +51,11 @@ namespace storage
 	class Partition;
 	class StrayBlkDevice;
 
-	Formatter(const CompoundAction::Impl* compound_action);
+	Formatter(const CompoundAction::Impl* compound_action,
+                  const string & device_classname = string() );
 	virtual ~Formatter();
 
-	std::string string_representation() const;
+	string string_representation() const;
 
     private:
 
@@ -64,7 +67,15 @@ namespace storage
 
 	const MountPoint* get_created_mount_point() const;
 
+        const char * get_device_classname() const;
+
 	Text default_text() const;
+
+        // See also the template has_create()
+        bool has_create(const string &classname) const;
+
+        // See also the template has_delete()
+        bool has_delete(const string &classname) const;
 
 	template <typename Type>
 	bool has_action() const
@@ -76,7 +87,7 @@ namespace storage
 	template <typename Type>
 	const Action::Base* get_action() const
 	{
-	    for(auto action : compound_action->get_commit_actions())
+	    for (auto action : _compound_action->get_commit_actions())
 	    {
 		if (is_action_of_type<const Type>(action))
 		    return action;
@@ -86,6 +97,7 @@ namespace storage
 	}
 
 
+        // See also has_create(const string&)
 	template <typename Type>
 	bool has_create() const
 	{
@@ -96,9 +108,9 @@ namespace storage
 	template <typename Type>
 	const Action::Base* get_create() const
 	{
-	    for(auto action : compound_action->get_commit_actions())
+	    for (auto action : _compound_action->get_commit_actions())
 	    {
-		auto device = CompoundAction::Impl::device(compound_action->get_actiongraph(), action);
+		auto device = CompoundAction::Impl::device(_compound_action->get_actiongraph(), action);
 		if (is_create(action) && is_device_of_type<const Type>(device))
 		    return action;
 	    }
@@ -107,6 +119,7 @@ namespace storage
 	}
 
 
+        // See also has_delete(const string&)
 	template <typename Type>
 	bool has_delete() const
 	{
@@ -117,9 +130,9 @@ namespace storage
 	template <typename Type>
 	const Action::Base* get_delete() const
 	{
-	    for(auto action : compound_action->get_commit_actions())
+	    for (auto action : _compound_action->get_commit_actions())
 	    {
-		auto device = CompoundAction::Impl::device(compound_action->get_actiongraph(), action);
+		auto device = CompoundAction::Impl::device(_compound_action->get_actiongraph(), action);
 		if (storage::is_delete(action) && is_device_of_type<const Type>(device))
 		    return action;
 	    }
@@ -130,9 +143,11 @@ namespace storage
 
         // Predicates
 
-        bool encrypting() const { return has_create<storage::Encryption>();    }
-        bool formatting() const { return has_create<storage::BlkFilesystem>(); }
-        bool mounting()   const { return has_create<storage::MountPoint>();    }
+        virtual bool creating()   const { return _creating;   }
+        virtual bool deleting()   const { return _deleting;   }
+        virtual bool encrypting() const { return _encrypting; }
+        virtual bool formatting() const { return _formatting; }
+        virtual bool mounting()   const { return _mounting;   }
 
         // Getters
 
@@ -141,8 +156,13 @@ namespace storage
 
     protected:
 
-	const CompoundAction::Impl* compound_action;
-
+	const CompoundAction::Impl* _compound_action;
+        string     _device_classname;
+        bool       _creating;
+        bool       _deleting;
+        bool       _encrypting;
+        bool       _formatting;
+        bool       _mounting;
     };
 
 }

--- a/storage/CompoundAction/Formatter/.gitignore
+++ b/storage/CompoundAction/Formatter/.gitignore
@@ -1,0 +1,1 @@
+libcompformatter.la

--- a/storage/CompoundAction/Formatter/Bcache.cc
+++ b/storage/CompoundAction/Formatter/Bcache.cc
@@ -280,10 +280,11 @@ namespace storage
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Create bcache %1$s on %2$s (%3$s) with %4$s" );
 
-	return sformat ( text,
-                         get_device_name().c_str(),
-                         get_size().c_str(),
-                         get_filesystem_type().c_str() );
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        get_filesystem_type().c_str() );
     }
 
 

--- a/storage/CompoundAction/Formatter/Bcache.cc
+++ b/storage/CompoundAction/Formatter/Bcache.cc
@@ -37,6 +37,7 @@ namespace storage
 	bcache( to_bcache( compound_action->get_target_device() ) ),
 	bcache_cset( bcache->get_bcache_cset() )
     {
+        // NOP
     }
 
 

--- a/storage/CompoundAction/Formatter/Bcache.cc
+++ b/storage/CompoundAction/Formatter/Bcache.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) 2018 SUSE LLC
  *
  * All Rights Reserved.
  *

--- a/storage/CompoundAction/Formatter/Bcache.cc
+++ b/storage/CompoundAction/Formatter/Bcache.cc
@@ -347,7 +347,8 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
 	Text text = _( "Encrypt bcache %1$s on %2$s (%3$s)" );
 
 	return sformat( text,

--- a/storage/CompoundAction/Formatter/Bcache.cc
+++ b/storage/CompoundAction/Formatter/Bcache.cc
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2017 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+
+#include "storage/CompoundAction/Formatter/Bcache.h"
+#include "storage/Devices/BcacheImpl.h"
+#include "storage/Devices/LvmPv.h"
+#include "storage/Filesystems/Swap.h"
+
+
+namespace storage
+{
+
+    CompoundAction::Formatter::Bcache::Bcache(const CompoundAction::Impl* compound_action) :
+	CompoundAction::Formatter(compound_action, "Bcache"),
+	bcache(to_bcache(compound_action->get_target_device()))
+    {}
+
+
+    Text
+    CompoundAction::Formatter::Bcache::text() const
+    {
+	if ( has_create<storage::LvmPv>() )
+	{
+	    if ( encrypting() )
+		return encrypted_pv_text();
+	    else
+		return pv_text();
+	}
+	else if ( formatting() && is_swap( get_created_filesystem() ) )
+	{
+	    if ( encrypting() )
+                return format_as_encrypted_swap_text();
+            else
+                return format_as_swap_text();
+	}
+	else
+	{
+	    if ( encrypting() && formatting() && mounting() )
+		return encrypted_with_fs_and_mount_point_text();
+
+	    else if ( encrypting() && formatting() )
+		return encrypted_with_fs_text();
+
+	    else if ( encrypting() )
+		return encrypted_text();
+
+	    else if ( formatting() && mounting() )
+		return fs_and_mount_point_text();
+
+	    else if ( formatting() )
+		return fs_text();
+
+	    else if ( mounting() )
+		return mount_point_text();
+
+	    else
+		return default_text();
+	}
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::format_as_swap_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
+	// %2$s is replaced by size (e.g. 2GiB)
+	Text text = _("Format bcache %1$s (%2$s) as swap");
+
+	return sformat(text, get_device_name().c_str(), get_size().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::format_as_encrypted_swap_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
+	// %2$s is replaced by size (e.g. 2GiB)
+	Text text = _("Format bcache %1$s (%2$s) as encryped swap");
+
+	return sformat(text, get_device_name().c_str(), get_size().c_str());
+    }
+
+    Text
+    CompoundAction::Formatter::Bcache::encrypted_pv_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
+	// %2$s is replaced by size (e.g. 2GiB)
+	Text text = _("Create LVM physical volume over encrypted %1$s (%2$s)");
+
+	return sformat(text, get_device_name().c_str(), get_size().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::pv_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
+	// %2$s is replaced by size (e.g. 2GiB)
+	Text text = _("Create LVM physical volume over %1$s (%2$s)");
+
+	return sformat(text, get_device_name().c_str(), get_size().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::encrypted_with_fs_and_mount_point_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
+	// %2$s is replaced by size (e.g. 2GiB),
+	// %3$s is replaced by mount point (e.g. /home),
+	// %4$s is replaced by file system name (e.g. ext4)
+	Text text = _("Encrypt bcache %1$s (%2$s) for %3$s with %4$s");
+
+	return sformat(text,
+		       get_device_name().c_str(),
+		       get_size().c_str(),
+		       get_mount_point().c_str(),
+		       get_filesystem_type().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::encrypted_with_fs_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
+	// %2$s is replaced by size (e.g. 2GiB),
+	// %3$s is replaced by file system name (e.g. ext4)
+	Text text = _("Encrypt bcache %1$s (%2$s) with %3$s");
+
+	return sformat(text,
+		       get_device_name().c_str(),
+		       get_size().c_str(),
+		       get_filesystem_type().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::encrypted_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
+	// %2$s is replaced by size (e.g. 2GiB),
+	Text text = _("Encrypt bcache %1$s (%2$s)");
+
+	return sformat(text, get_device_name().c_str(), get_size().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::fs_and_mount_point_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
+	// %2$s is replaced by size (e.g. 2GiB),
+	// %3$s is replaced by mount point (e.g. /home),
+	// %4$s is replaced by file system name (e.g. ext4)
+	Text text = _("Format bcache %1$s (%2$s) for %3$s with %4$s");
+
+	return sformat(text,
+		       get_device_name().c_str(),
+		       get_size().c_str(),
+		       get_mount_point().c_str(),
+		       get_filesystem_type().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::fs_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
+	// %2$s is replaced by size (e.g. 2GiB),
+	// %3$s is replaced by file system name (e.g. ext4)
+	Text text = _("Format bcache %1$s (%2$s) with %3$s");
+
+	return sformat(text,
+		       get_device_name().c_str(),
+		       get_size().c_str(),
+		       get_filesystem_type().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::mount_point_text() const
+    {
+	string mount_point = get_created_mount_point()->get_path();
+
+	// TRANSLATORS:
+	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
+	// %2$s is replaced by size (e.g. 2GiB),
+	// %3$s is replaced by mount point (e.g. /home)
+	Text text = _("Mount bcache %1$s (%2$s) at %3$s");
+
+	return sformat(text,
+		       get_device_name().c_str(),
+		       get_size().c_str(),
+                       mount_point.c_str());
+    }
+
+}

--- a/storage/CompoundAction/Formatter/Bcache.cc
+++ b/storage/CompoundAction/Formatter/Bcache.cc
@@ -119,22 +119,7 @@ namespace storage
     Text
     CompoundAction::Formatter::Bcache::bcache_cset_text() const
     {
-	Text dev_list_text;
-
-	for ( const BlkDevice * device: bcache_cset->get_blk_devices() )
-	{
-	    if ( ! dev_list_text.translated.empty() )
-		dev_list_text += Text( ", ", ", " );
-
-	    // TRANSLATORS:
-	    // %1$s is replaced with the the device name (e.g. /dev/sdc1),
-	    // %2$s is replaced with the the size (e.g. 60 GiB)
-	    Text dev_text = _( "%1$s (%2$s)" );
-
-	    dev_list_text += sformat( dev_text,
-                                      device->get_name().c_str(),
-                                      device->get_size_string().c_str() );
-	}
+	Text dev_list_text = format_devices_text( bcache_cset->get_blk_devices() );
 
 	// TRANSLATORS:
 	// %1$s is replaced with the the bcache name (e.g. /dev/bcache0),

--- a/storage/CompoundAction/Formatter/Bcache.cc
+++ b/storage/CompoundAction/Formatter/Bcache.cc
@@ -25,7 +25,6 @@
 #include "storage/CompoundAction/Formatter/Bcache.h"
 #include "storage/Devices/BcacheImpl.h"
 #include "storage/Devices/BcacheCsetImpl.h"
-#include "storage/Devices/LvmPv.h"
 #include "storage/Filesystems/Swap.h"
 
 
@@ -33,10 +32,10 @@
 namespace storage
 {
 
-    CompoundAction::Formatter::Bcache::Bcache(const CompoundAction::Impl* compound_action) :
-	CompoundAction::Formatter(compound_action, "Bcache"),
-	bcache(to_bcache(compound_action->get_target_device())),
-        bcache_cset(bcache->get_bcache_cset())
+    CompoundAction::Formatter::Bcache::Bcache( const CompoundAction::Impl* compound_action ):
+	CompoundAction::Formatter( compound_action, "Bcache" ),
+	bcache( to_bcache( compound_action->get_target_device() ) ),
+	bcache_cset( bcache->get_bcache_cset() )
     {
     }
 
@@ -44,39 +43,55 @@ namespace storage
     Text
     CompoundAction::Formatter::Bcache::text() const
     {
-        Text text = bcache_text();
-        Text cset_text = bcache_cset_text();
+	Text text = bcache_text();
+	Text cset_text = bcache_cset_text();
 
-        if ( ! cset_text.translated.empty() )
-        {
-            text += Text( "\n", "\n" );
-            text += cset_text;
-        }
+	if ( ! cset_text.translated.empty() )
+	{
+	    text += Text( "\n", "\n" );
+	    text += cset_text;
+	}
 
-        return text;
+	return text;
     }
 
 
     Text
     CompoundAction::Formatter::Bcache::bcache_text() const
     {
-	if ( has_create<storage::LvmPv>() )
-	{
-	    if ( encrypting() )
-		return encrypted_pv_text();
-	    else
-		return pv_text();
-	}
+	if ( deleting() )
+	    return delete_text();
+
 	else if ( formatting() && is_swap( get_created_filesystem() ) )
 	{
 	    if ( encrypting() )
-                return format_as_encrypted_swap_text();
-            else
-                return format_as_swap_text();
+		return create_encrypted_with_swap_text();
+
+	    else
+		return create_with_swap_text();
 	}
+
 	else
 	{
-	    if ( encrypting() && formatting() && mounting() )
+	    if ( creating() && encrypting() && formatting() && mounting() )
+		return create_encrypted_with_fs_and_mount_point_text();
+
+	    else if ( creating() && encrypting() && formatting() )
+		return create_encrypted_with_fs_text();
+
+	    else if ( creating() && encrypting() )
+		return create_encrypted_text();
+
+	    else if ( creating() && formatting() && mounting() )
+		return create_with_fs_and_mount_point_text();
+
+	    else if ( creating() && formatting() )
+		return create_with_fs_text();
+
+	    else if ( creating() )
+		return create_text();
+
+	    else if ( encrypting() && formatting() && mounting() )
 		return encrypted_with_fs_and_mount_point_text();
 
 	    else if ( encrypting() && formatting() )
@@ -103,77 +118,187 @@ namespace storage
     Text
     CompoundAction::Formatter::Bcache::bcache_cset_text() const
     {
-        Text dev_list_text;
+	Text dev_list_text;
 
-        for ( const BlkDevice * device: bcache_cset->get_blk_devices() )
-        {
-            if ( ! dev_list_text.translated.empty() )
-                dev_list_text += Text( ", ", ", " );
+	for ( const BlkDevice * device: bcache_cset->get_blk_devices() )
+	{
+	    if ( ! dev_list_text.translated.empty() )
+		dev_list_text += Text( ", ", ", " );
 
-            // TRANSLATORS:
-            // %1$s is replaced by the device name (e.g. /dev/sdc1),
-            // %2$s is replaced by the size (e.g. 60 GiB)
-            Text dev_text = _("%1$s (%2$s)");
+	    // TRANSLATORS:
+	    // %1$s is replaced with the the device name (e.g. /dev/sdc1),
+	    // %2$s is replaced with the the size (e.g. 60 GiB)
+	    Text dev_text = _( "%1$s (%2$s)" );
 
-            dev_list_text += sformat(dev_text,
-                                     device->get_name().c_str(),
-                                     device->get_size_string().c_str());
-        }
+	    dev_list_text += sformat( dev_text,
+                                      device->get_name().c_str(),
+                                      device->get_size_string().c_str() );
+	}
 
 	// TRANSLATORS:
-	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
-	// %2$s is replaced by a list of cache devices with size
-        // (e.g. "/dev/sdb1 (64 GiB), /dev/sdc1 (160 GiB)")
-        Text text = _( "Cache %1$s with %2$s" );
+	// %1$s is replaced with the the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the a list of cache devices with size
+	// (e.g. "/dev/sdb1 (64 GiB), /dev/sdc1 (160 GiB)")
+	Text text = _( "%1$s is cached by %2$s" );
 
-        return sformat(text, get_device_name().c_str(), dev_list_text.translated.c_str());
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        dev_list_text.translated.c_str() );
     }
 
 
     Text
-    CompoundAction::Formatter::Bcache::format_as_swap_text() const
+    CompoundAction::Formatter::Bcache::delete_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
-	// %2$s is replaced by size (e.g. 2GiB)
-	Text text = _("Format bcache %1$s (%2$s) as swap");
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB)
+	Text text = _( "Delete bcache %1$s on %2$s (%3$s)" );
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str() );
     }
 
 
     Text
-    CompoundAction::Formatter::Bcache::format_as_encrypted_swap_text() const
+    CompoundAction::Formatter::Bcache::create_encrypted_with_swap_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
-	// %2$s is replaced by size (e.g. 2GiB)
-	Text text = _("Format bcache %1$s (%2$s) as encryped swap");
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB)
+	Text text = _( "Create encrypted bcache %1$s on %2$s (%3$s) for swap" );
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
-    }
-
-    Text
-    CompoundAction::Formatter::Bcache::encrypted_pv_text() const
-    {
-	// TRANSLATORS:
-	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
-	// %2$s is replaced by size (e.g. 2GiB)
-	Text text = _("Create LVM physical volume over encrypted %1$s (%2$s)");
-
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str() );
     }
 
 
     Text
-    CompoundAction::Formatter::Bcache::pv_text() const
+    CompoundAction::Formatter::Bcache::create_with_swap_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
-	// %2$s is replaced by size (e.g. 2GiB)
-	Text text = _("Create LVM physical volume over %1$s (%2$s)");
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB)
+	Text text = _( "Create bcache %1$s on %2$s (%3$s) for swap" );
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::create_encrypted_with_fs_and_mount_point_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the mount point (e.g. /home),
+	// %5$s is replaced with the file system name (e.g. ext4)
+	Text text = _( "Create encrypted bcache %1$s on %2$s (%3$s) for %4$s with %5$s" );
+
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        get_mount_point().c_str(),
+                        get_filesystem_type().c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::create_encrypted_with_fs_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the file system name (e.g. ext4)
+	Text text = _( "Create encrypted bcache %1$s on %2$s (%3$s) with %4$s" );
+
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        get_filesystem_type().c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::create_encrypted_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB)
+	Text text = _( "Create encrypted bcache %1$s on %2$s (%3$s)" );
+
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::create_with_fs_and_mount_point_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the mount point (e.g. /home),
+	// %5$s is replaced with the file system name (e.g. ext4)
+	Text text = _( "Create bcache %1$s on %2$s (%3$s) for %4$s with %5$s" );
+
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        get_mount_point().c_str(),
+                        get_filesystem_type().c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::create_with_fs_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the file system name (e.g. ext4)
+	Text text = _( "Create bcache %1$s on %2$s (%3$s) with %4$s" );
+
+	return sformat ( text,
+                         get_device_name().c_str(),
+                         get_size().c_str(),
+                         get_filesystem_type().c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::create_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB)
+	Text text = _( "Create bcache %1$s on %2$s (%3$s)" );
+
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str() );
     }
 
 
@@ -181,17 +306,19 @@ namespace storage
     CompoundAction::Formatter::Bcache::encrypted_with_fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by mount point (e.g. /home),
-	// %4$s is replaced by file system name (e.g. ext4)
-	Text text = _("Encrypt bcache %1$s (%2$s) for %3$s with %4$s");
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the mount point (e.g. /home),
+	// %5$s is replaced with the file system name (e.g. ext4)
+	Text text = _( "Encrypt bcache %1$s on %2$s (%3$s) for %4$s with %5$s" );
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_mount_point().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        get_mount_point().c_str(),
+                        get_filesystem_type().c_str() );
     }
 
 
@@ -199,15 +326,17 @@ namespace storage
     CompoundAction::Formatter::Bcache::encrypted_with_fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by file system name (e.g. ext4)
-	Text text = _("Encrypt bcache %1$s (%2$s) with %3$s");
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the file system name (e.g. ext4)
+	Text text = _( "Encrypt bcache %1$s on %2$s (%3$s) with %4$s" );
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        get_filesystem_type().c_str() );
     }
 
 
@@ -215,11 +344,14 @@ namespace storage
     CompoundAction::Formatter::Bcache::encrypted_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
-	// %2$s is replaced by size (e.g. 2GiB),
-	Text text = _("Encrypt bcache %1$s (%2$s)");
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	Text text = _( "Encrypt bcache %1$s on %2$s (%3$s)" );
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str() );
     }
 
 
@@ -227,17 +359,19 @@ namespace storage
     CompoundAction::Formatter::Bcache::fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by mount point (e.g. /home),
-	// %4$s is replaced by file system name (e.g. ext4)
-	Text text = _("Format bcache %1$s (%2$s) for %3$s with %4$s");
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the mount point (e.g. /home),
+	// %5$s is replaced with the file system name (e.g. ext4)
+	Text text = _( "Format bcache %1$s on %2$s (%3$s) for %4$s with %5$s" );
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_mount_point().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        get_mount_point().c_str(),
+                        get_filesystem_type().c_str() );
     }
 
 
@@ -245,15 +379,17 @@ namespace storage
     CompoundAction::Formatter::Bcache::fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by file system name (e.g. ext4)
-	Text text = _("Format bcache %1$s (%2$s) with %3$s");
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the file system type (e.g. ext4)
+	Text text = _( "Format bcache %1$s on %2$s (%3$s) with %4$s" );
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        get_filesystem_type().c_str() );
     }
 
 
@@ -263,15 +399,17 @@ namespace storage
 	string mount_point = get_created_mount_point()->get_path();
 
 	// TRANSLATORS:
-	// %1$s is replaced by the bcache device name (e.g. /dev/bcache0),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by mount point (e.g. /home)
-	Text text = _("Mount bcache %1$s (%2$s) at %3$s");
+	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the mount point (e.g. /home)
+	Text text = _( "Mount bcache %1$s on %2$s (%3$s) at %4$s" );
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-                       mount_point.c_str());
+	return sformat( text,
+                        get_bcache_name().c_str(),
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        mount_point.c_str() );
     }
 
 }

--- a/storage/CompoundAction/Formatter/Bcache.h
+++ b/storage/CompoundAction/Formatter/Bcache.h
@@ -43,14 +43,20 @@ namespace storage
 
 	Text text() const override;
 
-        Text bcache_text() const;
-        Text bcache_cset_text() const;
+	Text bcache_text() const;
+	Text bcache_cset_text() const;
 
-        Text format_as_swap_text() const;
-        Text format_as_encrypted_swap_text() const;
-        Text encrypted_pv_text() const;
-	Text pv_text() const;
+	Text delete_text() const;
 
+	Text create_encrypted_with_swap_text() const;
+	Text create_with_swap_text() const;
+
+	Text create_encrypted_with_fs_and_mount_point_text() const;
+	Text create_encrypted_with_fs_text() const;
+	Text create_encrypted_text() const;
+	Text create_with_fs_and_mount_point_text() const;
+	Text create_with_fs_text() const;
+	Text create_text() const;
 	Text encrypted_with_fs_and_mount_point_text() const;
 	Text encrypted_with_fs_text() const;
 	Text encrypted_text() const;
@@ -58,13 +64,14 @@ namespace storage
 	Text fs_text() const;
 	Text mount_point_text() const;
 
-        string get_device_name()     const { return bcache->get_name();        }
-        string get_size()            const { return bcache->get_size_string(); }
+	string get_bcache_name() const { return bcache->get_name(); }
+	string get_device_name() const { return bcache->get_blk_device()->get_name(); }
+	string get_size()	 const { return bcache->get_size_string(); }
 
     private:
 
-	const storage::Bcache     * bcache;
-        const storage::BcacheCset * bcache_cset;
+	const storage::Bcache	  * bcache;
+	const storage::BcacheCset * bcache_cset;
     };
 
 }

--- a/storage/CompoundAction/Formatter/Bcache.h
+++ b/storage/CompoundAction/Formatter/Bcache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) 2018 SUSE LLC
  *
  * All Rights Reserved.
  *

--- a/storage/CompoundAction/Formatter/Bcache.h
+++ b/storage/CompoundAction/Formatter/Bcache.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+
+#ifndef STORAGE_FORMATTER_BCACHE_H
+#define STORAGE_FORMATTER_BCACHE_H
+
+
+#include "storage/CompoundAction/Formatter.h"
+#include "storage/Devices/Bcache.h"
+#include "storage/Filesystems/BlkFilesystem.h"
+
+
+namespace storage
+{
+
+    class CompoundAction::Formatter::Bcache: public CompoundAction::Formatter
+    {
+
+    public:
+
+	Bcache(const CompoundAction::Impl* compound_action);
+
+    private:
+
+	Text text() const override;
+
+        Text format_as_swap_text() const;
+        Text format_as_encrypted_swap_text() const;
+        Text encrypted_pv_text() const;
+	Text pv_text() const;
+
+	Text encrypted_with_fs_and_mount_point_text() const;
+	Text encrypted_with_fs_text() const;
+	Text encrypted_text() const;
+	Text fs_and_mount_point_text() const;
+	Text fs_text() const;
+	Text mount_point_text() const;
+
+        string get_device_name()     const { return bcache->get_name();        }
+        string get_size()            const { return bcache->get_size_string(); }
+
+    private:
+
+	const storage::Bcache * bcache;
+    };
+
+}
+
+#endif

--- a/storage/CompoundAction/Formatter/Bcache.h
+++ b/storage/CompoundAction/Formatter/Bcache.h
@@ -43,6 +43,9 @@ namespace storage
 
 	Text text() const override;
 
+        Text bcache_text() const;
+        Text bcache_cset_text() const;
+
         Text format_as_swap_text() const;
         Text format_as_encrypted_swap_text() const;
         Text encrypted_pv_text() const;
@@ -60,7 +63,8 @@ namespace storage
 
     private:
 
-	const storage::Bcache * bcache;
+	const storage::Bcache     * bcache;
+        const storage::BcacheCset * bcache_cset;
     };
 
 }

--- a/storage/CompoundAction/Formatter/Btrfs.cc
+++ b/storage/CompoundAction/Formatter/Btrfs.cc
@@ -76,7 +76,7 @@ namespace storage
     CompoundAction::Formatter::Btrfs::delete_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by name of devices separated by comma (e.g. /dev/sda1, /dev/sda2)
+	// %1$s is replaced with the names of the devices separated by comma (e.g. /dev/sda1, /dev/sda2)
         Text text = _("Delete file system btrfs on %1$s");
 
         return sformat(text, blk_devices_string_representation().c_str());
@@ -87,8 +87,8 @@ namespace storage
     CompoundAction::Formatter::Btrfs::create_and_mount_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by name of devices separated by comma (e.g. /dev/sda1, /dev/sda2),
-	// %2$s is replaced by mount point (e.g. /home)
+	// %1$s is replaced with the names of the devices separated by comma (e.g. /dev/sda1, /dev/sda2),
+	// %2$s is replaced with the mount point (e.g. /home)
         Text text = _("Create file system btrfs on %1$s and mount at %2$s");
 
         return sformat(text,
@@ -101,7 +101,7 @@ namespace storage
     CompoundAction::Formatter::Btrfs::create_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by name of devices separated by comma (e.g. /dev/sda1, /dev/sda2)
+	// %1$s is replaced with the names of the devices separated by comma (e.g. /dev/sda1, /dev/sda2)
         Text text = _("Create file system btrfs on %1$s");
 
         return sformat(text, blk_devices_string_representation().c_str());
@@ -112,8 +112,8 @@ namespace storage
     CompoundAction::Formatter::Btrfs::mount_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by name of devices separated by comma (e.g. /dev/sda1, /dev/sda2),
-	// %2$s is replaced by mount point (e.g. /home)
+	// %1$s is replaced with the names of the devices separated by comma (e.g. /dev/sda1, /dev/sda2),
+	// %2$s is replaced with the mount point (e.g. /home)
         Text text = _("Mount file system btrfs on %1$s at %2$s");
 
         return sformat(text,
@@ -126,8 +126,8 @@ namespace storage
     CompoundAction::Formatter::Btrfs::unmount_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by name of devices separated by comma (e.g. /dev/sda1, /dev/sda2),
-	// %2$s is replaced by mount point (e.g. /home)
+	// %1$s is replaced with the names of the devices separated by comma (e.g. /dev/sda1, /dev/sda2),
+	// %2$s is replaced with the mount point (e.g. /home)
         Text text = _("Unmount file system btrfs on %1$s at %2$s");
 
         return sformat(text,

--- a/storage/CompoundAction/Formatter/Btrfs.cc
+++ b/storage/CompoundAction/Formatter/Btrfs.cc
@@ -30,7 +30,7 @@ namespace storage
 {
 
     CompoundAction::Formatter::Btrfs::Btrfs(const CompoundAction::Impl* compound_action) :
-	CompoundAction::Formatter(compound_action),
+	CompoundAction::Formatter(compound_action, "Btrfs"),
 	btrfs(to_btrfs(compound_action->get_target_device()))
     {}
 
@@ -49,22 +49,22 @@ namespace storage
     Text
     CompoundAction::Formatter::Btrfs::text() const
     {
-	if (has_delete<storage::Btrfs>())
+	if ( deleting() )
 	    return delete_text();
 
-	else if (has_create<storage::Btrfs>())
+	else if ( creating() )
 	{
-	    if (has_create<storage::MountPoint>())
+	    if ( mounting() )
 		return create_and_mount_text();
 
 	    else
 		return create_text();
 	}
 
-	else if (has_create<storage::MountPoint>())
+	else if ( mounting() )
 	    return mount_text();
 
-	else if (has_delete<storage::MountPoint>())
+	else if ( has_delete<storage::MountPoint>() )
 	    return unmount_text();
 
 	else

--- a/storage/CompoundAction/Formatter/BtrfsSubvolume.cc
+++ b/storage/CompoundAction/Formatter/BtrfsSubvolume.cc
@@ -65,8 +65,8 @@ namespace storage
     CompoundAction::Formatter::BtrfsSubvolume::delete_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by subvolume path (e.g. var/log),
-	// %2$s is replaced by block device name (e.g. /dev/sda1)
+	// %1$s is replaced with the subvolume path (e.g. var/log),
+	// %2$s is replaced with the block device name (e.g. /dev/sda1)
         Text text = _("Delete subvolume %1$s on %2$s");
 
         return sformat(text, subvolume->get_path().c_str(), get_blk_device()->get_name().c_str());
@@ -77,8 +77,8 @@ namespace storage
     CompoundAction::Formatter::BtrfsSubvolume::create_with_no_copy_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by subvolume path (e.g. var/log),
-	// %2$s is replaced by block device name (e.g. /dev/sda1)
+	// %1$s is replaced with the subvolume path (e.g. var/log),
+	// %2$s is replaced with the block device name (e.g. /dev/sda1)
         Text text = _("Create subvolume %1$s on %2$s with option 'no copy on write'");
 
         return sformat(text, subvolume->get_path().c_str(), get_blk_device()->get_name().c_str());
@@ -89,8 +89,8 @@ namespace storage
     CompoundAction::Formatter::BtrfsSubvolume::create_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by subvolume path (e.g. var/log),
-	// %2$s is replaced by block device name (e.g. /dev/sda1)
+	// %1$s is replaced with the subvolume path (e.g. var/log),
+	// %2$s is replaced with the block device name (e.g. /dev/sda1)
         Text text = _("Create subvolume %1$s on %2$s");
 
         return sformat(text, subvolume->get_path().c_str(), get_blk_device()->get_name().c_str());

--- a/storage/CompoundAction/Formatter/LvmLv.cc
+++ b/storage/CompoundAction/Formatter/LvmLv.cc
@@ -92,9 +92,9 @@ namespace storage
     CompoundAction::Formatter::LvmLv::create_encrypted_with_swap_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system)
 	Text text = _("Create encrypted LVM logical volume %1$s (%2$s) on volume group %3$s for swap");
 
 	return sformat(text,
@@ -108,9 +108,9 @@ namespace storage
     CompoundAction::Formatter::LvmLv::create_with_swap_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system)
 	Text text = _("Create LVM logical volume %1$s (%2$s) on volume group %3$s for swap");
 
 	return sformat(text,
@@ -124,11 +124,11 @@ namespace storage
     CompoundAction::Formatter::LvmLv::create_encrypted_with_fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system),
-	// %4$s is replaced by mount point (e.g. /home),
-	// %5$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system),
+	// %4$s is replaced with the mount point (e.g. /home),
+	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create encrypted LVM logical volume %1$s (%2$s) on volume group %3$s for %4$s with %5$s");
 
 	return sformat(text,
@@ -144,10 +144,10 @@ namespace storage
     CompoundAction::Formatter::LvmLv::create_encrypted_with_fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system),
-	// %4$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system),
+	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create encrypted LVM logical volume %1$s (%2$s) on volume group %3$s with %4$s");
 
 	return sformat(text,
@@ -162,9 +162,9 @@ namespace storage
     CompoundAction::Formatter::LvmLv::create_encrypted_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system)
 	Text text = _("Create encrypted LVM logical volume %1$s (%2$s) on volume group %3$s");
 
 	return sformat(text,
@@ -178,11 +178,11 @@ namespace storage
     CompoundAction::Formatter::LvmLv::create_with_fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system),
-	// %4$s is replaced by mount point (e.g. /home),
-	// %5$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system),
+	// %4$s is replaced with the mount point (e.g. /home),
+	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create LVM logical volume %1$s (%2$s) on volume group %3$s for %4$s with %5$s");
 
 	return sformat(text,
@@ -198,10 +198,10 @@ namespace storage
     CompoundAction::Formatter::LvmLv::create_with_fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system),
-	// %4$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system),
+	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create LVM logical volume %1$s (%2$s) on volume group %3$s with %4$s");
 
 	return sformat(text,
@@ -216,9 +216,9 @@ namespace storage
     CompoundAction::Formatter::LvmLv::create_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system)
 	Text text = _("Create LVM logical volume %1$s (%2$s) on volume group %3$s");
 
 	return sformat(text,
@@ -232,11 +232,11 @@ namespace storage
     CompoundAction::Formatter::LvmLv::encrypted_with_fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system),
-	// %4$s is replaced by mount point (e.g. /home),
-	// %5$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system),
+	// %4$s is replaced with the mount point (e.g. /home),
+	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Encrypt LVM logical volume %1$s (%2$s) on volume group %3$s for %4$s with %5$s");
 
 	return sformat(text,
@@ -252,10 +252,10 @@ namespace storage
     CompoundAction::Formatter::LvmLv::encrypted_with_fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system),
-	// %4$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system),
+	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Encrypt LVM logical volume %1$s (%2$s) on volume group %3$s with %4$s");
 
 	return sformat(text,
@@ -270,9 +270,9 @@ namespace storage
     CompoundAction::Formatter::LvmLv::encrypted_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system)
 	Text text = _("Encrypt LVM logical volume %1$s (%2$s) on volume group %3$s");
 
 	return sformat(text,
@@ -286,11 +286,11 @@ namespace storage
     CompoundAction::Formatter::LvmLv::fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system),
-	// %4$s is replaced by mount point (e.g. /home),
-	// %5$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system),
+	// %4$s is replaced with the mount point (e.g. /home),
+	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Format LVM logical volume %1$s (%2$s) on volume group %3$s for %4$s with %5$s");
 
 	return sformat(text,
@@ -306,10 +306,10 @@ namespace storage
     CompoundAction::Formatter::LvmLv::fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system),
-	// %4$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system),
+	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Format LVM logical volume %1$s (%2$s) on volume group %3$s with %4$s");
 
 	return sformat(text,
@@ -326,10 +326,10 @@ namespace storage
 	string mount_point = get_created_mount_point()->get_path();
 
 	// TRANSLATORS:
-	// %1$s is replaced by logical volume name (e.g. root),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by volume group name (e.g. system),
-	// %4$s is replaced by mount point (e.g. /home)
+	// %1$s is replaced with the logical volume name (e.g. root),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the volume group name (e.g. system),
+	// %4$s is replaced with the mount point (e.g. /home)
 	Text text = _("Mount LVM logical volume %1$s (%2$s) on volume group %3$s at %4$s");
 
 	return sformat(text,

--- a/storage/CompoundAction/Formatter/LvmLv.cc
+++ b/storage/CompoundAction/Formatter/LvmLv.cc
@@ -30,7 +30,7 @@ namespace storage
 {
 
     CompoundAction::Formatter::LvmLv::LvmLv(const CompoundAction::Impl* compound_action) :
-	CompoundAction::Formatter(compound_action),
+	CompoundAction::Formatter(compound_action, "LvmLv"),
 	lv(to_lvm_lv(compound_action->get_target_device()))
     {}
 

--- a/storage/CompoundAction/Formatter/LvmLv.h
+++ b/storage/CompoundAction/Formatter/LvmLv.h
@@ -59,12 +59,6 @@ namespace storage
 	Text fs_text() const;
 	Text mount_point_text() const;
 
-        // Predicates for better code readability
-
-        bool creating()      const { return has_create<storage::LvmLv>(); }
-
-        // Getters for better code readability
-
         string get_lv_name() const { return lv->get_name();                  }
         string get_vg_name() const { return lv->get_lvm_vg()->get_vg_name(); }
         string get_size()    const { return lv->get_size_string();           }

--- a/storage/CompoundAction/Formatter/LvmVg.cc
+++ b/storage/CompoundAction/Formatter/LvmVg.cc
@@ -36,7 +36,7 @@ namespace storage
 
 
     CompoundAction::Formatter::LvmVg::LvmVg(const CompoundAction::Impl* compound_action) :
-	CompoundAction::Formatter(compound_action),
+	CompoundAction::Formatter(compound_action, "LvmVg"),
 	vg(to_lvm_vg(compound_action->get_target_device()))
     {}
 
@@ -57,7 +57,7 @@ namespace storage
     Text
     CompoundAction::Formatter::LvmVg::text() const
     {
-	if (has_create<storage::LvmVg>())
+	if ( creating() )
 	{
 	    if (vg->get_lvm_pvs().size() > 0)
 		return create_with_pvs_text();
@@ -75,9 +75,9 @@ namespace storage
     CompoundAction::Formatter::LvmVg::create_with_pvs_text() const
     {
 	// TRANSLATORS: displayed before action,
-	// %1$s is replaced by volume group name (e.g. system),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by name of devices (e.g. /dev/sda1, /dev/sda2)
+	// %1$s is replaced with the volume group name (e.g. system),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the name of devices (e.g. /dev/sda1, /dev/sda2)
 	Text text = _("Create volume group %1$s (%2$s) with %3$s");
 
 	return sformat(text,
@@ -91,8 +91,8 @@ namespace storage
     CompoundAction::Formatter::LvmVg::create_text() const
     {
 	// TRANSLATORS: displayed before action,
-	// %1$s is replaced by volume group name (e.g. system),
-	// %2$s is replaced by size (e.g. 2GiB),
+	// %1$s is replaced with the volume group name (e.g. system),
+	// %2$s is replaced with the size (e.g. 2 GiB),
 	Text text = _("Create volume group %1$s (%2$s)");
 
 	return sformat(text,

--- a/storage/CompoundAction/Formatter/Makefile.am
+++ b/storage/CompoundAction/Formatter/Makefile.am
@@ -11,7 +11,8 @@ libcompformatter_la_SOURCES =				\
 	BtrfsSubvolume.h	BtrfsSubvolume.cc	\
 	Btrfs.h			Btrfs.cc		\
 	Nfs.h			Nfs.cc			\
-	StrayBlkDevice.h	StrayBlkDevice.cc
+	StrayBlkDevice.h	StrayBlkDevice.cc	\
+	Bcache.h		Bcache.cc
 
 
 pkgincludedir = $(includedir)/storage/CompoundAction/Formatter

--- a/storage/CompoundAction/Formatter/Makefile.am
+++ b/storage/CompoundAction/Formatter/Makefile.am
@@ -4,13 +4,14 @@
 
 noinst_LTLIBRARIES = libcompformatter.la
 
-libcompformatter_la_SOURCES =			\
-	Partition.h	      Partition.cc	\
-	LvmLv.h		      LvmLv.cc		\
-	LvmVg.h		      LvmVg.cc		\
-	BtrfsSubvolume.h      BtrfsSubvolume.cc	\
-	Btrfs.h		      Btrfs.cc		\
-	Nfs.h		      Nfs.cc
+libcompformatter_la_SOURCES =				\
+	Partition.h		Partition.cc		\
+	LvmLv.h			LvmLv.cc		\
+	LvmVg.h			LvmVg.cc		\
+	BtrfsSubvolume.h	BtrfsSubvolume.cc	\
+	Btrfs.h			Btrfs.cc		\
+	Nfs.h			Nfs.cc			\
+	StrayBlkDevice.h	StrayBlkDevice.cc
 
 
 pkgincludedir = $(includedir)/storage/CompoundAction/Formatter

--- a/storage/CompoundAction/Formatter/Makefile.am
+++ b/storage/CompoundAction/Formatter/Makefile.am
@@ -1,0 +1,16 @@
+#
+# Makefile.am for libstorage/storage/CompoundAction/Formatter
+#
+
+noinst_LTLIBRARIES = libcompformatter.la
+
+libcompformatter_la_SOURCES =			\
+	Partition.h	      Partition.cc	\
+	LvmLv.h		      LvmLv.cc		\
+	LvmVg.h		      LvmVg.cc		\
+	BtrfsSubvolume.h      BtrfsSubvolume.cc	\
+	Btrfs.h		      Btrfs.cc		\
+	Nfs.h		      Nfs.cc
+
+
+pkgincludedir = $(includedir)/storage/CompoundAction/Formatter

--- a/storage/CompoundAction/Formatter/Makefile.am
+++ b/storage/CompoundAction/Formatter/Makefile.am
@@ -11,6 +11,7 @@ libcompformatter_la_SOURCES =				\
 	BtrfsSubvolume.h	BtrfsSubvolume.cc	\
 	Btrfs.h			Btrfs.cc		\
 	Nfs.h			Nfs.cc			\
+	Md.h			Md.cc			\
 	StrayBlkDevice.h	StrayBlkDevice.cc	\
 	Bcache.h		Bcache.cc
 

--- a/storage/CompoundAction/Formatter/Md.cc
+++ b/storage/CompoundAction/Formatter/Md.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) 2018 SUSE LLC
  *
  * All Rights Reserved.
  *

--- a/storage/CompoundAction/Formatter/Md.cc
+++ b/storage/CompoundAction/Formatter/Md.cc
@@ -320,8 +320,8 @@ namespace storage
     CompoundAction::Formatter::Md::encrypted_with_fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced with the md name (e.g. /dev/md0),
-	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %1$s is replaced with the md level (e.g. RAID1),
+	// %2$s is replaced with the md name (e.g. /dev/md0),
 	// %3$s is replaced with the size (e.g. 2 GiB),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
@@ -340,8 +340,8 @@ namespace storage
     CompoundAction::Formatter::Md::encrypted_with_fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced with the md name (e.g. /dev/md0),
-	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %1$s is replaced with the md level (e.g. RAID1),
+	// %2$s is replaced with the md name (e.g. /dev/md0),
 	// %3$s is replaced with the size (e.g. 2 GiB),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Encrypt %1$s %2$s (%3$s) with %4$s" );
@@ -358,8 +358,9 @@ namespace storage
     CompoundAction::Formatter::Md::encrypted_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced with the md name (e.g. /dev/md0),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %1$s is replaced with the md level (e.g. RAID1),
+	// %2$s is replaced with the md name (e.g. /dev/md0),
+	// %3$s is replaced with the size (e.g. 2 GiB),
 	Text text = _( "Encrypt %1$s %2$s (%3$s)" );
 
 	return sformat( text,
@@ -373,8 +374,8 @@ namespace storage
     CompoundAction::Formatter::Md::fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced with the md name (e.g. /dev/md0),
-	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %1$s is replaced with the md level (e.g. RAID1),
+	// %2$s is replaced with the md name (e.g. /dev/md0),
 	// %3$s is replaced with the size (e.g. 2 GiB),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
@@ -393,8 +394,8 @@ namespace storage
     CompoundAction::Formatter::Md::fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced with the md name (e.g. /dev/md0),
-	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %1$s is replaced with the md level (e.g. RAID1),
+	// %2$s is replaced with the md name (e.g. /dev/md0),
 	// %3$s is replaced with the size (e.g. 2 GiB),
 	// %4$s is replaced with the file system type (e.g. ext4)
 	Text text = _( "Format %1$s %2$s (%3$s) with %4$s" );
@@ -413,8 +414,8 @@ namespace storage
 	string mount_point = get_created_mount_point()->get_path();
 
 	// TRANSLATORS:
-	// %1$s is replaced with the md name (e.g. /dev/md0),
-	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %1$s is replaced with the md level (e.g. RAID1),
+	// %2$s is replaced with the md name (e.g. /dev/md0),
 	// %3$s is replaced with the size (e.g. 2 GiB),
 	// %4$s is replaced with the mount point (e.g. /home)
 	Text text = _( "Mount %1$s %2$s (%3$s) at %4$s" );

--- a/storage/CompoundAction/Formatter/Md.cc
+++ b/storage/CompoundAction/Formatter/Md.cc
@@ -154,6 +154,7 @@ namespace storage
         //   the RAID is built from and their sizes: e.g.
         //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
 	Text text = _( "Create encrypted %1$s %2$s (%3$s) for swap\nfrom %4$s" );
+        text += _( "\nare you serious?!" );
 
 	return sformat( text,
                         get_md_level().c_str(),

--- a/storage/CompoundAction/Formatter/Md.cc
+++ b/storage/CompoundAction/Formatter/Md.cc
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2017 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+
+#include <boost/algorithm/string.hpp>
+
+#include "storage/CompoundAction/Formatter/Md.h"
+#include "storage/Filesystems/Swap.h"
+
+
+
+namespace storage
+{
+
+    CompoundAction::Formatter::Md::Md( const CompoundAction::Impl* compound_action ):
+	CompoundAction::Formatter( compound_action, "Md" ),
+	md( to_md( compound_action->get_target_device() ) )
+    {
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::text() const
+    {
+	if ( deleting() )
+	    return delete_text();
+
+	else if ( formatting() && is_swap( get_created_filesystem() ) )
+	{
+	    if ( encrypting() )
+		return create_encrypted_with_swap_text();
+
+	    else
+		return create_with_swap_text();
+	}
+
+	else
+	{
+	    if ( creating() && encrypting() && formatting() && mounting() )
+		return create_encrypted_with_fs_and_mount_point_text();
+
+	    else if ( creating() && encrypting() && formatting() )
+		return create_encrypted_with_fs_text();
+
+	    else if ( creating() && encrypting() )
+		return create_encrypted_text();
+
+	    else if ( creating() && formatting() && mounting() )
+		return create_with_fs_and_mount_point_text();
+
+	    else if ( creating() && formatting() )
+		return create_with_fs_text();
+
+	    else if ( creating() )
+		return create_text();
+
+	    else if ( encrypting() && formatting() && mounting() )
+		return encrypted_with_fs_and_mount_point_text();
+
+	    else if ( encrypting() && formatting() )
+		return encrypted_with_fs_text();
+
+	    else if ( encrypting() )
+		return encrypted_text();
+
+	    else if ( formatting() && mounting() )
+		return fs_and_mount_point_text();
+
+	    else if ( formatting() )
+		return fs_text();
+
+	    else if ( mounting() )
+		return mount_point_text();
+
+	    else
+		return default_text();
+	}
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::devices_text() const
+    {
+        std::vector<const BlkDevice *> devices = md->get_devices();
+        std::sort( devices.begin(), devices.end(),
+                   [](const BlkDevice * a, const BlkDevice * b) -> bool
+                   {
+                       return a->get_name() < b->get_name();
+                   });
+
+	Text text;
+
+	for ( const BlkDevice * device: devices )
+	{
+	    if ( ! text.translated.empty() )
+		text += Text( ", ", ", " );
+
+	    // TRANSLATORS:
+	    // %1$s is replaced with the the device name (e.g. /dev/sdc1),
+	    // %2$s is replaced with the the size (e.g. 60 GiB)
+	    Text dev_text = _( "%1$s (%2$s)" );
+
+	    text += sformat( dev_text,
+                             device->get_name().c_str(),
+                             device->get_size_string().c_str() );
+	}
+
+        return text;
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::delete_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md level (e.g. RAID1),
+	// %2$s is replaced with the md name (e.g. /dev/md0)
+	// %3$s is replaced with the size (e.g. 2 GiB)
+	Text text = _( "Delete %1$s %2$s (%3$s)" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::create_encrypted_with_swap_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md level (e.g. RAID1),
+	// %2$s is replaced with the md name (e.g. /dev/md0)
+	// %3$s is replaced with the size (e.g. 2 GiB)
+        // %4$s is replaced with a comma-spearated list of the devices
+        //   the RAID is built from and their sizes: e.g.
+        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	Text text = _( "Create encrypted %1$s %2$s (%3$s) for swap\nfrom %4$s" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str(),
+                        devices_text().translated.c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::create_with_swap_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md level (e.g. RAID1),
+	// %2$s is replaced with the md name (e.g. /dev/md0)
+	// %3$s is replaced with the size (e.g. 2 GiB)
+        // %4$s is replaced with a comma-spearated list of the devices
+        //   the RAID is built from and their sizes: e.g.
+        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	Text text = _( "Create %1$s %2$s (%3$s) for swap\nfrom %4$s" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str(),
+                        devices_text().translated.c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::create_encrypted_with_fs_and_mount_point_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md name (e.g. /dev/md0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the mount point (e.g. /home),
+	// %5$s is replaced with the file system name (e.g. ext4)
+        // %6$s is replaced with a comma-spearated list of the devices
+        //   the RAID is built from and their sizes: e.g.
+        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	Text text = _( "Create encrypted %1$s %2$s (%3$s) for %4$s with %5$s\nfrom %6$s" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str(),
+                        get_mount_point().c_str(),
+                        get_filesystem_type().c_str(),
+                        devices_text().translated.c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::create_encrypted_with_fs_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md name (e.g. /dev/md0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the file system name (e.g. ext4)
+        // %5$s is replaced with a comma-spearated list of the devices
+        //   the RAID is built from and their sizes: e.g.
+        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	Text text = _( "Create encrypted %1$s %2$s (%3$s) with %4$s\nfrom %5$s" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str(),
+                        get_filesystem_type().c_str(),
+                        devices_text().translated.c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::create_encrypted_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md name (e.g. /dev/md0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB)
+        // %4$s is replaced with a comma-spearated list of the devices
+        //   the RAID is built from and their sizes: e.g.
+        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	Text text = _( "Create encrypted %1$s %2$s (%3$s)\nfrom %4$s" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str(),
+                        devices_text().translated.c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::create_with_fs_and_mount_point_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md level (e.g. RAID1),
+	// %2$s is replaced with the md name (e.g. /dev/md0),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the mount point (e.g. /home),
+	// %5$s is replaced with the file system name (e.g. ext4)
+        // %6$s is replaced with a comma-spearated list of the devices
+        //   the RAID is built from and their sizes: e.g.
+        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	Text text = _( "Create %1$s %2$s (%3$s) for %4$s with %5$s\nfrom %6$s" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str(),
+                        get_mount_point().c_str(),
+                        get_filesystem_type().c_str(),
+                        devices_text().translated.c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::create_with_fs_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md name (e.g. /dev/md0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the file system name (e.g. ext4)
+        // %5$s is replaced with a comma-spearated list of the devices
+        //   the RAID is built from and their sizes: e.g.
+        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	Text text = _( "Create %1$s %2$s (%3$s) with %4$s\nfrom %5$s" );
+
+	return sformat ( text,
+                         get_md_level().c_str(),
+                         get_md_name().c_str(),
+                         get_size().c_str(),
+                         get_filesystem_type().c_str(),
+                         devices_text().translated.c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::create_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md level (e.g. RAID1),
+	// %2$s is replaced with the md name (e.g. /dev/md0),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+        // %4$s is replaced with a comma-spearated list of the devices
+        //   the RAID is built from and their sizes: e.g.
+        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	Text text = _( "Create %1$s %2$s (%3$s) from %4$s" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str(),
+                        devices_text().translated.c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::encrypted_with_fs_and_mount_point_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md name (e.g. /dev/md0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the mount point (e.g. /home),
+	// %5$s is replaced with the file system name (e.g. ext4)
+	Text text = _( "Encrypt %1$s %2$s (%3$s) for %4$s with %5$s" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str(),
+                        get_mount_point().c_str(),
+                        get_filesystem_type().c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::encrypted_with_fs_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md name (e.g. /dev/md0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the file system name (e.g. ext4)
+	Text text = _( "Encrypt %1$s %2$s (%3$s) with %4$s" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str(),
+                        get_filesystem_type().c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::encrypted_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md name (e.g. /dev/md0),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	Text text = _( "Encrypt %1$s %2$s (%3$s)" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::fs_and_mount_point_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md name (e.g. /dev/md0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the mount point (e.g. /home),
+	// %5$s is replaced with the file system name (e.g. ext4)
+	Text text = _( "Format %1$s %2$s (%3$s) for %4$s with %5$s" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str(),
+                        get_mount_point().c_str(),
+                        get_filesystem_type().c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::fs_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the md name (e.g. /dev/md0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the file system type (e.g. ext4)
+	Text text = _( "Format %1$s %2$s (%3$s) with %4$s" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str(),
+                        get_filesystem_type().c_str() );
+    }
+
+
+    Text
+    CompoundAction::Formatter::Md::mount_point_text() const
+    {
+	string mount_point = get_created_mount_point()->get_path();
+
+	// TRANSLATORS:
+	// %1$s is replaced with the md name (e.g. /dev/md0),
+	// %2$s is replaced with the device name (e.g. /dev/sda1),
+	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %4$s is replaced with the mount point (e.g. /home)
+	Text text = _( "Mount %1$s %2$s (%3$s) at %4$s" );
+
+	return sformat( text,
+                        get_md_level().c_str(),
+                        get_md_name().c_str(),
+                        get_size().c_str(),
+                        mount_point.c_str() );
+    }
+
+}

--- a/storage/CompoundAction/Formatter/Md.cc
+++ b/storage/CompoundAction/Formatter/Md.cc
@@ -99,12 +99,12 @@ namespace storage
     Text
     CompoundAction::Formatter::Md::devices_text() const
     {
-        std::vector<const BlkDevice *> devices = md->get_devices();
-        std::sort( devices.begin(), devices.end(),
-                   [](const BlkDevice * a, const BlkDevice * b) -> bool
-                   {
-                       return a->get_name() < b->get_name();
-                   });
+	std::vector<const BlkDevice *> devices = md->get_devices();
+	std::sort( devices.begin(), devices.end(),
+		   [](const BlkDevice * a, const BlkDevice * b) -> bool
+		       {
+			   return a->get_name() < b->get_name();
+		       });
 
 	Text text;
 
@@ -119,11 +119,11 @@ namespace storage
 	    Text dev_text = _( "%1$s (%2$s)" );
 
 	    text += sformat( dev_text,
-                             device->get_name().c_str(),
-                             device->get_size_string().c_str() );
+			     device->get_name().c_str(),
+			     device->get_size_string().c_str() );
 	}
 
-        return text;
+	return text;
     }
 
 
@@ -137,9 +137,9 @@ namespace storage
 	Text text = _( "Delete %1$s %2$s (%3$s)" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str() );
     }
 
 
@@ -150,17 +150,17 @@ namespace storage
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0)
 	// %3$s is replaced with the size (e.g. 2 GiB)
-        // %4$s is replaced with a comma-spearated list of the devices
-        //   the RAID is built from and their sizes: e.g.
-        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	// %4$s is replaced with a comma-spearated list of the devices
+	//   the RAID is built from and their sizes: e.g.
+	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
 	Text text = _( "Create encrypted %1$s %2$s (%3$s) for swap\nfrom %4$s" );
-        text += _( "\nare you serious?!" );
+	text += _( "\nare you serious?!" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str(),
-                        devices_text().translated.c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str(),
+			devices_text().translated.c_str() );
     }
 
 
@@ -171,16 +171,16 @@ namespace storage
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0)
 	// %3$s is replaced with the size (e.g. 2 GiB)
-        // %4$s is replaced with a comma-spearated list of the devices
-        //   the RAID is built from and their sizes: e.g.
-        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	// %4$s is replaced with a comma-spearated list of the devices
+	//   the RAID is built from and their sizes: e.g.
+	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
 	Text text = _( "Create %1$s %2$s (%3$s) for swap\nfrom %4$s" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str(),
-                        devices_text().translated.c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str(),
+			devices_text().translated.c_str() );
     }
 
 
@@ -193,18 +193,18 @@ namespace storage
 	// %3$s is replaced with the size (e.g. 2 GiB),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
-        // %6$s is replaced with a comma-spearated list of the devices
-        //   the RAID is built from and their sizes: e.g.
-        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	// %6$s is replaced with a comma-spearated list of the devices
+	//   the RAID is built from and their sizes: e.g.
+	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
 	Text text = _( "Create encrypted %1$s %2$s (%3$s) for %4$s with %5$s\nfrom %6$s" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str(),
-                        get_mount_point().c_str(),
-                        get_filesystem_type().c_str(),
-                        devices_text().translated.c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str(),
+			get_mount_point().c_str(),
+			get_filesystem_type().c_str(),
+			devices_text().translated.c_str() );
     }
 
 
@@ -216,17 +216,17 @@ namespace storage
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
 	// %3$s is replaced with the size (e.g. 2 GiB),
 	// %4$s is replaced with the file system name (e.g. ext4)
-        // %5$s is replaced with a comma-spearated list of the devices
-        //   the RAID is built from and their sizes: e.g.
-        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	// %5$s is replaced with a comma-spearated list of the devices
+	//   the RAID is built from and their sizes: e.g.
+	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
 	Text text = _( "Create encrypted %1$s %2$s (%3$s) with %4$s\nfrom %5$s" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str(),
-                        get_filesystem_type().c_str(),
-                        devices_text().translated.c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str(),
+			get_filesystem_type().c_str(),
+			devices_text().translated.c_str() );
     }
 
 
@@ -237,16 +237,16 @@ namespace storage
 	// %1$s is replaced with the md name (e.g. /dev/md0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
 	// %3$s is replaced with the size (e.g. 2 GiB)
-        // %4$s is replaced with a comma-spearated list of the devices
-        //   the RAID is built from and their sizes: e.g.
-        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	// %4$s is replaced with a comma-spearated list of the devices
+	//   the RAID is built from and their sizes: e.g.
+	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
 	Text text = _( "Create encrypted %1$s %2$s (%3$s)\nfrom %4$s" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str(),
-                        devices_text().translated.c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str(),
+			devices_text().translated.c_str() );
     }
 
 
@@ -259,18 +259,18 @@ namespace storage
 	// %3$s is replaced with the size (e.g. 2 GiB),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
-        // %6$s is replaced with a comma-spearated list of the devices
-        //   the RAID is built from and their sizes: e.g.
-        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	// %6$s is replaced with a comma-spearated list of the devices
+	//   the RAID is built from and their sizes: e.g.
+	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
 	Text text = _( "Create %1$s %2$s (%3$s) for %4$s with %5$s\nfrom %6$s" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str(),
-                        get_mount_point().c_str(),
-                        get_filesystem_type().c_str(),
-                        devices_text().translated.c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str(),
+			get_mount_point().c_str(),
+			get_filesystem_type().c_str(),
+			devices_text().translated.c_str() );
     }
 
 
@@ -282,17 +282,17 @@ namespace storage
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
 	// %3$s is replaced with the size (e.g. 2 GiB),
 	// %4$s is replaced with the file system name (e.g. ext4)
-        // %5$s is replaced with a comma-spearated list of the devices
-        //   the RAID is built from and their sizes: e.g.
-        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	// %5$s is replaced with a comma-spearated list of the devices
+	//   the RAID is built from and their sizes: e.g.
+	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
 	Text text = _( "Create %1$s %2$s (%3$s) with %4$s\nfrom %5$s" );
 
 	return sformat ( text,
-                         get_md_level().c_str(),
-                         get_md_name().c_str(),
-                         get_size().c_str(),
-                         get_filesystem_type().c_str(),
-                         devices_text().translated.c_str() );
+			 get_md_level().c_str(),
+			 get_md_name().c_str(),
+			 get_size().c_str(),
+			 get_filesystem_type().c_str(),
+			 devices_text().translated.c_str() );
     }
 
 
@@ -303,16 +303,16 @@ namespace storage
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0),
 	// %3$s is replaced with the size (e.g. 2 GiB),
-        // %4$s is replaced with a comma-spearated list of the devices
-        //   the RAID is built from and their sizes: e.g.
-        //   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	// %4$s is replaced with a comma-spearated list of the devices
+	//   the RAID is built from and their sizes: e.g.
+	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
 	Text text = _( "Create %1$s %2$s (%3$s) from %4$s" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str(),
-                        devices_text().translated.c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str(),
+			devices_text().translated.c_str() );
     }
 
 
@@ -328,11 +328,11 @@ namespace storage
 	Text text = _( "Encrypt %1$s %2$s (%3$s) for %4$s with %5$s" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str(),
-                        get_mount_point().c_str(),
-                        get_filesystem_type().c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str(),
+			get_mount_point().c_str(),
+			get_filesystem_type().c_str() );
     }
 
 
@@ -347,10 +347,10 @@ namespace storage
 	Text text = _( "Encrypt %1$s %2$s (%3$s) with %4$s" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str(),
-                        get_filesystem_type().c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str(),
+			get_filesystem_type().c_str() );
     }
 
 
@@ -363,9 +363,9 @@ namespace storage
 	Text text = _( "Encrypt %1$s %2$s (%3$s)" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str() );
     }
 
 
@@ -381,11 +381,11 @@ namespace storage
 	Text text = _( "Format %1$s %2$s (%3$s) for %4$s with %5$s" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str(),
-                        get_mount_point().c_str(),
-                        get_filesystem_type().c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str(),
+			get_mount_point().c_str(),
+			get_filesystem_type().c_str() );
     }
 
 
@@ -400,10 +400,10 @@ namespace storage
 	Text text = _( "Format %1$s %2$s (%3$s) with %4$s" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str(),
-                        get_filesystem_type().c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str(),
+			get_filesystem_type().c_str() );
     }
 
 
@@ -420,10 +420,10 @@ namespace storage
 	Text text = _( "Mount %1$s %2$s (%3$s) at %4$s" );
 
 	return sformat( text,
-                        get_md_level().c_str(),
-                        get_md_name().c_str(),
-                        get_size().c_str(),
-                        mount_point.c_str() );
+			get_md_level().c_str(),
+			get_md_name().c_str(),
+			get_size().c_str(),
+			mount_point.c_str() );
     }
 
 }

--- a/storage/CompoundAction/Formatter/Md.cc
+++ b/storage/CompoundAction/Formatter/Md.cc
@@ -99,31 +99,7 @@ namespace storage
     Text
     CompoundAction::Formatter::Md::devices_text() const
     {
-	std::vector<const BlkDevice *> devices = md->get_devices();
-	std::sort( devices.begin(), devices.end(),
-		   [](const BlkDevice * a, const BlkDevice * b) -> bool
-		       {
-			   return a->get_name() < b->get_name();
-		       });
-
-	Text text;
-
-	for ( const BlkDevice * device: devices )
-	{
-	    if ( ! text.translated.empty() )
-		text += Text( ", ", ", " );
-
-	    // TRANSLATORS:
-	    // %1$s is replaced with the the device name (e.g. /dev/sdc1),
-	    // %2$s is replaced with the the size (e.g. 60 GiB)
-	    Text dev_text = _( "%1$s (%2$s)" );
-
-	    text += sformat( dev_text,
-			     device->get_name().c_str(),
-			     device->get_size_string().c_str() );
-	}
-
-	return text;
+        return format_devices_text( md->get_devices() );
     }
 
 

--- a/storage/CompoundAction/Formatter/Md.h
+++ b/storage/CompoundAction/Formatter/Md.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) 2018 SUSE LLC
  *
  * All Rights Reserved.
  *

--- a/storage/CompoundAction/Formatter/Md.h
+++ b/storage/CompoundAction/Formatter/Md.h
@@ -37,7 +37,7 @@ namespace storage
 
     public:
 
-	Md(const CompoundAction::Impl* compound_action);
+	Md( const CompoundAction::Impl* compound_action );
 
     private:
 
@@ -65,10 +65,10 @@ namespace storage
 	string get_md_name()  const { return md->get_name(); }
 	string get_size()     const { return md->get_size_string(); }
 
-        string get_md_level() const
-        {
-            return get_md_level_name( md->get_md_level() );
-        }
+	string get_md_level() const
+	{
+	    return get_md_level_name( md->get_md_level() );
+	}
 
     private:
 

--- a/storage/CompoundAction/Formatter/Md.h
+++ b/storage/CompoundAction/Formatter/Md.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+
+#ifndef STORAGE_FORMATTER_MD_H
+#define STORAGE_FORMATTER_MD_H
+
+
+#include "storage/CompoundAction/Formatter.h"
+#include "storage/Devices/Md.h"
+#include "storage/Filesystems/BlkFilesystem.h"
+
+
+namespace storage
+{
+
+    class CompoundAction::Formatter::Md: public CompoundAction::Formatter
+    {
+
+    public:
+
+	Md(const CompoundAction::Impl* compound_action);
+
+    private:
+
+	Text text() const override;
+	Text devices_text() const;
+
+	Text delete_text() const;
+
+	Text create_encrypted_with_swap_text() const;
+	Text create_with_swap_text() const;
+
+	Text create_encrypted_with_fs_and_mount_point_text() const;
+	Text create_encrypted_with_fs_text() const;
+	Text create_encrypted_text() const;
+	Text create_with_fs_and_mount_point_text() const;
+	Text create_with_fs_text() const;
+	Text create_text() const;
+	Text encrypted_with_fs_and_mount_point_text() const;
+	Text encrypted_with_fs_text() const;
+	Text encrypted_text() const;
+	Text fs_and_mount_point_text() const;
+	Text fs_text() const;
+	Text mount_point_text() const;
+
+	string get_md_name()  const { return md->get_name(); }
+	string get_size()     const { return md->get_size_string(); }
+
+        string get_md_level() const
+        {
+            return get_md_level_name( md->get_md_level() );
+        }
+
+    private:
+
+	const storage::Md * md;
+    };
+
+}
+
+#endif

--- a/storage/CompoundAction/Formatter/Nfs.cc
+++ b/storage/CompoundAction/Formatter/Nfs.cc
@@ -51,8 +51,8 @@ namespace storage
     CompoundAction::Formatter::Nfs::mount_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by nfs name (e.g. 99.99.00.00:path),
-	// %2$s is replaced by mount point (e.g. /home)
+	// %1$s is replaced with the nfs name (e.g. 99.99.00.00:path),
+	// %2$s is replaced with the mount point (e.g. /home)
         Text text = _("Mount NFS %1$s on %2$s");
 
         return sformat(text,
@@ -65,8 +65,8 @@ namespace storage
     CompoundAction::Formatter::Nfs::unmount_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by nfs name (e.g. 99.99.00.00:path),
-	// %2$s is replaced by mount point (e.g. /home)
+	// %1$s is replaced with the nfs name (e.g. 99.99.00.00:path),
+	// %2$s is replaced with the mount point (e.g. /home)
         Text text = _("Unmount NFS %1$s at %2$s");
 
         return sformat(text,

--- a/storage/CompoundAction/Formatter/Partition.cc
+++ b/storage/CompoundAction/Formatter/Partition.cc
@@ -115,8 +115,8 @@ namespace storage
     CompoundAction::Formatter::Partition::delete_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB)
 	Text text = _("Delete partition %1$s (%2$s)");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -127,8 +127,8 @@ namespace storage
     CompoundAction::Formatter::Partition::create_encrypted_pv_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB)
 	Text text = _("Create encrypted partition %1$s (%2$s) as LVM physical volume");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -139,8 +139,8 @@ namespace storage
     CompoundAction::Formatter::Partition::create_pv_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB)
 	Text text = _("Create partition %1$s (%2$s) as LVM physical volume");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -151,8 +151,8 @@ namespace storage
     CompoundAction::Formatter::Partition::encrypted_pv_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB)
 	Text text = _("Create LVM physical volume over encrypted %1$s (%2$s)");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -163,8 +163,8 @@ namespace storage
     CompoundAction::Formatter::Partition::pv_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB)
 	Text text = _("Create LVM volume device over %1$s (%2$s)");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -175,8 +175,8 @@ namespace storage
     CompoundAction::Formatter::Partition::create_encrypted_with_swap_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB)
 	Text text = _("Create encrypted partition %1$s (%2$s) for swap");
 
 	return sformat(text,
@@ -189,8 +189,8 @@ namespace storage
     CompoundAction::Formatter::Partition::create_with_swap_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB)
 	Text text = _("Create partition %1$s (%2$s) for swap");
 
 	return sformat(text,
@@ -203,10 +203,10 @@ namespace storage
     CompoundAction::Formatter::Partition::create_encrypted_with_fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by mount point (e.g. /home),
-	// %4$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the mount point (e.g. /home),
+	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create encrypted partition %1$s (%2$s) for %3$s with %4$s");
 
 	return sformat(text,
@@ -221,9 +221,9 @@ namespace storage
     CompoundAction::Formatter::Partition::create_encrypted_with_fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create encrypted partition %1$s (%2$s) with %3$s");
 
 	return sformat(text,
@@ -237,8 +237,8 @@ namespace storage
     CompoundAction::Formatter::Partition::create_encrypted_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB)
 	Text text = _("Create encrypted partition %1$s (%2$s)");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -249,10 +249,10 @@ namespace storage
     CompoundAction::Formatter::Partition::create_with_fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by mount point (e.g. /home),
-	// %4$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the mount point (e.g. /home),
+	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create partition %1$s (%2$s) for %3$s with %4$s");
 
 	return sformat(text,
@@ -267,9 +267,9 @@ namespace storage
     CompoundAction::Formatter::Partition::create_with_fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create partition %1$s (%2$s) with %3$s");
 
 	return sformat(text,
@@ -287,9 +287,9 @@ namespace storage
 	if (!tmp.empty())
 	{
 	    // TRANSLATORS:
-	    // %1$s is replaced by partition name (e.g. /dev/sda1),
-	    // %2$s is replaced by size (e.g. 2 GiB),
-	    // %3$s is replaced by partition id string (e.g. Linux LVM)
+	    // %1$s is replaced with the partition name (e.g. /dev/sda1),
+	    // %2$s is replaced with the size (e.g. 2 GiB),
+	    // %3$s is replaced with the partition id string (e.g. Linux LVM)
 	    Text text = _("Create partition %1$s (%2$s) as %3$s");
 
 	    return sformat(text, get_device_name().c_str(),
@@ -298,8 +298,8 @@ namespace storage
 	else
 	{
 	    // TRANSLATORS:
-	    // %1$s is replaced by partition name (e.g. /dev/sda1),
-	    // %2$s is replaced by size (e.g. 2 GiB)
+	    // %1$s is replaced with the partition name (e.g. /dev/sda1),
+	    // %2$s is replaced with the size (e.g. 2 GiB)
 	    Text text = _("Create partition %1$s (%2$s)");
 
 	    return sformat(text, get_device_name().c_str(),
@@ -312,10 +312,10 @@ namespace storage
     CompoundAction::Formatter::Partition::encrypted_with_fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by mount point (e.g. /home),
-	// %4$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the mount point (e.g. /home),
+	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Encrypt partition %1$s (%2$s) for %3$s with %4$s");
 
 	return sformat(text,
@@ -330,9 +330,9 @@ namespace storage
     CompoundAction::Formatter::Partition::encrypted_with_fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Encrypt partition %1$s (%2$s) with %3$s");
 
 	return sformat(text,
@@ -346,8 +346,8 @@ namespace storage
     CompoundAction::Formatter::Partition::encrypted_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB),
 	Text text = _("Encrypt partition %1$s (%2$s)");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -358,10 +358,10 @@ namespace storage
     CompoundAction::Formatter::Partition::fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by mount point (e.g. /home),
-	// %4$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the mount point (e.g. /home),
+	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Format partition %1$s (%2$s) for %3$s with %4$s");
 
 	return sformat(text,
@@ -376,9 +376,9 @@ namespace storage
     CompoundAction::Formatter::Partition::fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by file system name (e.g. ext4)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Format partition %1$s (%2$s) with %3$s");
 
 	return sformat(text,
@@ -394,9 +394,9 @@ namespace storage
 	string mount_point = get_created_mount_point()->get_path();
 
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by mount point (e.g. /home)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the mount point (e.g. /home)
 	Text text = _("Mount partition %1$s (%2$s) at %3$s");
 
 	return sformat(text,

--- a/storage/CompoundAction/Formatter/Partition.cc
+++ b/storage/CompoundAction/Formatter/Partition.cc
@@ -30,9 +30,11 @@ namespace storage
 {
 
     CompoundAction::Formatter::Partition::Partition(const CompoundAction::Impl* compound_action) :
-	CompoundAction::Formatter(compound_action),
+	CompoundAction::Formatter(compound_action, "Partition"),
 	partition(to_partition(compound_action->get_target_device()))
-    {}
+    {
+
+    }
 
 
     Text

--- a/storage/CompoundAction/Formatter/Partition.h
+++ b/storage/CompoundAction/Formatter/Partition.h
@@ -66,13 +66,6 @@ namespace storage
 	Text fs_text() const;
 	Text mount_point_text() const;
 
-        // Predicates for better code readability
-
-        bool creating()   const { return has_create<storage::Partition>();     }
-        bool deleting()   const { return has_delete<storage::Partition>();     }
-
-        // Getters for better code readability
-
         string get_device_name()     const { return partition->get_name();        }
         string get_size()            const { return partition->get_size_string(); }
 

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.cc
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.cc
@@ -22,7 +22,6 @@
 
 #include "storage/CompoundAction/Formatter/StrayBlkDevice.h"
 #include "storage/Devices/LvmPv.h"
-#include "storage/Devices/PartitionImpl.h"
 #include "storage/Filesystems/Swap.h"
 
 

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.cc
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.cc
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2017 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+
+#include "storage/CompoundAction/Formatter/StrayBlkDevice.h"
+#include "storage/Devices/LvmPv.h"
+#include "storage/Devices/PartitionImpl.h"
+#include "storage/Filesystems/Swap.h"
+
+
+namespace storage
+{
+
+    CompoundAction::Formatter::StrayBlkDevice::StrayBlkDevice(const CompoundAction::Impl* compound_action) :
+	CompoundAction::Formatter(compound_action),
+	stray_blk_device(to_stray_blk_device(compound_action->get_target_device()))
+    {}
+
+
+    Text
+    CompoundAction::Formatter::StrayBlkDevice::text() const
+    {
+	if ( has_create<storage::LvmPv>() )
+	{
+	    if ( encrypting() )
+		return encrypted_pv_text();
+	    else
+		return pv_text();
+	}
+	else if ( formatting() && is_swap( get_created_filesystem() ) )
+	{
+	    if ( encrypting() )
+                return format_as_encrypted_swap_text();
+            else
+                return format_as_swap_text();
+	}
+	else
+	{
+	    if ( encrypting() && formatting() && mounting() )
+		return encrypted_with_fs_and_mount_point_text();
+
+	    else if ( encrypting() && formatting() )
+		return encrypted_with_fs_text();
+
+	    else if ( encrypting() )
+		return encrypted_text();
+
+	    else if ( formatting() && mounting() )
+		return fs_and_mount_point_text();
+
+	    else if ( formatting() )
+		return fs_text();
+
+	    else if ( mounting() )
+		return mount_point_text();
+
+	    else
+		return default_text();
+	}
+    }
+
+
+    Text
+    CompoundAction::Formatter::StrayBlkDevice::format_as_swap_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by partition name (e.g. /dev/sda1),
+	// %2$s is replaced by size (e.g. 2GiB)
+	Text text = _("Format partition %1$s (%2$s) as swap");
+
+	return sformat(text, get_device_name().c_str(), get_size().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::StrayBlkDevice::format_as_encrypted_swap_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by partition name (e.g. /dev/sda1),
+	// %2$s is replaced by size (e.g. 2GiB)
+	Text text = _("Format partition %1$s (%2$s) as encryped swap");
+
+	return sformat(text, get_device_name().c_str(), get_size().c_str());
+    }
+
+    Text
+    CompoundAction::Formatter::StrayBlkDevice::encrypted_pv_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by partition name (e.g. /dev/sda1),
+	// %2$s is replaced by size (e.g. 2GiB)
+	Text text = _("Create LVM physical volume over encrypted %1$s (%2$s)");
+
+	return sformat(text, get_device_name().c_str(), get_size().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::StrayBlkDevice::pv_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by partition name (e.g. /dev/sda1),
+	// %2$s is replaced by size (e.g. 2GiB)
+	Text text = _("Create LVM physical volume over %1$s (%2$s)");
+
+	return sformat(text, get_device_name().c_str(), get_size().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::StrayBlkDevice::encrypted_with_fs_and_mount_point_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by partition name (e.g. /dev/sda1),
+	// %2$s is replaced by size (e.g. 2GiB),
+	// %3$s is replaced by mount point (e.g. /home),
+	// %4$s is replaced by file system name (e.g. ext4)
+	Text text = _("Encrypt partition %1$s (%2$s) for %3$s with %4$s");
+
+	return sformat(text,
+		       get_device_name().c_str(),
+		       get_size().c_str(),
+		       get_mount_point().c_str(),
+		       get_filesystem_type().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::StrayBlkDevice::encrypted_with_fs_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by partition name (e.g. /dev/sda1),
+	// %2$s is replaced by size (e.g. 2GiB),
+	// %3$s is replaced by file system name (e.g. ext4)
+	Text text = _("Encrypt partition %1$s (%2$s) with %3$s");
+
+	return sformat(text,
+		       get_device_name().c_str(),
+		       get_size().c_str(),
+		       get_filesystem_type().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::StrayBlkDevice::encrypted_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by partition name (e.g. /dev/sda1),
+	// %2$s is replaced by size (e.g. 2GiB),
+	Text text = _("Encrypt partition %1$s (%2$s)");
+
+	return sformat(text, get_device_name().c_str(), get_size().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::StrayBlkDevice::fs_and_mount_point_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by partition name (e.g. /dev/sda1),
+	// %2$s is replaced by size (e.g. 2GiB),
+	// %3$s is replaced by mount point (e.g. /home),
+	// %4$s is replaced by file system name (e.g. ext4)
+	Text text = _("Format partition %1$s (%2$s) for %3$s with %4$s");
+
+	return sformat(text,
+		       get_device_name().c_str(),
+		       get_size().c_str(),
+		       get_mount_point().c_str(),
+		       get_filesystem_type().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::StrayBlkDevice::fs_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced by partition name (e.g. /dev/sda1),
+	// %2$s is replaced by size (e.g. 2GiB),
+	// %3$s is replaced by file system name (e.g. ext4)
+	Text text = _("Format partition %1$s (%2$s) with %3$s");
+
+	return sformat(text,
+		       get_device_name().c_str(),
+		       get_size().c_str(),
+		       get_filesystem_type().c_str());
+    }
+
+
+    Text
+    CompoundAction::Formatter::StrayBlkDevice::mount_point_text() const
+    {
+	string mount_point = get_created_mount_point()->get_path();
+
+	// TRANSLATORS:
+	// %1$s is replaced by partition name (e.g. /dev/sda1),
+	// %2$s is replaced by size (e.g. 2GiB),
+	// %3$s is replaced by mount point (e.g. /home)
+	Text text = _("Mount partition %1$s (%2$s) at %3$s");
+
+	return sformat(text,
+		       get_device_name().c_str(),
+		       get_size().c_str(),
+                       mount_point.c_str());
+    }
+
+}

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.cc
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) 2018 SUSE LLC
  *
  * All Rights Reserved.
  *

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.cc
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.cc
@@ -81,8 +81,8 @@ namespace storage
     CompoundAction::Formatter::StrayBlkDevice::format_as_swap_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2GiB)
 	Text text = _("Format partition %1$s (%2$s) as swap");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -93,8 +93,8 @@ namespace storage
     CompoundAction::Formatter::StrayBlkDevice::format_as_encrypted_swap_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2GiB)
 	Text text = _("Format partition %1$s (%2$s) as encryped swap");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -104,8 +104,8 @@ namespace storage
     CompoundAction::Formatter::StrayBlkDevice::encrypted_pv_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2GiB)
 	Text text = _("Create LVM physical volume over encrypted %1$s (%2$s)");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -116,8 +116,8 @@ namespace storage
     CompoundAction::Formatter::StrayBlkDevice::pv_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2GiB)
 	Text text = _("Create LVM physical volume over %1$s (%2$s)");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -128,9 +128,9 @@ namespace storage
     CompoundAction::Formatter::StrayBlkDevice::encrypted_with_fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by mount point (e.g. /home),
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2GiB),
+	// %3$s is replaced with the mount point (e.g. /home),
 	// %4$s is replaced by file system name (e.g. ext4)
 	Text text = _("Encrypt partition %1$s (%2$s) for %3$s with %4$s");
 
@@ -146,8 +146,8 @@ namespace storage
     CompoundAction::Formatter::StrayBlkDevice::encrypted_with_fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2GiB),
 	// %3$s is replaced by file system name (e.g. ext4)
 	Text text = _("Encrypt partition %1$s (%2$s) with %3$s");
 
@@ -162,8 +162,8 @@ namespace storage
     CompoundAction::Formatter::StrayBlkDevice::encrypted_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2GiB),
 	Text text = _("Encrypt partition %1$s (%2$s)");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -174,9 +174,9 @@ namespace storage
     CompoundAction::Formatter::StrayBlkDevice::fs_and_mount_point_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by mount point (e.g. /home),
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2GiB),
+	// %3$s is replaced with the mount point (e.g. /home),
 	// %4$s is replaced by file system name (e.g. ext4)
 	Text text = _("Format partition %1$s (%2$s) for %3$s with %4$s");
 
@@ -192,8 +192,8 @@ namespace storage
     CompoundAction::Formatter::StrayBlkDevice::fs_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2GiB),
 	// %3$s is replaced by file system name (e.g. ext4)
 	Text text = _("Format partition %1$s (%2$s) with %3$s");
 
@@ -210,9 +210,9 @@ namespace storage
 	string mount_point = get_created_mount_point()->get_path();
 
 	// TRANSLATORS:
-	// %1$s is replaced by partition name (e.g. /dev/sda1),
-	// %2$s is replaced by size (e.g. 2GiB),
-	// %3$s is replaced by mount point (e.g. /home)
+	// %1$s is replaced with the partition name (e.g. /dev/sda1),
+	// %2$s is replaced with the size (e.g. 2GiB),
+	// %3$s is replaced with the mount point (e.g. /home)
 	Text text = _("Mount partition %1$s (%2$s) at %3$s");
 
 	return sformat(text,

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.cc
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.cc
@@ -30,7 +30,7 @@ namespace storage
 {
 
     CompoundAction::Formatter::StrayBlkDevice::StrayBlkDevice(const CompoundAction::Impl* compound_action) :
-	CompoundAction::Formatter(compound_action),
+	CompoundAction::Formatter(compound_action, "StrayBlkDevice"),
 	stray_blk_device(to_stray_blk_device(compound_action->get_target_device()))
     {}
 

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.cc
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.cc
@@ -28,10 +28,12 @@
 namespace storage
 {
 
-    CompoundAction::Formatter::StrayBlkDevice::StrayBlkDevice(const CompoundAction::Impl* compound_action) :
-	CompoundAction::Formatter(compound_action, "StrayBlkDevice"),
-	stray_blk_device(to_stray_blk_device(compound_action->get_target_device()))
-    {}
+    CompoundAction::Formatter::StrayBlkDevice::StrayBlkDevice( const CompoundAction::Impl* compound_action ):
+	CompoundAction::Formatter( compound_action, "StrayBlkDevice" ),
+	stray_blk_device( to_stray_blk_device( compound_action->get_target_device( ) ) )
+    {
+        // NOP
+    }
 
 
     Text
@@ -83,9 +85,9 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
 	// %2$s is replaced with the size (e.g. 2 GiB)
-	Text text = _("Format partition %1$s (%2$s) as swap");
+	Text text = _( "Format partition %1$s (%2$s) as swap" );
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat( text, get_device_name().c_str(), get_size().c_str() );
     }
 
 
@@ -95,9 +97,9 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
 	// %2$s is replaced with the size (e.g. 2 GiB)
-	Text text = _("Format partition %1$s (%2$s) as encryped swap");
+	Text text = _( "Format partition %1$s (%2$s) as encryped swap" );
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat( text, get_device_name().c_str(), get_size().c_str() );
     }
 
     Text
@@ -106,9 +108,9 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
 	// %2$s is replaced with the size (e.g. 2 GiB)
-	Text text = _("Create LVM physical volume over encrypted %1$s (%2$s)");
+	Text text = _( "Create LVM physical volume over encrypted %1$s (%2$s)" );
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat( text, get_device_name().c_str(), get_size().c_str() );
     }
 
 
@@ -118,9 +120,9 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
 	// %2$s is replaced with the size (e.g. 2 GiB)
-	Text text = _("Create LVM physical volume over %1$s (%2$s)");
+	Text text = _( "Create LVM physical volume over %1$s (%2$s)" );
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat( text, get_device_name().c_str(), get_size().c_str() );
     }
 
 
@@ -132,13 +134,13 @@ namespace storage
 	// %2$s is replaced with the size (e.g. 2 GiB),
 	// %3$s is replaced with the mount point (e.g. /home),
 	// %4$s is replaced with the file system name (e.g. ext4)
-	Text text = _("Encrypt partition %1$s (%2$s) for %3$s with %4$s");
+	Text text = _( "Encrypt partition %1$s (%2$s) for %3$s with %4$s" );
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_mount_point().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat( text,
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        get_mount_point().c_str(),
+                        get_filesystem_type().c_str() );
     }
 
 
@@ -149,12 +151,12 @@ namespace storage
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
 	// %2$s is replaced with the size (e.g. 2 GiB),
 	// %3$s is replaced with the file system name (e.g. ext4)
-	Text text = _("Encrypt partition %1$s (%2$s) with %3$s");
+	Text text = _( "Encrypt partition %1$s (%2$s) with %3$s" );
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat( text,
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        get_filesystem_type().c_str() );
     }
 
 
@@ -164,9 +166,9 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
 	// %2$s is replaced with the size (e.g. 2 GiB),
-	Text text = _("Encrypt partition %1$s (%2$s)");
+	Text text = _( "Encrypt partition %1$s (%2$s)" );
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat( text, get_device_name().c_str(), get_size().c_str() );
     }
 
 
@@ -178,13 +180,13 @@ namespace storage
 	// %2$s is replaced with the size (e.g. 2 GiB),
 	// %3$s is replaced with the mount point (e.g. /home),
 	// %4$s is replaced with the file system name (e.g. ext4)
-	Text text = _("Format partition %1$s (%2$s) for %3$s with %4$s");
+	Text text = _( "Format partition %1$s (%2$s) for %3$s with %4$s" );
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_mount_point().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat( text,
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        get_mount_point().c_str(),
+                        get_filesystem_type().c_str() );
     }
 
 
@@ -195,12 +197,12 @@ namespace storage
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
 	// %2$s is replaced with the size (e.g. 2 GiB),
 	// %3$s is replaced with the file system name (e.g. ext4)
-	Text text = _("Format partition %1$s (%2$s) with %3$s");
+	Text text = _( "Format partition %1$s (%2$s) with %3$s" );
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat( text,
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        get_filesystem_type().c_str() );
     }
 
 
@@ -213,12 +215,12 @@ namespace storage
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
 	// %2$s is replaced with the size (e.g. 2 GiB),
 	// %3$s is replaced with the mount point (e.g. /home)
-	Text text = _("Mount partition %1$s (%2$s) at %3$s");
+	Text text = _( "Mount partition %1$s (%2$s) at %3$s" );
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-                       mount_point.c_str());
+	return sformat( text,
+                        get_device_name().c_str(),
+                        get_size().c_str(),
+                        mount_point.c_str() );
     }
 
 }

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.cc
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.cc
@@ -82,7 +82,7 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2GiB)
+	// %2$s is replaced with the size (e.g. 2 GiB)
 	Text text = _("Format partition %1$s (%2$s) as swap");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -94,7 +94,7 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2GiB)
+	// %2$s is replaced with the size (e.g. 2 GiB)
 	Text text = _("Format partition %1$s (%2$s) as encryped swap");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -105,7 +105,7 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2GiB)
+	// %2$s is replaced with the size (e.g. 2 GiB)
 	Text text = _("Create LVM physical volume over encrypted %1$s (%2$s)");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -117,7 +117,7 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2GiB)
+	// %2$s is replaced with the size (e.g. 2 GiB)
 	Text text = _("Create LVM physical volume over %1$s (%2$s)");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -129,9 +129,9 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2GiB),
+	// %2$s is replaced with the size (e.g. 2 GiB),
 	// %3$s is replaced with the mount point (e.g. /home),
-	// %4$s is replaced by file system name (e.g. ext4)
+	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Encrypt partition %1$s (%2$s) for %3$s with %4$s");
 
 	return sformat(text,
@@ -147,8 +147,8 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2GiB),
-	// %3$s is replaced by file system name (e.g. ext4)
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Encrypt partition %1$s (%2$s) with %3$s");
 
 	return sformat(text,
@@ -163,7 +163,7 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2GiB),
+	// %2$s is replaced with the size (e.g. 2 GiB),
 	Text text = _("Encrypt partition %1$s (%2$s)");
 
 	return sformat(text, get_device_name().c_str(), get_size().c_str());
@@ -175,9 +175,9 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2GiB),
+	// %2$s is replaced with the size (e.g. 2 GiB),
 	// %3$s is replaced with the mount point (e.g. /home),
-	// %4$s is replaced by file system name (e.g. ext4)
+	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Format partition %1$s (%2$s) for %3$s with %4$s");
 
 	return sformat(text,
@@ -193,8 +193,8 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2GiB),
-	// %3$s is replaced by file system name (e.g. ext4)
+	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Format partition %1$s (%2$s) with %3$s");
 
 	return sformat(text,
@@ -211,7 +211,7 @@ namespace storage
 
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2GiB),
+	// %2$s is replaced with the size (e.g. 2 GiB),
 	// %3$s is replaced with the mount point (e.g. /home)
 	Text text = _("Mount partition %1$s (%2$s) at %3$s");
 

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.h
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2017 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact SUSE LLC.
+ *
+ * To contact SUSE LLC about this file by physical or electronic mail, you may
+ * find current contact information at www.suse.com.
+ */
+
+
+#ifndef STORAGE_FORMATTER_STRAY_BLK_DEVICE_H
+#define STORAGE_FORMATTER_STRAY_BLK_DEVICE_H
+
+
+#include "storage/CompoundAction/Formatter.h"
+#include "storage/Devices/StrayBlkDevice.h"
+#include "storage/Filesystems/BlkFilesystem.h"
+
+
+namespace storage
+{
+
+    class CompoundAction::Formatter::StrayBlkDevice : public CompoundAction::Formatter
+    {
+
+    public:
+
+	StrayBlkDevice(const CompoundAction::Impl* compound_action);
+
+    private:
+
+	Text text() const override;
+
+        Text format_as_swap_text() const;
+        Text format_as_encrypted_swap_text() const;
+        Text encrypted_pv_text() const;
+	Text pv_text() const;
+
+	Text encrypted_with_fs_and_mount_point_text() const;
+	Text encrypted_with_fs_text() const;
+	Text encrypted_text() const;
+	Text fs_and_mount_point_text() const;
+	Text fs_text() const;
+	Text mount_point_text() const;
+
+
+        // Getters for better code readability
+
+        string get_device_name()     const { return stray_blk_device->get_name();        }
+        string get_size()            const { return stray_blk_device->get_size_string(); }
+
+    private:
+
+	const storage::StrayBlkDevice * stray_blk_device;
+
+    };
+
+}
+
+#endif

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.h
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.h
@@ -55,16 +55,12 @@ namespace storage
 	Text fs_text() const;
 	Text mount_point_text() const;
 
-
-        // Getters for better code readability
-
         string get_device_name()     const { return stray_blk_device->get_name();        }
         string get_size()            const { return stray_blk_device->get_size_string(); }
 
     private:
 
 	const storage::StrayBlkDevice * stray_blk_device;
-
     };
 
 }

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.h
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) 2018 SUSE LLC
  *
  * All Rights Reserved.
  *

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.h
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.h
@@ -37,15 +37,15 @@ namespace storage
 
     public:
 
-	StrayBlkDevice(const CompoundAction::Impl* compound_action);
+	StrayBlkDevice( const CompoundAction::Impl* compound_action );
 
     private:
 
 	Text text() const override;
 
-        Text format_as_swap_text() const;
-        Text format_as_encrypted_swap_text() const;
-        Text encrypted_pv_text() const;
+	Text format_as_swap_text() const;
+	Text format_as_encrypted_swap_text() const;
+	Text encrypted_pv_text() const;
 	Text pv_text() const;
 
 	Text encrypted_with_fs_and_mount_point_text() const;
@@ -55,8 +55,8 @@ namespace storage
 	Text fs_text() const;
 	Text mount_point_text() const;
 
-        string get_device_name()     const { return stray_blk_device->get_name();        }
-        string get_size()            const { return stray_blk_device->get_size_string(); }
+	string get_device_name() const { return stray_blk_device->get_name();	     }
+	string get_size()	 const { return stray_blk_device->get_size_string(); }
 
     private:
 

--- a/storage/CompoundAction/Generator.cc
+++ b/storage/CompoundAction/Generator.cc
@@ -38,7 +38,7 @@ namespace storage
     {
 	vector<CompoundAction*> compound_actions;
 
-	for(auto& commit_action : actiongraph->get_commit_actions())
+	for (auto& commit_action : actiongraph->get_commit_actions())
 	{
 	    auto target = CompoundAction::Impl::get_target_device(actiongraph, commit_action);
 

--- a/storage/CompoundAction/Makefile.am
+++ b/storage/CompoundAction/Makefile.am
@@ -2,17 +2,14 @@
 # Makefile.am for libstorage/storage/CompoundAction
 #
 
+SUBDIRS = Formatter
+
 noinst_LTLIBRARIES = libcompoundaction.la
 
-libcompoundaction_la_SOURCES =						\
-	Generator.h			Generator.cc			\
-	Formatter.h			Formatter.cc			\
-	Formatter/Partition.h		Formatter/Partition.cc		\
-	Formatter/LvmLv.h		Formatter/LvmLv.cc		\
-	Formatter/LvmVg.h		Formatter/LvmVg.cc		\
-	Formatter/BtrfsSubvolume.h	Formatter/BtrfsSubvolume.cc	\
-	Formatter/Btrfs.h		Formatter/Btrfs.cc		\
-	Formatter/Nfs.h			Formatter/Nfs.cc
+libcompoundaction_la_SOURCES =		\
+	Generator.h	Generator.cc	\
+	Formatter.h	Formatter.cc
+
 
 pkgincludedir = $(includedir)/storage/CompoundAction
 

--- a/storage/CompoundActionImpl.cc
+++ b/storage/CompoundActionImpl.cc
@@ -25,6 +25,7 @@
 #include "storage/CompoundActionImpl.h"
 #include "storage/CompoundAction/Generator.h"
 #include "storage/CompoundAction/Formatter/Partition.h"
+#include "storage/CompoundAction/Formatter/StrayBlkDevice.h"
 #include "storage/CompoundAction/Formatter/LvmLv.h"
 #include "storage/CompoundAction/Formatter/LvmVg.h"
 #include "storage/CompoundAction/Formatter/BtrfsSubvolume.h"
@@ -105,6 +106,9 @@ namespace storage
     {
 	if (is_partition(target_device))
 	    return CompoundAction::Formatter::Partition(this).string_representation();
+
+	if (is_stray_blk_device(target_device))
+	    return CompoundAction::Formatter::StrayBlkDevice(this).string_representation();
 
 	else if (is_lvm_lv(target_device))
 	    return CompoundAction::Formatter::LvmLv(this).string_representation();

--- a/storage/CompoundActionImpl.cc
+++ b/storage/CompoundActionImpl.cc
@@ -33,10 +33,11 @@
 #include "storage/CompoundAction/Formatter/Partition.h"
 #include "storage/CompoundAction/Formatter/StrayBlkDevice.h"
 #include "storage/ActiongraphImpl.h"
-#include "storage/Devices/PartitionTable.h"
-#include "storage/Devices/Partitionable.h"
+#include "storage/Devices/BcacheCset.h"
 #include "storage/Devices/Encryption.h"
 #include "storage/Devices/LvmPv.h"
+#include "storage/Devices/PartitionTable.h"
+#include "storage/Devices/Partitionable.h"
 #include "storage/Filesystems/BlkFilesystem.h"
 #include "storage/Filesystems/MountPoint.h"
 #include "storage/Utils/Exception.h"
@@ -126,7 +127,7 @@ namespace storage
 	else if (is_nfs(target_device))
 	    return CompoundAction::Formatter::Nfs(this).string_representation();
 
-	else if (is_bcache(target_device))
+	else if (is_bcache(target_device) || is_bcache_cset(target_device))
 	    return CompoundAction::Formatter::Bcache(this).string_representation();
 
 	else

--- a/storage/CompoundActionImpl.cc
+++ b/storage/CompoundActionImpl.cc
@@ -29,6 +29,7 @@
 #include "storage/CompoundAction/Formatter/BtrfsSubvolume.h"
 #include "storage/CompoundAction/Formatter/LvmLv.h"
 #include "storage/CompoundAction/Formatter/LvmVg.h"
+#include "storage/CompoundAction/Formatter/Md.h"
 #include "storage/CompoundAction/Formatter/Nfs.h"
 #include "storage/CompoundAction/Formatter/Partition.h"
 #include "storage/CompoundAction/Formatter/StrayBlkDevice.h"
@@ -109,7 +110,7 @@ namespace storage
 	if (is_partition(target_device))
 	    return CompoundAction::Formatter::Partition(this).string_representation();
 
-	if (is_stray_blk_device(target_device))
+	else if (is_stray_blk_device(target_device))
 	    return CompoundAction::Formatter::StrayBlkDevice(this).string_representation();
 
 	else if (is_lvm_lv(target_device))
@@ -129,6 +130,9 @@ namespace storage
 
 	else if (is_bcache(target_device) || is_bcache_cset(target_device))
 	    return CompoundAction::Formatter::Bcache(this).string_representation();
+
+	else if (is_md(target_device))
+	    return CompoundAction::Formatter::Md(this).string_representation();
 
 	else
 	    return boost::algorithm::join(get_commit_actions_as_strings(), "\n");

--- a/storage/CompoundActionImpl.cc
+++ b/storage/CompoundActionImpl.cc
@@ -131,7 +131,7 @@ namespace storage
 	    return CompoundAction::Formatter::Bcache(this).string_representation();
 
 	else
-	    return boost::algorithm::join(get_commit_actions_as_strings(), " and ");
+	    return boost::algorithm::join(get_commit_actions_as_strings(), "\n");
     }
 
 

--- a/storage/Makefile.am
+++ b/storage/Makefile.am
@@ -34,14 +34,15 @@ libstorage_ng_la_SOURCES =						\
 
 libstorage_ng_la_LDFLAGS = -version-info @LIBVERSION_INFO@
 
-libstorage_ng_la_LIBADD =			\
-	CompoundAction/libcompoundaction.la	\
-	Devices/libdevices.la			\
-	Filesystems/libfilesystems.la		\
-	Holders/libholders.la			\
-	Utils/libutils.la			\
-	SystemInfo/libsystem-info.la		\
-	$(XML_LIBS)				\
+libstorage_ng_la_LIBADD =				\
+	CompoundAction/libcompoundaction.la		\
+	CompoundAction/Formatter/libcompformatter.la	\
+	Devices/libdevices.la			        \
+	Filesystems/libfilesystems.la		        \
+	Holders/libholders.la			        \
+	Utils/libutils.la			        \
+	SystemInfo/libsystem-info.la		        \
+	$(XML_LIBS)				        \
 	$(JSON_C_LIBS)
 
 pkgincludedir = $(includedir)/storage

--- a/testsuite/CompoundAction/Fixture.h
+++ b/testsuite/CompoundAction/Fixture.h
@@ -38,6 +38,8 @@ namespace storage
 		sda2 = gpt->create_partition("/dev/sda2", Region(2048, 500 * 2048, 512), PartitionType::PRIMARY);
 	    }
 
+
+
 	    void
 	    initialize_with_devicegraph(string devicegraph_file)
 	    {
@@ -72,6 +74,15 @@ namespace storage
 
 		return nullptr;
 	    }
+
+
+            void
+            copy_staging_to_probed()
+            {
+                storage->remove_devicegraph("system");
+                storage->copy_devicegraph("staging", "system");
+            }
+
 
 	    shared_ptr<Storage> storage;
 	    Devicegraph* staging;

--- a/testsuite/CompoundAction/Makefile.am
+++ b/testsuite/CompoundAction/Makefile.am
@@ -10,14 +10,15 @@ AM_CPPFLAGS = -I$(top_srcdir)
 
 LDADD = ../../storage/libstorage-ng.la libcompoundactionfixture.la -lboost_unit_test_framework
 
-check_PROGRAMS =                                \
-	btrfs-subvolume-sentence.test           \
-	encrypted-sentence.test                 \
-	is-delete.test                          \
-	lvm-lv-sentence.test                    \
-	lvm-vg-sentence.test                    \
-	nfs-sentence.test                       \
-	partition-sentence.test                 \
+check_PROGRAMS =				\
+	bcache-sentence.test			\
+	btrfs-subvolume-sentence.test		\
+	encrypted-sentence.test			\
+	is-delete.test				\
+	lvm-lv-sentence.test			\
+	lvm-vg-sentence.test			\
+	nfs-sentence.test			\
+	partition-sentence.test			\
 	stray-blk-device-sentence.test
 
 AM_DEFAULT_SOURCE_EXT = .cc

--- a/testsuite/CompoundAction/Makefile.am
+++ b/testsuite/CompoundAction/Makefile.am
@@ -17,6 +17,7 @@ check_PROGRAMS =				\
 	is-delete.test				\
 	lvm-lv-sentence.test			\
 	lvm-vg-sentence.test			\
+	md-sentence.test			\
 	nfs-sentence.test			\
 	partition-sentence.test			\
 	stray-blk-device-sentence.test

--- a/testsuite/CompoundAction/Makefile.am
+++ b/testsuite/CompoundAction/Makefile.am
@@ -10,9 +10,16 @@ AM_CPPFLAGS = -I$(top_srcdir)
 
 LDADD = ../../storage/libstorage-ng.la libcompoundactionfixture.la -lboost_unit_test_framework
 
-check_PROGRAMS = btrfs-subvolume-sentence.test lvm-vg-sentence.test lvm-lv-sentence.test \
-		 nfs-sentence.test partition-sentence.test is-delete.test encrypted-sentence.test
-		 
+check_PROGRAMS =                                \
+	btrfs-subvolume-sentence.test           \
+	encrypted-sentence.test                 \
+	is-delete.test                          \
+	lvm-lv-sentence.test                    \
+	lvm-vg-sentence.test                    \
+	nfs-sentence.test                       \
+	partition-sentence.test                 \
+	stray-blk-device-sentence.test
+
 AM_DEFAULT_SOURCE_EXT = .cc
 
 TESTS = $(check_PROGRAMS)

--- a/testsuite/CompoundAction/bcache-sentence.cc
+++ b/testsuite/CompoundAction/bcache-sentence.cc
@@ -1,0 +1,123 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE libstorage
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+
+#include "storage/Devices/Bcache.h"
+#include "storage/Devices/BcacheCset.h"
+#include "storage/Devices/Encryption.h"
+
+#include "storage/Filesystems/BlkFilesystem.h"
+#include "storage/Filesystems/MountPoint.h"
+#include "storage/Devices/LvmVg.h"
+#include "storage/Devices/LvmPv.h"
+
+#include "testsuite/CompoundAction/Fixture.h"
+
+#define BLOCK_SIZE	1024L
+#define kiB             1L
+#define MiB		(1024L*kiB)
+#define GiB		(1024L*MiB)
+#define TiB		(1024L*GiB)
+
+
+// DEBUG
+// DEBUG
+// DEBUG
+#include <iostream>
+using std::cout;
+using std::endl;
+// DEBUG
+// DEBUG
+// DEBUG
+
+
+namespace storage
+{
+    namespace test
+    {
+	struct BCacheFixture: public CompoundActionFixture
+	{
+	    BCacheFixture():
+		disk0(0),
+		disk1(0),
+		ssd0(0),
+		ssd1(0),
+		ssd2(0)
+	    {
+                init_disks();
+            }
+
+
+	    void init_disks()
+	    {
+		Environment environment(true, ProbeMode::NONE, TargetMode::IMAGE);
+		storage = shared_ptr<Storage>(new Storage(environment));
+		staging = storage->get_staging();
+
+		disk0 = Disk::create( staging, "/dev/sda", Region( 0,   2*TiB, BLOCK_SIZE ) );
+		disk1 = Disk::create( staging, "/dev/sdb", Region( 0, 512*MiB, BLOCK_SIZE ) );
+
+		ssd0  = Disk::create( staging, "/dev/sdf", Region( 0, 128*MiB, BLOCK_SIZE ) );
+		ssd1  = Disk::create( staging, "/dev/sdg", Region( 0, 160*MiB, BLOCK_SIZE ) );
+		ssd2  = Disk::create( staging, "/dev/sdh", Region( 0,  64*MiB, BLOCK_SIZE ) );
+
+		copy_staging_to_probed();
+	    }
+
+
+	    Disk * disk0;
+	    Disk * disk1;
+	    Disk * ssd0;
+	    Disk * ssd1;
+	    Disk * ssd2;
+	};
+    }
+}
+
+using namespace storage;
+
+BOOST_FIXTURE_TEST_SUITE( bcache_sentence, test::BCacheFixture )
+
+
+BOOST_AUTO_TEST_CASE( test1 )
+{
+    BcacheCset * cset0 = ssd0->create_bcache_cset();
+    Bcache * bcache0 = disk0->create_bcache( "/dev/bcache0" );
+    bcache0->attach_bcache_cset( cset0 );
+
+    BlkFilesystem * ext4 = bcache0->create_blk_filesystem( FsType::EXT4 );
+    ext4->create_mount_point( "/data" );
+
+    
+    BcacheCset * cset1 = ssd1->create_bcache_cset();
+    BcacheCset * cset2 = ssd2->create_bcache_cset();
+
+    Bcache * bcache1 = disk1->create_bcache( "/dev/bcache1" );
+    bcache1->attach_bcache_cset( cset1 );
+    bcache1->attach_bcache_cset( cset2 );
+
+    Encryption * encryption = bcache1->create_encryption( "cr_bcache1" );
+    BlkFilesystem * xfs = encryption->create_blk_filesystem( FsType::XFS );
+    xfs->create_mount_point( "/home" );
+
+
+    const Actiongraph	 * actiongraph = storage->calculate_actiongraph();
+    const CompoundAction * compound_action0 = find_compound_action_by_target( actiongraph, bcache0 );
+    const CompoundAction * compound_action1 = find_compound_action_by_target( actiongraph, bcache1 );
+    
+    BOOST_REQUIRE( compound_action0 ) ;
+    BOOST_REQUIRE( compound_action1 ) ;
+
+    BOOST_CHECK_EQUAL( compound_action0->sentence(),
+		       "Create Bcache /dev/bcache0 on /dev/sda (2.00 TiB) from /dev/sdf (128.00 GiB) for /data with ext4" );
+    
+    BOOST_CHECK_EQUAL( compound_action1->sentence(),
+		       "Create encrypted Bcache /dev/bcache1 on /dev/sdb (512 GiB) from /dev/sdg (160.00 GiB), /dev/sdh (64 MiB) for /home with XFS" );
+    
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/CompoundAction/bcache-sentence.cc
+++ b/testsuite/CompoundAction/bcache-sentence.cc
@@ -116,7 +116,11 @@ BOOST_AUTO_TEST_CASE( test1 )
     
     BOOST_CHECK_EQUAL( compound_action1->sentence(),
 		       "Create encrypted Bcache /dev/bcache1 on /dev/sdb (512 GiB) from /dev/sdg (160.00 GiB), /dev/sdh (64 MiB) for /home with XFS" );
-    
+
+#if 1
+    cout << "\naction0:\n" << compound_action0->sentence() << "\n" << endl;
+    cout << "\naction1:\n" << compound_action1->sentence() << "\n" << endl;
+#endif
 }
 
 

--- a/testsuite/CompoundAction/bcache-sentence.cc
+++ b/testsuite/CompoundAction/bcache-sentence.cc
@@ -13,15 +13,11 @@
 #include "storage/Filesystems/MountPoint.h"
 #include "storage/Devices/LvmVg.h"
 #include "storage/Devices/LvmPv.h"
+#include "storage/Utils/HumanString.h"
 
 #include "testsuite/CompoundAction/Fixture.h"
 
-#define BLOCK_SIZE	1024L
-#define kiB             1L
-#define MiB		(1024L*kiB)
-#define GiB		(1024L*MiB)
-#define TiB		(1024L*GiB)
-
+#define BLOCK_SIZE	512L
 
 using std::cout;
 using std::endl;
@@ -53,11 +49,11 @@ namespace storage
 		storage = shared_ptr<Storage>(new Storage(environment));
 		staging = storage->get_staging();
 
-		disk0 = Disk::create( staging, "/dev/sda", Region( 0,   2*TiB, BLOCK_SIZE ) );
-		disk1 = Disk::create( staging, "/dev/sdb", Region( 0, 512*GiB, BLOCK_SIZE ) );
+		disk0 = Disk::create( staging, "/dev/sda", Region( 0,   2*TiB / BLOCK_SIZE, BLOCK_SIZE ) );
+		disk1 = Disk::create( staging, "/dev/sdb", Region( 0, 512*GiB / BLOCK_SIZE, BLOCK_SIZE ) );
 
-		ssd0  = Disk::create( staging, "/dev/sdf", Region( 0, 128*MiB, BLOCK_SIZE ) );
-		ssd1  = Disk::create( staging, "/dev/sdg", Region( 0, 160*MiB, BLOCK_SIZE ) );
+		ssd0  = Disk::create( staging, "/dev/sdf", Region( 0, 128*MiB / BLOCK_SIZE, BLOCK_SIZE ) );
+		ssd1  = Disk::create( staging, "/dev/sdg", Region( 0, 160*MiB / BLOCK_SIZE, BLOCK_SIZE ) );
 
 		copy_staging_to_probed();
 	    }

--- a/testsuite/CompoundAction/md-sentence.cc
+++ b/testsuite/CompoundAction/md-sentence.cc
@@ -40,8 +40,8 @@ namespace storage
 
 	    void create_disks()
 	    {
-		Environment environment(true, ProbeMode::NONE, TargetMode::IMAGE);
-		storage = shared_ptr<Storage>(new Storage(environment));
+		Environment environment( true, ProbeMode::NONE, TargetMode::IMAGE );
+		storage = shared_ptr<Storage>( new Storage( environment ) );
 		staging = storage->get_staging();
 
                 for ( int i=0; i < 5; ++i )

--- a/testsuite/CompoundAction/md-sentence.cc
+++ b/testsuite/CompoundAction/md-sentence.cc
@@ -272,7 +272,8 @@ BOOST_AUTO_TEST_CASE( test_create_encrypted_swap )
 
     string expected =
         "Create encrypted RAID1 /dev/md1 (511.87 GiB) for swap\n"
-        "from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB)";
+        "from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB)"
+        "\nare you serious?!";
 
     BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
 

--- a/testsuite/CompoundAction/md-sentence.cc
+++ b/testsuite/CompoundAction/md-sentence.cc
@@ -12,15 +12,11 @@
 #include "storage/Filesystems/MountPoint.h"
 #include "storage/Devices/LvmVg.h"
 #include "storage/Devices/LvmPv.h"
+#include "storage/Utils/HumanString.h"
 
 #include "testsuite/CompoundAction/Fixture.h"
 
 #define BLOCK_SIZE	1024L
-#define kiB             1L
-#define MiB		(1024L*kiB)
-#define GiB		(1024L*MiB)
-#define TiB		(1024L*GiB)
-
 
 using std::cout;
 using std::endl;
@@ -50,7 +46,8 @@ namespace storage
                     device_name += 'a' + i;
 
                     // cout << "Creating disk " << device_name << endl;
-                    Disk * disk = Disk::create( staging, device_name, Region( 0, 512*GiB, BLOCK_SIZE ) );
+                    Disk * disk = Disk::create( staging, device_name,
+                                                Region( 0, 512*GiB / BLOCK_SIZE, BLOCK_SIZE ) );
                     disks.push_back( disk );
                 }
 

--- a/testsuite/CompoundAction/md-sentence.cc
+++ b/testsuite/CompoundAction/md-sentence.cc
@@ -57,7 +57,7 @@ namespace storage
 		copy_staging_to_probed();
 	    }
 
-            
+
             Md * create_raid( const string & raid_name, MdLevel md_level )
             {
                 Md * raid = Md::create( staging, raid_name );
@@ -82,13 +82,12 @@ using namespace storage;
 BOOST_FIXTURE_TEST_SUITE( md_raid_sentence, test::MdFixture )
 
 
-BOOST_AUTO_TEST_CASE( test_create )
+BOOST_AUTO_TEST_CASE( test_create_format_mount )
 {
     Md * raid = create_raid( "/dev/md0", MdLevel::RAID6 );
-        
-    // Encryption * encryption = raid->create_encryption( "cr_raid0" );
-    BlkFilesystem * ext4 = raid->create_blk_filesystem( FsType::EXT4 );
-    ext4->create_mount_point( "/data" );
+
+    BlkFilesystem * fs = raid->create_blk_filesystem( FsType::EXT4 );
+    fs->create_mount_point( "/data" );
 
 
     const Actiongraph	 * actiongraph     = storage->calculate_actiongraph();
@@ -99,6 +98,181 @@ BOOST_AUTO_TEST_CASE( test_create )
     string expected =
         "Create RAID6 /dev/md0 (1023.75 GiB) for /data with ext4\n"
         "from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB), /dev/sdc (512.00 GiB), /dev/sdd (512.00 GiB)";
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
+
+#if 0
+    cout << "\nEXPECTED:\n\n" << expected << "\n" << endl;
+    cout << "\nACTUAL:\n\n"   << compound_action->sentence() << "\n" << endl;
+#endif
+}
+
+
+BOOST_AUTO_TEST_CASE( test_create_encrypt_format_mount )
+{
+    Md * raid = create_raid( "/dev/md0", MdLevel::RAID1 );
+
+    Encryption * encryption = raid->create_encryption( "cr_raid0" );
+    BlkFilesystem * fs = encryption->create_blk_filesystem( FsType::XFS );
+    fs->create_mount_point( "/secret" );
+
+
+    const Actiongraph	 * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, raid );
+
+    BOOST_REQUIRE( compound_action ) ;
+
+    string expected =
+        "Create encrypted RAID1 /dev/md0 (511.87 GiB) for /secret with xfs\n"
+        "from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB)";
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
+
+#if 0
+    cout << "\nEXPECTED:\n\n" << expected << "\n" << endl;
+    cout << "\nACTUAL:\n\n"   << compound_action->sentence() << "\n" << endl;
+#endif
+}
+
+
+BOOST_AUTO_TEST_CASE( test_create_encrypt_format_no_mount )
+{
+    Md * raid = create_raid( "/dev/md0", MdLevel::RAID1 );
+
+    Encryption * encryption = raid->create_encryption( "cr_raid0" );
+    encryption->create_blk_filesystem( FsType::XFS );
+
+    const Actiongraph	 * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, raid );
+
+    BOOST_REQUIRE( compound_action ) ;
+
+    string expected =
+        "Create encrypted RAID1 /dev/md0 (511.87 GiB) with xfs\n"
+        "from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB)";
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
+
+#if 0
+    cout << "\nEXPECTED:\n\n" << expected << "\n" << endl;
+    cout << "\nACTUAL:\n\n"   << compound_action->sentence() << "\n" << endl;
+#endif
+}
+
+
+BOOST_AUTO_TEST_CASE( test_just_create )
+{
+    Md * raid = create_raid( "/dev/md0", MdLevel::RAID1 );
+
+    const Actiongraph	 * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, raid );
+
+    BOOST_REQUIRE( compound_action ) ;
+
+    string expected =
+        "Create RAID1 /dev/md0 (511.87 GiB) from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB)";
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
+
+#if 0
+    cout << "\nEXPECTED:\n\n" << expected << "\n" << endl;
+    cout << "\nACTUAL:\n\n"   << compound_action->sentence() << "\n" << endl;
+#endif
+}
+
+
+BOOST_AUTO_TEST_CASE( test_format_mount )
+{
+    Md * raid = create_raid( "/dev/md0", MdLevel::RAID6 );
+    copy_staging_to_probed();
+
+    BlkFilesystem * fs = raid->create_blk_filesystem( FsType::EXT4 );
+    fs->create_mount_point( "/data" );
+
+
+    const Actiongraph	 * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, raid );
+
+    BOOST_REQUIRE( compound_action ) ;
+
+    string expected = "Format RAID6 /dev/md0 (1023.75 GiB) for /data with ext4";
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
+
+#if 0
+    cout << "\nEXPECTED:\n\n" << expected << "\n" << endl;
+    cout << "\nACTUAL:\n\n"   << compound_action->sentence() << "\n" << endl;
+#endif
+}
+
+
+BOOST_AUTO_TEST_CASE( test_encrypt_format_mount )
+{
+    Md * raid = create_raid( "/dev/md0", MdLevel::RAID5 );
+    copy_staging_to_probed();
+
+    Encryption * encryption = raid->create_encryption( "cr_raid0" );
+    BlkFilesystem * fs = encryption->create_blk_filesystem( FsType::XFS );
+
+    fs->create_mount_point( "/data" );
+
+    const Actiongraph	 * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, raid );
+
+    BOOST_REQUIRE( compound_action ) ;
+
+    string expected = "Encrypt RAID5 /dev/md0 (1023.75 GiB) for /data with xfs";
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
+
+#if 0
+    cout << "\nEXPECTED:\n\n" << expected << "\n" << endl;
+    cout << "\nACTUAL:\n\n"   << compound_action->sentence() << "\n" << endl;
+#endif
+}
+
+
+BOOST_AUTO_TEST_CASE( test_just_mount )
+{
+    Md * raid = create_raid( "/dev/md0", MdLevel::RAID5 );
+    BlkFilesystem * fs = raid->create_blk_filesystem( FsType::EXT4 );
+    copy_staging_to_probed();
+
+    fs->create_mount_point( "/data" );
+
+
+    const Actiongraph	 * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, raid );
+
+    BOOST_REQUIRE( compound_action ) ;
+
+    string expected = "Mount RAID5 /dev/md0 (1023.75 GiB) at /data";
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
+
+#if 0
+    cout << "\nEXPECTED:\n\n" << expected << "\n" << endl;
+    cout << "\nACTUAL:\n\n"   << compound_action->sentence() << "\n" << endl;
+#endif
+}
+
+
+BOOST_AUTO_TEST_CASE( test_create_encrypted_swap )
+{
+    Md * raid = create_raid( "/dev/md1", MdLevel::RAID1 );
+
+    Encryption * encryption = raid->create_encryption( "cr_raid1" );
+    BlkFilesystem * fs = encryption->create_blk_filesystem( FsType::SWAP );
+    fs->create_mount_point( "swap" );
+
+    const Actiongraph	 * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, raid );
+
+    BOOST_REQUIRE( compound_action ) ;
+
+    string expected =
+        "Create encrypted RAID1 /dev/md1 (511.87 GiB) for swap\n"
+        "from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB)";
 
     BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
 

--- a/testsuite/CompoundAction/md-sentence.cc
+++ b/testsuite/CompoundAction/md-sentence.cc
@@ -97,13 +97,12 @@ BOOST_AUTO_TEST_CASE( test_create )
     BOOST_REQUIRE( compound_action ) ;
 
     string expected =
-        "Create RAID 0 /dev/md0 (1023.75 GiB) for /data with ext4\n"
-        "from /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB), /dev/sdd (512 GiB)";
+        "Create RAID6 /dev/md0 (1023.75 GiB) for /data with ext4\n"
+        "from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB), /dev/sdc (512.00 GiB), /dev/sdd (512.00 GiB)";
 
     BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
 
-
-#if 1
+#if 0
     cout << "\nEXPECTED:\n\n" << expected << "\n" << endl;
     cout << "\nACTUAL:\n\n"   << compound_action->sentence() << "\n" << endl;
 #endif

--- a/testsuite/CompoundAction/md-sentence.cc
+++ b/testsuite/CompoundAction/md-sentence.cc
@@ -1,0 +1,113 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE libstorage
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+
+#include "storage/Devices/Md.h"
+#include "storage/Devices/Encryption.h"
+
+#include "storage/Filesystems/BlkFilesystem.h"
+#include "storage/Filesystems/MountPoint.h"
+#include "storage/Devices/LvmVg.h"
+#include "storage/Devices/LvmPv.h"
+
+#include "testsuite/CompoundAction/Fixture.h"
+
+#define BLOCK_SIZE	1024L
+#define kiB             1L
+#define MiB		(1024L*kiB)
+#define GiB		(1024L*MiB)
+#define TiB		(1024L*GiB)
+
+
+using std::cout;
+using std::endl;
+
+
+namespace storage
+{
+    namespace test
+    {
+	struct MdFixture: public CompoundActionFixture
+	{
+	    MdFixture()
+	    {
+                create_disks();
+            }
+
+
+	    void create_disks()
+	    {
+		Environment environment(true, ProbeMode::NONE, TargetMode::IMAGE);
+		storage = shared_ptr<Storage>(new Storage(environment));
+		staging = storage->get_staging();
+
+                for ( int i=0; i < 5; ++i )
+                {
+                    string device_name = "/dev/sd";
+                    device_name += 'a' + i;
+
+                    // cout << "Creating disk " << device_name << endl;
+                    Disk * disk = Disk::create( staging, device_name, Region( 0, 512*GiB, BLOCK_SIZE ) );
+                    disks.push_back( disk );
+                }
+
+		copy_staging_to_probed();
+	    }
+
+            
+            Md * create_raid( const string & raid_name, MdLevel md_level )
+            {
+                Md * raid = Md::create( staging, raid_name );
+                raid->set_md_level( md_level );
+
+                for ( unsigned i=0; i < raid->minimal_number_of_devices() && i < disk_count(); ++i )
+                    raid->add_device( disks[i] );
+
+                return raid;
+            }
+
+
+            unsigned disk_count() const { return disks.size(); }
+
+	    vector<Disk *> disks;
+	};
+    }
+}
+
+using namespace storage;
+
+BOOST_FIXTURE_TEST_SUITE( md_raid_sentence, test::MdFixture )
+
+
+BOOST_AUTO_TEST_CASE( test_create )
+{
+    Md * raid = create_raid( "/dev/md0", MdLevel::RAID6 );
+        
+    // Encryption * encryption = raid->create_encryption( "cr_raid0" );
+    BlkFilesystem * ext4 = raid->create_blk_filesystem( FsType::EXT4 );
+    ext4->create_mount_point( "/data" );
+
+
+    const Actiongraph	 * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, raid );
+
+    BOOST_REQUIRE( compound_action ) ;
+
+    string expected =
+        "Create RAID 0 /dev/md0 (1023.75 GiB) for /data with ext4\n"
+        "from /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB), /dev/sdd (512 GiB)";
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
+
+
+#if 1
+    cout << "\nEXPECTED:\n\n" << expected << "\n" << endl;
+    cout << "\nACTUAL:\n\n"   << compound_action->sentence() << "\n" << endl;
+#endif
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/CompoundAction/stray-blk-device-sentence.cc
+++ b/testsuite/CompoundAction/stray-blk-device-sentence.cc
@@ -3,7 +3,6 @@
 #define BOOST_TEST_MODULE libstorage
 
 #include <boost/test/unit_test.hpp>
-#include <iostream>
 
 #include "storage/Devices/StrayBlkDevice.h"
 #include "storage/Devices/Encryption.h"
@@ -45,8 +44,6 @@ namespace storage
 }
 
 using namespace storage;
-using std::cout;
-using std::endl;
 
 
 BOOST_FIXTURE_TEST_SUITE(stray_blk_device_sentence, test::StrayBlkDeviceFixture)

--- a/testsuite/CompoundAction/stray-blk-device-sentence.cc
+++ b/testsuite/CompoundAction/stray-blk-device-sentence.cc
@@ -1,0 +1,181 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE libstorage
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+
+#include "storage/Devices/StrayBlkDevice.h"
+#include "storage/Devices/Encryption.h"
+#include "storage/Filesystems/BlkFilesystem.h"
+#include "storage/Filesystems/MountPoint.h"
+#include "storage/Devices/LvmVg.h"
+#include "storage/Devices/LvmPv.h"
+
+#include "testsuite/CompoundAction/Fixture.h"
+
+
+namespace storage
+{
+    namespace test
+    {
+	struct StrayBlkDeviceFixture: public CompoundActionFixture
+        {
+	    void
+	    initialize_probed_with_three_strays()
+	    {
+		Environment environment(true, ProbeMode::NONE, TargetMode::IMAGE);
+		storage = shared_ptr<Storage>(new Storage(environment));
+		staging = storage->get_staging();
+
+                // StrayBlkDevice regions always start at 0
+
+		stray1 = StrayBlkDevice::create(staging, "/dev/vda1", Region(0,    4 * 2048, 512));
+		stray2 = StrayBlkDevice::create(staging, "/dev/vda2", Region(0,  500 * 2048, 512));
+		stray3 = StrayBlkDevice::create(staging, "/dev/vda3", Region(0, 4096 * 2048, 512));
+
+                copy_staging_to_probed();
+	    }
+
+	    StrayBlkDevice * stray1;
+	    StrayBlkDevice * stray2;
+	    StrayBlkDevice * stray3;
+        };
+    }
+}
+
+using namespace storage;
+using std::cout;
+using std::endl;
+
+
+BOOST_FIXTURE_TEST_SUITE(stray_blk_device_sentence, test::StrayBlkDeviceFixture)
+
+
+BOOST_AUTO_TEST_CASE( test_format_and_mount )
+{
+    initialize_probed_with_three_strays();
+
+    StrayBlkDevice * stray = StrayBlkDevice::find_by_name( staging, "/dev/vda3" );
+    BlkFilesystem  * fs    = stray->create_blk_filesystem( FsType::EXT4 );
+    fs->create_mount_point( "/home" );
+    const Actiongraph    * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, stray );
+
+    BOOST_REQUIRE( compound_action) ;
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(),
+                       "Format partition /dev/vda3 (4.00 GiB) for /home with ext4");
+}
+
+
+BOOST_AUTO_TEST_CASE( test_format_no_mount )
+{
+    initialize_probed_with_three_strays();
+
+    StrayBlkDevice * stray = StrayBlkDevice::find_by_name( staging, "/dev/vda3" );
+    stray->create_blk_filesystem( FsType::EXT4 );
+    // Not mounting this filesystem
+
+    const Actiongraph    * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, stray );
+
+    BOOST_REQUIRE( compound_action) ;
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(),
+                       "Format partition /dev/vda3 (4.00 GiB) with ext4");
+}
+
+
+BOOST_AUTO_TEST_CASE( test_mount_no_format )
+{
+    initialize_probed_with_three_strays();
+
+    StrayBlkDevice * stray = StrayBlkDevice::find_by_name( staging, "/dev/vda3" );
+    BlkFilesystem  * fs    = stray->create_blk_filesystem( FsType::EXT4 );
+    // Pretend the filesystem was already there during probing
+    copy_staging_to_probed();
+
+    fs->create_mount_point( "/home" );
+
+    const Actiongraph    * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, stray );
+
+    BOOST_REQUIRE( compound_action) ;
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(),
+                       "Mount partition /dev/vda3 (4.00 GiB) at /home");
+}
+
+
+BOOST_AUTO_TEST_CASE( test_swap )
+{
+    initialize_probed_with_three_strays();
+
+    StrayBlkDevice * stray = StrayBlkDevice::find_by_name( staging, "/dev/vda3" );
+    BlkFilesystem  * swap  = stray->create_blk_filesystem( FsType::SWAP );
+    swap->create_mount_point( "swap" );
+    const Actiongraph    * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, stray );
+
+    BOOST_REQUIRE( compound_action) ;
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(),
+                       "Format partition /dev/vda3 (4.00 GiB) as swap");
+}
+
+
+BOOST_AUTO_TEST_CASE( test_encrypted_swap )
+{
+    initialize_probed_with_three_strays();
+
+    StrayBlkDevice * stray      = StrayBlkDevice::find_by_name( staging, "/dev/vda3" );
+    Encryption     * encryption = stray3->create_encryption("cr_vda3");
+    BlkFilesystem  * swap       = encryption->create_blk_filesystem( FsType::SWAP );
+    swap->create_mount_point( "swap" );
+    const Actiongraph    * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, stray );
+
+    BOOST_REQUIRE( compound_action) ;
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(),
+                       "Format partition /dev/vda3 (4.00 GiB) as encryped swap");
+}
+
+
+BOOST_AUTO_TEST_CASE( test_lvm_pv )
+{
+    initialize_probed_with_three_strays();
+
+    LvmVg * lvm_vg = LvmVg::create(staging, "test-vg");
+    lvm_vg->add_lvm_pv( stray3 );
+
+    const Actiongraph    * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target(actiongraph, stray3);
+
+    BOOST_REQUIRE( compound_action );
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(),
+                       "Create LVM physical volume over /dev/vda3 (4.00 GiB)" );
+}
+
+
+BOOST_AUTO_TEST_CASE( test_encrypted_pv )
+{
+    initialize_probed_with_three_strays();
+
+    Encryption * encryption = stray3->create_encryption("cr_vda3");
+    LvmVg * lvm_vg = LvmVg::create(staging, "test-vg");
+    lvm_vg->add_lvm_pv( encryption );
+
+    const Actiongraph    * actiongraph     = storage->calculate_actiongraph();
+    const CompoundAction * compound_action = find_compound_action_by_target(actiongraph, stray3);
+
+    BOOST_REQUIRE( compound_action );
+
+    BOOST_CHECK_EQUAL( compound_action->sentence(),
+                       "Create LVM physical volume over encrypted /dev/vda3 (4.00 GiB)" );
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/CompoundAction/stray-blk-device-sentence.cc
+++ b/testsuite/CompoundAction/stray-blk-device-sentence.cc
@@ -23,15 +23,15 @@ namespace storage
 	    void
 	    initialize_probed_with_three_strays()
 	    {
-		Environment environment(true, ProbeMode::NONE, TargetMode::IMAGE);
-		storage = shared_ptr<Storage>(new Storage(environment));
+		Environment environment( true, ProbeMode::NONE, TargetMode::IMAGE );
+		storage = shared_ptr<Storage>( new Storage( environment ) );
 		staging = storage->get_staging();
 
                 // StrayBlkDevice regions always start at 0
 
-		stray1 = StrayBlkDevice::create(staging, "/dev/vda1", Region(0,    4 * 2048, 512));
-		stray2 = StrayBlkDevice::create(staging, "/dev/vda2", Region(0,  500 * 2048, 512));
-		stray3 = StrayBlkDevice::create(staging, "/dev/vda3", Region(0, 4096 * 2048, 512));
+		stray1 = StrayBlkDevice::create( staging, "/dev/vda1", Region( 0,    4 * 2048, 512 ) );
+		stray2 = StrayBlkDevice::create( staging, "/dev/vda2", Region( 0,  500 * 2048, 512 ) );
+		stray3 = StrayBlkDevice::create( staging, "/dev/vda3", Region( 0, 4096 * 2048, 512 ) );
 
                 copy_staging_to_probed();
 	    }
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE( test_format_and_mount )
     BOOST_REQUIRE( compound_action) ;
 
     BOOST_CHECK_EQUAL( compound_action->sentence(),
-                       "Format partition /dev/vda3 (4.00 GiB) for /home with ext4");
+                       "Format partition /dev/vda3 (4.00 GiB) for /home with ext4" );
 }
 
 
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE( test_format_no_mount )
     BOOST_REQUIRE( compound_action) ;
 
     BOOST_CHECK_EQUAL( compound_action->sentence(),
-                       "Format partition /dev/vda3 (4.00 GiB) with ext4");
+                       "Format partition /dev/vda3 (4.00 GiB) with ext4" );
 }
 
 
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE( test_swap )
     BOOST_REQUIRE( compound_action) ;
 
     BOOST_CHECK_EQUAL( compound_action->sentence(),
-                       "Format partition /dev/vda3 (4.00 GiB) as swap");
+                       "Format partition /dev/vda3 (4.00 GiB) as swap" );
 }
 
 
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE( test_encrypted_swap )
     BOOST_REQUIRE( compound_action) ;
 
     BOOST_CHECK_EQUAL( compound_action->sentence(),
-                       "Format partition /dev/vda3 (4.00 GiB) as encryped swap");
+                       "Format partition /dev/vda3 (4.00 GiB) as encryped swap" );
 }
 
 
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE( test_lvm_pv )
 {
     initialize_probed_with_three_strays();
 
-    LvmVg * lvm_vg = LvmVg::create(staging, "test-vg");
+    LvmVg * lvm_vg = LvmVg::create( staging, "test-vg" );
     lvm_vg->add_lvm_pv( stray3 );
 
     const Actiongraph    * actiongraph     = storage->calculate_actiongraph();
@@ -161,12 +161,12 @@ BOOST_AUTO_TEST_CASE( test_encrypted_pv )
 {
     initialize_probed_with_three_strays();
 
-    Encryption * encryption = stray3->create_encryption("cr_vda3");
-    LvmVg * lvm_vg = LvmVg::create(staging, "test-vg");
+    Encryption * encryption = stray3->create_encryption( "cr_vda3" );
+    LvmVg * lvm_vg = LvmVg::create( staging, "test-vg" );
     lvm_vg->add_lvm_pv( encryption );
 
     const Actiongraph    * actiongraph     = storage->calculate_actiongraph();
-    const CompoundAction * compound_action = find_compound_action_by_target(actiongraph, stray3);
+    const CompoundAction * compound_action = find_compound_action_by_target( actiongraph, stray3 );
 
     BOOST_REQUIRE( compound_action );
 


### PR DESCRIPTION
## Trello

https://trello.com/c/pknRFKvl/184-3-implement-the-missing-compound-actions

## Changes

### Added CompoundActions formatter for StrayBlkDevices

The texts are mostly taken from the partitions formatter.

Since those StrayBlkDevices are only created in a Xen environment, we don't allow the user to create them, so most of the texts that partitions have are irrelevant here.


### Added CompoundActions formatter for Bcache

Using two-line sentences to avoid too complex single-line sentences.

Examples:

    Create bcache /dev/bcache0 on /dev/sda (2.00 TiB) for /data with ext4
    /dev/bcache0 is cached by /dev/sdf (128.00 MiB)

    Create encrypted bcache /dev/bcache1 on /dev/sdb (512.00 GiB) for /home with xfs
    /dev/bcache1 is cached by /dev/sdg (160.00 MiB)

This is prepared for Bcache-Csets with more than one device (which we can't create in the partitioner or easily with libstorage-ng).


### MD-RAID

Using mostly two-line sentences to avoid too complex single-line sentences.

Example:

    Create RAID6 /dev/md0 (1023.75 GiB) for /data with ext4
    from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB), /dev/sdc (512.00 GiB), /dev/sdd (512.00 GiB)

    Create encrypted RAID1 /dev/md0 (511.87 GiB) for /secret with xfs
    from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB)

...but not always:

    Create RAID1 /dev/md0 (511.87 GiB) from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB)
    Mount RAID5 /dev/md1 (1023.75 GiB) at /data
    Encrypt RAID5 /dev/md2 (1023.75 GiB) for /secret with xfs


