### PR TITLE
Activate SWIG trackobject feature

### DIFF
--- a/bindings/ruby/storage-ruby.i
+++ b/bindings/ruby/storage-ruby.i
@@ -37,3 +37,6 @@
 
 %include "../storage.i"
 
+// Tell SWIG to keep track of mappings between C/C++ structs/classes
+// See Object Tracking section at http://www.swig.org/Doc1.3/Ruby.html#Ruby_nn60
+%trackobjects;


### PR DESCRIPTION
Using "trackobjects" SWIG feature to avoid aleatory unit tests crashes at IBS and OBS, for example: https://build.suse.de/build/Devel:YaST:Head/SUSE_SLE-15-SP1_GA/s390x/yast2-storage-ng/_log

Maybe this does not solve the problem at all, only giving it a try.