### PR TITLE
Fix dead links to old libstorage in the documentation

### DIFF
--- a/doc/goals.md
+++ b/doc/goals.md
@@ -7,15 +7,15 @@ YaST is to make YaST catch up with storage trends of the last years, to
 provide new features and at the same time improve robustness and testability.
 
 The shortcomings of the old code are documented at
-https://github.com/openSUSE/libstorage/blob/master/doc/status-current-code.md. These
-shortcomings should be removed.
+https://github.com/openSUSE/libstorage/blob/SLE-12-SP4/doc/status-current-code.md.
+These shortcomings should be removed.
 
 
 Features and Bugs
 -----------------
 
 Some features and bugs blocked by the old code are listed at
-https://github.com/openSUSE/libstorage/blob/master/doc/blocked-features-and-bugs.md.
+https://github.com/openSUSE/libstorage/blob/SLE-12-SP4/doc/blocked-features-and-bugs.md.
 
 Additional some features have already been requests:
 

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -23,7 +23,7 @@ partitions and two filesystems where one is encrypted:
 
 You might have seen the diagram above in YaST. But in libstorage-ng it is a
 direct dump of internal data structure instead of a [cumbersome
-transformation](https://github.com/openSUSE/libstorage/blob/master/storage/Graph.cc).
+transformation](https://github.com/openSUSE/libstorage/blob/SLE-12-SP4/storage/Graph.cc).
 
 The graph approach has several advantages compared to the list of list design
 of libstorage:


### PR DESCRIPTION
The master branch is deprecated in the other repo, so the files are not longer there.