### PR TITLE
improved calculation of usable size for LVM PVs (bsc#1121129)

### DIFF
--- a/storage/Devices/BlkDeviceImpl.h
+++ b/storage/Devices/BlkDeviceImpl.h
@@ -160,8 +160,9 @@ namespace storage
 
 	virtual void probe_pass_1a(Prober& prober) override;
 
-	void probe_size(Prober& prober);
-	void probe_topology(Prober& prober);
+	virtual void probe_size(Prober& prober);
+
+	virtual void probe_topology(Prober& prober);
 
 	virtual ResizeInfo detect_resize_info() const override = 0;
 

--- a/storage/Devices/LuksImpl.cc
+++ b/storage/Devices/LuksImpl.cc
@@ -366,6 +366,8 @@ namespace storage
 
 	    const File& size_file = get_sysfs_file(system_info, "size");
 	    set_region(Region(0, size_file.get<unsigned long long>(), 512));
+
+	    probe_topology(prober);
 	}
     }
 
@@ -385,12 +387,12 @@ namespace storage
     void
     Luks::Impl::parent_has_new_region(const Device* parent)
     {
-	calculate_region();
+	calculate_region_and_topology();
     }
 
 
     void
-    Luks::Impl::calculate_region()
+    Luks::Impl::calculate_region_and_topology()
     {
 	const BlkDevice* blk_device = get_blk_device();
 
@@ -405,6 +407,13 @@ namespace storage
 	    size = 0 * B;
 
 	set_size(size);
+
+	// alignment_offset is 0 even is the underlying blk device
+	// (e.g. a partition) has alignment_offset !=
+	// 0. optimal_io_size is the same as for the underlying blk
+	// device.
+
+	set_topology(Topology(0, blk_device->get_topology().get_optimal_io_size()));
     }
 
 

--- a/storage/Devices/LuksImpl.h
+++ b/storage/Devices/LuksImpl.h
@@ -120,7 +120,7 @@ namespace storage
 
 	static const unsigned long long metadata_size = 2 * MiB;
 
-	void calculate_region();
+	void calculate_region_and_topology();
 
 	string uuid;
 

--- a/storage/Devices/LvmPvImpl.cc
+++ b/storage/Devices/LvmPvImpl.cc
@@ -115,6 +115,9 @@ namespace storage
 	const BlkDevice* blk_device = get_blk_device();
 	const Topology& topology = blk_device->get_topology();
 
+	// The pe_start is simply optimal_io_size, even when the blk
+	// device, e.g. partition, is not properly aligned.
+
 	pe_start = max(default_pe_start, (unsigned long long) topology.get_optimal_io_size());
     }
 
@@ -207,10 +210,7 @@ namespace storage
 	// A physical volume must have at least one extent and space for
 	// metadata.
 
-	// TODO 1 MiB due to metadata and physical extent alignment, needs
-	// more research.
-
-	resize_info.min_size = 1 * MiB;
+	resize_info.min_size = get_pe_start();
 
 	if (has_lvm_vg())
 	{

--- a/storage/Devices/PartitionImpl.h
+++ b/storage/Devices/PartitionImpl.h
@@ -64,6 +64,8 @@ namespace storage
 
 	virtual void probe_pass_1a(Prober& prober) override;
 
+	virtual void probe_topology(Prober& prober) override;
+
 	virtual void save(xmlNode* node) const override;
 
 	virtual bool has_dependency_manager() const override { return true; }
@@ -78,6 +80,8 @@ namespace storage
 	void set_number(unsigned int number);
 
 	virtual void set_region(const Region& region) override;
+
+	void calculate_topology();
 
 	PartitionType get_type() const { return type; }
 	void set_type(PartitionType type);

--- a/storage/Devices/PartitionTableImpl.cc
+++ b/storage/Devices/PartitionTableImpl.cc
@@ -119,6 +119,8 @@ namespace storage
 	Partition* partition = Partition::create(get_devicegraph(), name, region, type);
 	Subdevice::create(get_devicegraph(), parent, partition);
 
+	partition->get_impl().calculate_topology();
+
 	partition->get_impl().update_sysfs_name_and_path();
 	partition->get_impl().update_udev_paths_and_ids();
 

--- a/testsuite/lvm-pv-usable-size.cc
+++ b/testsuite/lvm-pv-usable-size.cc
@@ -76,3 +76,25 @@ BOOST_AUTO_TEST_CASE(disk2)
 
     BOOST_CHECK_EQUAL(lvm_pv->get_usable_size(), sda->get_size() - 2 * MiB);
 }
+
+
+BOOST_AUTO_TEST_CASE(partition2)
+{
+    set_logger(get_stdout_logger());
+
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+
+    Storage storage(environment);
+
+    Devicegraph* staging = storage.get_staging();
+
+    Disk* sda = Disk::create(staging, "/dev/sda", 1 * GiB);
+    sda->set_topology(Topology(0, 2 * MiB));
+    Msdos* msdos = to_msdos(sda->create_partition_table(PtType::MSDOS));
+    Partition* sda1 = msdos->create_partition("/dev/sda1", Region(2048, 2095104, 512), PartitionType::PRIMARY);
+
+    LvmVg* lvm_vg = LvmVg::create(staging, "test");
+    const LvmPv* lvm_pv = lvm_vg->add_lvm_pv(sda1);
+
+    BOOST_CHECK_EQUAL(lvm_pv->get_usable_size(), sda1->get_size() - 2 * MiB);
+}

--- a/testsuite/probe/bcache1-mockup.xml
+++ b/testsuite/probe/bcache1-mockup.xml
@@ -908,6 +908,14 @@
       <content>41943040</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:07.0/virtio2/block/vda/vda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:07.0/virtio2/block/vda/vda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/pci0000:00/0000:00:08.0/virtio3/block/vdb/alignment_offset</name>
       <content>0</content>
     </File>
@@ -980,6 +988,18 @@
       <content>8388608</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:0c.0/virtio7/block/vdd/vdd1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:0c.0/virtio7/block/vdd/vdd2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:0c.0/virtio7/block/vdd/vdd3/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/virtual/block/bcache0/dev</name>
       <content>253:0</content>
     </File>
@@ -1006,6 +1026,10 @@
     <File>
       <name>/sys/devices/virtual/block/bcache0/size</name>
       <content>10485744</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/bcache0/bcache0p1/alignment_offset</name>
+      <content>0</content>
     </File>
     <File>
       <name>/sys/devices/virtual/block/bcache1/dev</name>
@@ -1062,6 +1086,10 @@
     <File>
       <name>/sys/devices/virtual/block/bcache2/size</name>
       <content>106480</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/bcache2/bcache2p1/alignment_offset</name>
+      <content>0</content>
     </File>
     <File>
       <name>/sys/fs/bcache/acb129b8-b55e-45bb-aa99-41a6f0a0ef07/bdev0/dev/dev</name>

--- a/testsuite/probe/bcache2-mockup.xml
+++ b/testsuite/probe/bcache2-mockup.xml
@@ -1110,6 +1110,22 @@
       <content>15974400</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:1.0/host3/target3:0:0/3:0:0:0/block/sdb/sdb1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:1.0/host3/target3:0:0/3:0:0:0/block/sdb/sdb2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:1.0/host3/target3:0:0/3:0:0:0/block/sdb/sdb3/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:1.0/host3/target3:0:0/3:0:0:0/block/sdb/sdb4/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda/alignment_offset</name>
       <content>0</content>
     </File>
@@ -1132,6 +1148,18 @@
     <File>
       <name>/sys/devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda/size</name>
       <content>104857600</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda3/alignment_offset</name>
+      <content>0</content>
     </File>
     <File>
       <name>/sys/devices/virtual/block/bcache0/alignment_offset</name>
@@ -1200,6 +1228,14 @@
     <File>
       <name>/sys/devices/virtual/block/bcache1/size</name>
       <content>2097152</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/bcache1/bcache1p1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/bcache1/bcache1p2/alignment_offset</name>
+      <content>0</content>
     </File>
     <File>
       <name>/sys/devices/virtual/block/bcache2/alignment_offset</name>

--- a/testsuite/probe/btrfs1-mockup.xml
+++ b/testsuite/probe/btrfs1-mockup.xml
@@ -583,5 +583,13 @@
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/size</name>
       <content>33554432</content>
     </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/dasd1-mockup.xml
+++ b/testsuite/probe/dasd1-mockup.xml
@@ -309,5 +309,17 @@
       <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasda/size</name>
       <content>14424480</content>
     </File>
+    <File>
+      <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasda/dasda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasda/dasda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasda/dasda3/alignment_offset</name>
+      <content>0</content>
+    </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/dasd2-mockup.xml
+++ b/testsuite/probe/dasd2-mockup.xml
@@ -508,6 +508,18 @@
       <content>14424480</content>
     </File>
     <File>
+      <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasdb/dasdb1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasdb/dasdb2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasdb/dasdb3/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/css0/0.0.0004/0.0.0160/block/dasdc/alignment_offset</name>
       <content>0</content>
     </File>

--- a/testsuite/probe/disk-mockup.xml
+++ b/testsuite/probe/disk-mockup.xml
@@ -460,6 +460,14 @@
       <content>0</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/alignment_offset</name>
       <content>0</content>
     </File>

--- a/testsuite/probe/dmraid1-mockup.xml
+++ b/testsuite/probe/dmraid1-mockup.xml
@@ -723,6 +723,14 @@
       <content>33554432</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/alignment_offset</name>
       <content>0</content>
     </File>
@@ -809,6 +817,14 @@
     <File>
       <name>/sys/devices/virtual/block/dm-1/size</name>
       <content>33534976</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-3/alignment_offset</name>
+      <content>0</content>
     </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/external-journal-mockup.xml
+++ b/testsuite/probe/external-journal-mockup.xml
@@ -702,6 +702,22 @@
       <content>33554432</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda3/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda4/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/alignment_offset</name>
       <content>0</content>
     </File>
@@ -724,6 +740,14 @@
     <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/size</name>
       <content>2147483648</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb2/alignment_offset</name>
+      <content>0</content>
     </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/luks+lvm1-mockup.xml
+++ b/testsuite/probe/luks+lvm1-mockup.xml
@@ -704,8 +704,24 @@
       <content>33554432</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/virtual/block/dm-0/size</name>
       <content>33546207</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-0/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-0/queue/optimal_io_size</name>
+      <content>0</content>
     </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/luks1-mockup.xml
+++ b/testsuite/probe/luks1-mockup.xml
@@ -427,8 +427,24 @@
       <content>33554432</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/virtual/block/dm-0/size</name>
       <content>16779264</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-0/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-0/queue/optimal_io_size</name>
+      <content>0</content>
     </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/luks2-mockup.xml
+++ b/testsuite/probe/luks2-mockup.xml
@@ -488,12 +488,44 @@
       <content>5860466688</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.3/1-1.3:1.0/host6/target6:0:0/6:0:0:0/block/sdb/sdb1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.3/1-1.3:1.0/host6/target6:0:0/6:0:0:0/block/sdb/sdb2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.3/1-1.3:1.0/host6/target6:0:0/6:0:0:0/block/sdb/sdb3/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.3/1-1.3:1.0/host6/target6:0:0/6:0:0:0/block/sdb/sdb4/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/virtual/block/dm-6/size</name>
       <content>58599424</content>
     </File>
     <File>
+      <name>/sys/devices/virtual/block/dm-6/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-6/queue/optimal_io_size</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/virtual/block/dm-8/size</name>
       <content>58601472</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-8/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-8/queue/optimal_io_size</name>
+      <content>0</content>
     </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/luks3-mockup.xml
+++ b/testsuite/probe/luks3-mockup.xml
@@ -276,8 +276,20 @@
       <content>5860466688</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc/sdc1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/virtual/block/dm-5/size</name>
       <content>2093056</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-5/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-5/queue/optimal_io_size</name>
+      <content>0</content>
     </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/lvm+luks1-mockup.xml
+++ b/testsuite/probe/lvm+luks1-mockup.xml
@@ -702,8 +702,24 @@
       <content>33554432</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/virtual/block/dm-3/size</name>
       <content>15822848</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-3/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-3/queue/optimal_io_size</name>
+      <content>0</content>
     </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/lvm-errors1-mockup.xml
+++ b/testsuite/probe/lvm-errors1-mockup.xml
@@ -566,6 +566,14 @@
       <content>2097152</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc/alignment_offset</name>
       <content>0</content>
     </File>
@@ -588,6 +596,14 @@
     <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc/size</name>
       <content>2097152</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc/sdc1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc/sdc2/alignment_offset</name>
+      <content>0</content>
     </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/lvm-unsupported1-mockup.xml
+++ b/testsuite/probe/lvm-unsupported1-mockup.xml
@@ -1069,6 +1069,10 @@
       <content>33554432</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/alignment_offset</name>
       <content>0</content>
     </File>
@@ -1091,6 +1095,10 @@
     <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/size</name>
       <content>8388608</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb1/alignment_offset</name>
+      <content>0</content>
     </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/lvm1-mockup.xml
+++ b/testsuite/probe/lvm1-mockup.xml
@@ -667,5 +667,9 @@
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/size</name>
       <content>33554432</content>
     </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/lvm2-mockup.xml
+++ b/testsuite/probe/lvm2-mockup.xml
@@ -662,5 +662,13 @@
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/size</name>
       <content>33554432</content>
     </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/md-ddf1-mockup.xml
+++ b/testsuite/probe/md-ddf1-mockup.xml
@@ -887,6 +887,14 @@
       <content>33554432</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/alignment_offset</name>
       <content>0</content>
     </File>

--- a/testsuite/probe/md-imsm1-mockup.xml
+++ b/testsuite/probe/md-imsm1-mockup.xml
@@ -887,6 +887,14 @@
       <content>33554432</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/alignment_offset</name>
       <content>0</content>
     </File>

--- a/testsuite/probe/md2-mockup.xml
+++ b/testsuite/probe/md2-mockup.xml
@@ -813,6 +813,14 @@
       <content>0</content>
     </File>
     <File>
+      <name>/sys/devices/virtual/block/md0/md0p1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/md0/md0p2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/virtual/block/md1/size</name>
       <content>16777088</content>
     </File>

--- a/testsuite/probe/md3-devicegraph.xml
+++ b/testsuite/probe/md3-devicegraph.xml
@@ -468,6 +468,9 @@
         <length>3352576</length>
         <block-size>512</block-size>
       </region>
+      <topology>
+        <optimal-io-size>1048576</optimal-io-size>
+      </topology>
       <udev-id>md-uuid-04ac694a:d5170a17:75bf9d81:6ec1f71f-part1</udev-id>
       <type>primary</type>
       <id>131</id>
@@ -485,6 +488,9 @@
         <length>3352576</length>
         <block-size>512</block-size>
       </region>
+      <topology>
+        <optimal-io-size>1048576</optimal-io-size>
+      </topology>
       <udev-id>md-uuid-d18642aa:6cec3364:52da8d3b:e6229373-part1</udev-id>
       <type>primary</type>
       <id>131</id>
@@ -502,6 +508,9 @@
         <length>3352576</length>
         <block-size>512</block-size>
       </region>
+      <topology>
+        <optimal-io-size>1048576</optimal-io-size>
+      </topology>
       <udev-id>md-uuid-0ea71d45:8bed4762:7e2112f0:67d0a563-part1</udev-id>
       <type>primary</type>
       <id>131</id>

--- a/testsuite/probe/md3-mockup.xml
+++ b/testsuite/probe/md3-mockup.xml
@@ -2085,6 +2085,18 @@
       <content>33554432</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda3/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/alignment_offset</name>
       <content>0</content>
     </File>
@@ -2107,6 +2119,54 @@
     <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/size</name>
       <content>67108864</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb3/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb4/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb5/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb6/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb7/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb8/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb9/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb10/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb11/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb12/alignment_offset</name>
+      <content>0</content>
     </File>
     <File>
       <name>/sys/devices/virtual/block/md0/alignment_offset</name>
@@ -2149,6 +2209,10 @@
       <content>6707200</content>
     </File>
     <File>
+      <name>/sys/devices/virtual/block/md1/md1p1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/virtual/block/md126/alignment_offset</name>
       <content>0</content>
     </File>
@@ -2167,6 +2231,10 @@
     <File>
       <name>/sys/devices/virtual/block/md126/size</name>
       <content>6707200</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/md126/md126p1/alignment_offset</name>
+      <content>0</content>
     </File>
     <File>
       <name>/sys/devices/virtual/block/md127/alignment_offset</name>
@@ -2227,6 +2295,10 @@
     <File>
       <name>/sys/devices/virtual/block/md_test5/size</name>
       <content>6707200</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/md_test5/md_test5p1/alignment_offset</name>
+      <content>0</content>
     </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/multi-mount-point-mockup.xml
+++ b/testsuite/probe/multi-mount-point-mockup.xml
@@ -462,6 +462,14 @@
       <content>0</content>
     </File>
     <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/alignment_offset</name>
       <content>0</content>
     </File>

--- a/testsuite/probe/multipath+luks1-mockup.xml
+++ b/testsuite/probe/multipath+luks1-mockup.xml
@@ -765,6 +765,18 @@
       <content>14424480</content>
     </File>
     <File>
+      <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasda/dasda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasda/dasda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasda/dasda3/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/css0/0.0.0008/0.0.fc00/host0/rport-0:0-0/target0:0:0/0:0:0:1085554707/block/sda/alignment_offset</name>
       <content>0</content>
     </File>
@@ -881,8 +893,20 @@
       <content>2097152</content>
     </File>
     <File>
+      <name>/sys/devices/virtual/block/dm-1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/virtual/block/dm-2/size</name>
       <content>2090975</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-2/queue/optimal_io_size</name>
+      <content>0</content>
     </File>
     <File>
       <name>/sys/devices/virtual/block/dm-3/alignment_offset</name>
@@ -907,6 +931,14 @@
     <File>
       <name>/sys/devices/virtual/block/dm-4/size</name>
       <content>2093056</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-4/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-4/queue/optimal_io_size</name>
+      <content>0</content>
     </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/multipath1-mockup.xml
+++ b/testsuite/probe/multipath1-mockup.xml
@@ -739,6 +739,18 @@
       <content>14424480</content>
     </File>
     <File>
+      <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasdb/dasdb1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasdb/dasdb2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/css0/0.0.0003/0.0.0150/block/dasdb/dasdb3/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/css0/0.0.0008/0.0.fa00/host0/rport-0:0-0/target0:0:0/0:0:0:1085554707/block/sda/alignment_offset</name>
       <content>0</content>
     </File>
@@ -853,6 +865,10 @@
     <File>
       <name>/sys/devices/virtual/block/dm-0/size</name>
       <content>2097152</content>
+    </File>
+    <File>
+      <name>/sys/devices/virtual/block/dm-1/alignment_offset</name>
+      <content>0</content>
     </File>
     <File>
       <name>/sys/devices/virtual/block/dm-3/alignment_offset</name>

--- a/testsuite/probe/ntfs1-mockup.xml
+++ b/testsuite/probe/ntfs1-mockup.xml
@@ -352,5 +352,17 @@
       <name>/sys/devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.6/1-1.6:1.0/host7/target7:0:0/7:0:0:0/block/sdc/size</name>
       <content>5860466688</content>
     </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.6/1-1.6:1.0/host7/target7:0:0/7:0:0:0/block/sdc/sdc1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.6/1-1.6:1.0/host7/target7:0:0/7:0:0:0/block/sdc/sdc2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.6/1-1.6:1.0/host7/target7:0:0/7:0:0:0/block/sdc/sdc3/alignment_offset</name>
+      <content>0</content>
+    </File>
   </Files>
 </Mockup>

--- a/testsuite/probe/xen1-mockup.xml
+++ b/testsuite/probe/xen1-mockup.xml
@@ -534,6 +534,14 @@
       <content>1310720</content>
     </File>
     <File>
+      <name>/sys/devices/vbd-51712/block/xvda/xvda1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/vbd-51712/block/xvda/xvda2/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
       <name>/sys/devices/vbd-51728/block/xvdb/alignment_offset</name>
       <content>0</content>
     </File>
@@ -556,6 +564,14 @@
     <File>
       <name>/sys/devices/vbd-51728/block/xvdb/size</name>
       <content>125829120</content>
+    </File>
+    <File>
+      <name>/sys/devices/vbd-51728/block/xvdb/xvdb1/alignment_offset</name>
+      <content>0</content>
+    </File>
+    <File>
+      <name>/sys/devices/vbd-51728/block/xvdb/xvdb2/alignment_offset</name>
+      <content>0</content>
     </File>
     <File>
       <name>/sys/devices/vbd-51745/block/xvdc1/ext_range</name>


### PR DESCRIPTION
For https://trello.com/c/37u3G3aN/ or https://bugzilla.suse.com/show_bug.cgi?id=1121129.

This adds topology handling to Partition and Luks, esp. optimal_io_size, which is needed to calculate the usable size of LVM PVs.
