### PR TITLE
Use the libstorage-ng SLE15 (Leap 15.0) image in Travis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,2 @@
-FROM yastdevel/cpp
-RUN zypper --non-interactive install swig graphviz python3-devel libxml2-devel libjson-c-devel libboost_test-devel
+FROM yastdevel/libstorage-ng:sle15
 COPY . /usr/src/app


### PR DESCRIPTION
- Use the libstorage-ng specific Docker image
- Use the SLE15/Leap 15.0 based image (instead of the Tumbleweed one)