### PR TITLE
- parse devid in output of 'btrfs filesystem show' 

### DIFF
--- a/storage/Devices/BcacheCsetImpl.cc
+++ b/storage/Devices/BcacheCsetImpl.cc
@@ -102,8 +102,7 @@ namespace storage
     bool
     BcacheCset::Impl::is_valid_uuid(const string& uuid)
     {
-	static regex uuid_regex("[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}",
-				regex::extended);
+	static const regex uuid_regex(UUID_REGEX, regex::extended);
 
 	return regex_match(uuid, uuid_regex);
     }

--- a/storage/Filesystems/BtrfsImpl.cc
+++ b/storage/Filesystems/BtrfsImpl.cc
@@ -387,8 +387,8 @@ namespace storage
 
 		vector<BlkDevice*> blk_devices;
 
-		for (const string& name : detected_btrfs.devices)
-		    blk_devices.push_back(BlkDevice::find_by_any_name(system, name));
+		for (const CmdBtrfsFilesystemShow::Device& device : detected_btrfs.devices)
+		    blk_devices.push_back(BlkDevice::find_by_any_name(system, device.name));
 
 		BlkFilesystem* blk_filesystem = nullptr;
 

--- a/storage/SystemInfo/CmdBtrfs.h
+++ b/storage/SystemInfo/CmdBtrfs.h
@@ -58,14 +58,27 @@ namespace storage
 	CmdBtrfsFilesystemShow();
 
 	/**
+	 * Device of a btrfs filesystem.
+	 */
+	struct Device
+	{
+	    Device() : id(0), name() {}
+
+	    unsigned int id;
+	    string name;
+	};
+
+	/**
 	 * Entry for one btrfs filesystem. Since btrfs includes a volume
 	 * manager (independent of LVM or the device mapper), this may be
 	 * multiple devices for a single btrfs filesystem.
 	 */
 	struct Entry
 	{
+	    Entry() : uuid(), devices() {}
+
 	    string uuid;
-	    vector<string> devices;
+	    vector<Device> devices;
 	};
 
 	typedef vector<Entry>::value_type value_type;
@@ -76,6 +89,7 @@ namespace storage
 
 	friend std::ostream& operator<<(std::ostream& s, const CmdBtrfsFilesystemShow& cmd_btrfs_filesystem_show);
 	friend std::ostream& operator<<(std::ostream& s, const Entry& entry);
+	friend std::ostream& operator<<(std::ostream& s, const Device& device);
 
     private:
 

--- a/storage/Utils/StorageDefines.h
+++ b/storage/Utils/StorageDefines.h
@@ -133,4 +133,7 @@
 #define MKFS_UDF_BIN "/usr/sbin/mkfs.udf"
 
 
+#define UUID_REGEX "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+
+
 #endif

--- a/testsuite/SystemInfo/btrfs-filesystem-show.cc
+++ b/testsuite/SystemInfo/btrfs-filesystem-show.cc
@@ -81,9 +81,9 @@ BOOST_AUTO_TEST_CASE(parse_good)
     };
 
     vector<string> output = {
-	"uuid:ea108250-d02c-41dd-b4d8-d4a707a5c649 devices:</dev/mapper/system-test>",
-	"uuid:d82229f2-f9e4-40fd-b15f-84e2d42e6d0d devices:</dev/mapper/system-testsuite>",
-	"uuid:653764e0-7ea2-4dbe-9fa1-866f3f7783c9 devices:</dev/mapper/system-btrfs>"
+	"uuid:ea108250-d02c-41dd-b4d8-d4a707a5c649 devices:<{ id:1 name:/dev/mapper/system-test }>",
+	"uuid:d82229f2-f9e4-40fd-b15f-84e2d42e6d0d devices:<{ id:1 name:/dev/mapper/system-testsuite }>",
+	"uuid:653764e0-7ea2-4dbe-9fa1-866f3f7783c9 devices:<{ id:1 name:/dev/mapper/system-btrfs }>"
     };
 
     check(input, output);
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(systemcmd_error)
 BOOST_AUTO_TEST_CASE(parse_missing)
 {
     vector<string> input = {
-	"Label: none  uuid: b0749dbe-7de5-4719-9cb6-043dd5c70d00",
+	"Label: 'hello world'  uuid: b0749dbe-7de5-4719-9cb6-043dd5c70d00",
 	"        Total devices 4 FS bytes used 256.00KiB",
 	"        devid    1 size 2.00GiB used 417.12MiB path /dev/sdb1",
 	"        devid    2 size 2.00GiB used 417.12MiB path /dev/sdc1",
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(parse_missing)
     };
 
     vector<string> output = {
-	"uuid:b0749dbe-7de5-4719-9cb6-043dd5c70d00 devices:</dev/sdb1 /dev/sdc1 /dev/sdd1>"
+	"uuid:b0749dbe-7de5-4719-9cb6-043dd5c70d00 devices:<{ id:1 name:/dev/sdb1 } { id:2 name:/dev/sdc1 } { id:3 name:/dev/sdd1 }>"
     };
 
     check(input, output);


### PR DESCRIPTION
Also parse the devid in the output of 'btrfs filesystem show'. The devid will be required for some btrfs commands when adding multiple devices support.