### PR TITLE
- parse UUID in output of mkfs.btrfs

### DIFF
--- a/storage/Filesystems/BtrfsImpl.cc
+++ b/storage/Filesystems/BtrfsImpl.cc
@@ -410,7 +410,7 @@ namespace storage
 	    {
 		// TRANSLATORS: error message
 		error_callback(prober.get_probe_callbacks(), sformat(_("Probing file system with UUID %s failed"),
-								     detected_btrfs.uuid, exception));
+								     detected_btrfs.uuid), exception);
 	    }
 	}
     }

--- a/storage/Filesystems/BtrfsImpl.cc
+++ b/storage/Filesystems/BtrfsImpl.cc
@@ -532,6 +532,26 @@ namespace storage
 
 
     void
+    Btrfs::Impl::parse_mkfs_output(const vector<string>& stdout)
+    {
+	static const regex uuid_regex("UUID:[ \t]+(" UUID_REGEX ")", regex::extended);
+
+	smatch match;
+
+	for (const string& line : stdout)
+	{
+	    if (regex_match(line, match, uuid_regex) && match.size() == 2)
+	    {
+		set_uuid(match[1]);
+		return;
+	    }
+	}
+
+	ST_THROW(Exception("UUID not found in output of mkfs.btrfs"));
+    }
+
+
+    void
     Btrfs::Impl::do_create()
     {
 	string cmd_line = MKFSBTRFSBIN " --force";
@@ -552,9 +572,7 @@ namespace storage
 
 	SystemCmd cmd(cmd_line, SystemCmd::DoThrow);
 
-	// TODO uuid is included in mkfs output
-
-	probe_uuid();
+	parse_mkfs_output(cmd.stdout());
 
         // This would fit better in do_mount(), but that one is a const method
         // which would not allow to set the snapper_config member variable.

--- a/storage/Filesystems/BtrfsImpl.h
+++ b/storage/Filesystems/BtrfsImpl.h
@@ -141,6 +141,8 @@ namespace storage
 
 	virtual void do_pre_mount() const override;
 
+	void parse_mkfs_output(const vector<string>& stdout);
+
     private:
 
         bool configure_snapper;

--- a/testsuite/actions/btrfs1-mockup.xml
+++ b/testsuite/actions/btrfs1-mockup.xml
@@ -5,11 +5,28 @@
       <name>/sbin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
-      <name>/sbin/mkfs.btrfs --force --metadata=RAID1 --data=RAID0 --mixed '/dev/sda' '/dev/sdb' '/dev/sdc' '/dev/sdd'</name>
-    </Command>
-    <Command>
-      <name>/sbin/blkid -c '/dev/null' '/dev/sda'</name>
-      <stdout>/dev/sda: UUID="318eac77-bbe5-40b4-a8fd-b30ec45d0003" UUID_SUB="b62c72f0-2798-4a79-8307-c07a3781fbb2" TYPE="btrfs"</stdout>
+      <name>/sbin/mkfs.btrfs --force --metadata=RAID1 --data=RAID0 --nodiscard '/dev/sda' '/dev/sdb' '/dev/sdc' '/dev/sdd'</name>
+      <stdout>btrfs-progs v4.19.1 </stdout>
+      <stdout>See http://btrfs.wiki.kernel.org for more information.</stdout>
+      <stdout></stdout>
+      <stdout>Label:              (null)</stdout>
+      <stdout>UUID:               318eac77-bbe5-40b4-a8fd-b30ec45d0003</stdout>
+      <stdout>Node size:          16384</stdout>
+      <stdout>Sector size:        4096</stdout>
+      <stdout>Filesystem size:    31.99GiB</stdout>
+      <stdout>Block group profiles:</stdout>
+      <stdout>  Data:             RAID0             3.20GiB</stdout>
+      <stdout>  Metadata:         RAID1             1.00GiB</stdout>
+      <stdout>  System:           RAID1             8.00MiB</stdout>
+      <stdout>SSD detected:       no</stdout>
+      <stdout>Incompat features:  extref, skinny-metadata</stdout>
+      <stdout>Number of devices:  4</stdout>
+      <stdout>Devices:</stdout>
+      <stdout>   ID        SIZE  PATH</stdout>
+      <stdout>    1     8.00GiB  /dev/sda</stdout>
+      <stdout>    2     8.00GiB  /dev/sdb</stdout>
+      <stdout>    3     8.00GiB  /dev/sdc</stdout>
+      <stdout>    4     8.00GiB  /dev/sdd</stdout>
     </Command>
   </Commands>
 </Mockup>

--- a/testsuite/actions/btrfs1-staging.xml
+++ b/testsuite/actions/btrfs1-staging.xml
@@ -81,7 +81,7 @@
       <sid>46</sid>
       <metadata-raid-level>RAID1</metadata-raid-level>
       <data-raid-level>RAID0</data-raid-level>
-      <mkfs-options>--mixed</mkfs-options>
+      <mkfs-options>--nodiscard</mkfs-options>
     </Btrfs>
     <BtrfsSubvolume>
       <sid>47</sid>


### PR DESCRIPTION
Parsing the UUID in the output of mkfs.btrfs avoids calling blkid.
