### PR TITLE
- fix resizing btrfs on e.g. LVM

### DIFF
--- a/integration-tests/filesystems/btrfs/multiple-devices/grow.py
+++ b/integration-tests/filesystems/btrfs/multiple-devices/grow.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# requirements: btrfs on /dev/sdc1 and unused /dev/sdd1
+# requirements: btrfs on /dev/sdc1 and /dev/sdd1 and space after both partitions
 
 
 from storage import *
@@ -18,17 +18,18 @@ staging = storage.get_staging()
 
 print(staging)
 
-partition = Partition.find_by_name(staging, "/dev/sdc1")
+def grow(partition):
+    region = partition.get_region()
+    region.set_length(int(region.get_length() + 1 * GiB / region.get_block_size()))
+    region = partition.get_partition_table().align(region, AlignPolicy_KEEP_START_ALIGN_END)
+    partition.set_region(region)
 
-region = partition.get_region()
+sdc1 = Partition.find_by_name(staging, "/dev/sdc1")
+grow(sdc1)
 
-region.set_length(int(region.get_length() + 1 * GiB / region.get_block_size()))
-
-region = partition.get_partition_table().align(region, AlignPolicy_KEEP_START_ALIGN_END)
-
-partition.set_region(region)
+sdd1 = Partition.find_by_name(staging, "/dev/sdd1")
+grow(sdd1)
 
 print(staging)
 
-commit(storage)
-
+commit(storage, skip_save_graphs = False)

--- a/storage/Devices/BlkDeviceImpl.cc
+++ b/storage/Devices/BlkDeviceImpl.cc
@@ -457,6 +457,8 @@ namespace storage
 	/**
 	 * Auxiliary method to get all parent-child relationships: from the device that
 	 * is being resized to the most high-level device that also needs to be resized.
+	 *
+	 * TODO handle extended partitions (unsupported so far)
 	 */
 	vector<DirectRelation>
 	devices_to_resize(const BlkDevice* blk_device)

--- a/storage/Filesystems/BtrfsImpl.cc
+++ b/storage/Filesystems/BtrfsImpl.cc
@@ -743,34 +743,6 @@ namespace storage
     }
 
 
-    namespace
-    {
-
-	// TODO aliases, maybe just add devid to FilesystemUser during probing
-
-	unsigned int
-	devid(const string& uuid, const string& name)
-	{
-	    SystemInfo system_info;
-
-	    const CmdBtrfsFilesystemShow& cmd_btrfs_filesystem_show = system_info.getCmdBtrfsFilesystemShow();
-
-	    const CmdBtrfsFilesystemShow::const_iterator& it = cmd_btrfs_filesystem_show.find_by_uuid(uuid);
-	    if (it == cmd_btrfs_filesystem_show.end())
-		ST_THROW(Exception(sformat("btrfs not found by uuid %s", uuid)));
-
-	    for (const CmdBtrfsFilesystemShow::Device& device : it->devices)
-	    {
-		if (device.name == name)
-		    return device.id;
-	    }
-
-	    ST_THROW(Exception(sformat("device %s of btrfs with uuid %s not found", name, uuid)));
-	}
-
-    }
-
-
     Text
     Btrfs::Impl::do_resize_text(ResizeMode resize_mode, const Device* lhs, const Device* rhs,
 				const BlkDevice* blk_device, Tense tense) const
@@ -804,11 +776,15 @@ namespace storage
     {
 	EnsureMounted ensure_mounted(get_filesystem(), false);
 
-        string cmd_line = BTRFSBIN " filesystem resize " + to_string(devid(get_uuid(), blk_device->get_name())) + ":";
-        if (resize_mode == ResizeMode::SHRINK)
-            cmd_line += to_string(blk_device->get_size());
-        else
-            cmd_line += "max";
+	const FilesystemUser* filesystem_user = to_filesystem_user(get_devicegraph()->find_holder(blk_device->get_sid(),
+												  get_sid()));
+	unsigned int devid = filesystem_user->get_impl().get_id();
+
+	string cmd_line = BTRFSBIN " filesystem resize " + to_string(devid) + ":";
+	if (resize_mode == ResizeMode::SHRINK)
+	    cmd_line += to_string(blk_device->get_size());
+	else
+	    cmd_line += "max";
 	cmd_line += " " + quote(ensure_mounted.get_any_mount_point());
 
 	SystemCmd cmd(cmd_line, SystemCmd::DoThrow);


### PR DESCRIPTION
The devid function does not handle device name aliasing, e.g. it cannot find /dev/test/foo which btrfs reports as /dev/mapper/test-foo. By using the newly added id from the devicegraph the function is not needed anymore.