### PR TITLE
Log messages about the mount_by fallback are just warnings

### DIFF
--- a/storage/Devices/BlkDeviceImpl.cc
+++ b/storage/Devices/BlkDeviceImpl.cc
@@ -277,25 +277,25 @@ namespace storage
 	switch (mount_by_type)
 	{
 	    case MountByType::UUID:
-		y2err("no uuid possible, using fallback");
+		y2war("no uuid possible, using fallback");
 		break;
 
 	    case MountByType::LABEL:
-		y2err("no label possible, using fallback");
+		y2war("no label possible, using fallback");
 		break;
 
 	    case MountByType::ID:
 		if (!get_udev_ids().empty())
 		    ret = DEV_DISK_BY_ID_DIR "/" + get_udev_ids().front();
 		else
-		    y2err("no udev-id defined, using fallback");
+		    y2war("no udev-id defined, using fallback");
 		break;
 
 	    case MountByType::PATH:
 		if (!get_udev_paths().empty())
 		    ret = DEV_DISK_BY_PATH_DIR "/" + get_udev_paths().front();
 		else
-		    y2err("no udev-path defined, using fallback");
+		    y2war("no udev-path defined, using fallback");
 		break;
 
 	    case MountByType::DEVICE:

--- a/storage/Devices/EncryptionImpl.cc
+++ b/storage/Devices/EncryptionImpl.cc
@@ -165,11 +165,11 @@ namespace storage
 	switch (mount_by_type)
 	{
 	    case MountByType::UUID:
-		y2err("no uuid possible, using fallback");
+		y2war("no uuid possible, using fallback");
 		break;
 
 	    case MountByType::LABEL:
-		y2err("no label possible, using fallback");
+		y2war("no label possible, using fallback");
 		break;
 
 	    case MountByType::ID:

--- a/storage/Devices/LuksImpl.cc
+++ b/storage/Devices/LuksImpl.cc
@@ -108,14 +108,14 @@ namespace storage
 		if (!uuid.empty())
 		    ret = "UUID=" + uuid;
 		else
-		    y2err("no uuid defined, using fallback");
+		    y2war("no uuid defined, using fallback");
 		break;
 
 	    case MountByType::LABEL:
 		if (!label.empty())
 		    ret = "LABEL=" + label;
 		else
-		    y2err("no label defined, using fallback");
+		    y2war("no label defined, using fallback");
 		break;
 
 	    case MountByType::ID:

--- a/storage/Filesystems/BlkFilesystemImpl.cc
+++ b/storage/Filesystems/BlkFilesystemImpl.cc
@@ -629,14 +629,14 @@ namespace storage
 		if (!uuid.empty())
 		    ret = "UUID=" + uuid;
 		else
-		    y2err("no uuid defined, using fallback mount-by");
+		    y2war("no uuid defined, using fallback mount-by");
 		break;
 
 	    case MountByType::LABEL:
 		if (!label.empty())
 		    ret = "LABEL=" + label;
 		else
-		    y2err("no label defined, using fallback mount-by");
+		    y2war("no label defined, using fallback mount-by");
 		break;
 
 	    case MountByType::ID:

--- a/storage/Filesystems/SwapImpl.cc
+++ b/storage/Filesystems/SwapImpl.cc
@@ -114,7 +114,7 @@ namespace storage
 	    case MountByType::UUID:
 		if (!is_permanent())
 		{
-		    y2err("no uuid possible for non-permanent swap, using fallback mount-by");
+		    y2war("no uuid possible for non-permanent swap, using fallback mount-by");
 		    mount_by = MountByType::DEVICE;
 		}
 		break;
@@ -122,7 +122,7 @@ namespace storage
 	    case MountByType::LABEL:
 		if (!is_permanent())
 		{
-		    y2err("no label possible for non-permanent swap, using fallback mount-by");
+		    y2war("no label possible for non-permanent swap, using fallback mount-by");
 		    mount_by = MountByType::DEVICE;
 		}
 		break;


### PR DESCRIPTION
Since QA recently complained about it, I took the opportunity to fix it as part of 

https://trello.com/c/GrmrcH1n/1337-3-sles15-sp1-p3-1151075-sles-15-sp1-yast-mounts-nvme-partitions-by-kernel-name-per-default-upon-reboot-they-are-randomly-enumera

I have not tested, but it looks trivial enough to be safe.