### PR TITLE
show all block devices for action texts of btrfs subvolumes

### DIFF
--- a/storage/CompoundAction/Formatter.cc
+++ b/storage/CompoundAction/Formatter.cc
@@ -138,30 +138,4 @@ namespace storage
 	return first_action->text(commit_data);
     }
 
-
-    Text
-    CompoundAction::Formatter::format_devices_text(const std::vector<const BlkDevice *> &devices)
-    {
-	std::vector<const BlkDevice *> sorted_devices = devices;
-	std::sort( sorted_devices.begin(), sorted_devices.end(),
-                   BlkDevice::compare_by_name );
-
-	Text text;
-
-	for ( const BlkDevice * device: sorted_devices )
-	{
-	    if ( ! text.translated.empty() )
-		text += Text( ", ", ", " );
-
-	    // TRANSLATORS:
-	    // %1$s is replaced with the device name (e.g. /dev/sdc1),
-	    // %2$s is replaced with the size (e.g. 60 GiB)
-	    Text dev_text = _( "%1$s (%2$s)" );
-
-	    text += sformat(dev_text, device->get_name(), device->get_size_string());
-	}
-
-	return text;
-    }
-
 }

--- a/storage/CompoundAction/Formatter.h
+++ b/storage/CompoundAction/Formatter.h
@@ -59,8 +59,6 @@ namespace storage
 
 	string string_representation() const;
 
-        static Text format_devices_text(const std::vector<const BlkDevice *> &devices);
-
     private:
 
 	virtual Text text() const = 0;

--- a/storage/CompoundAction/Formatter/Bcache.cc
+++ b/storage/CompoundAction/Formatter/Bcache.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 SUSE LLC
+ * Copyright (c) [2018-2019] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -53,6 +53,13 @@ namespace storage
 	}
 
 	return text;
+    }
+
+
+    Text
+    CompoundAction::Formatter::Bcache::blk_devices_text() const
+    {
+	return join(bcache->get_bcache_cset()->get_blk_devices(), JoinMode::COMMA, 20);
     }
 
 
@@ -126,17 +133,13 @@ namespace storage
 	if(!bcache->has_bcache_cset())
 	    return Text();
 
-	Text dev_list_text = format_devices_text( bcache->get_bcache_cset()->get_blk_devices() );
-
 	// TRANSLATORS:
 	// %1$s is replaced with the the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the a list of cache devices with size
-	// (e.g. "/dev/sdb1 (64 GiB), /dev/sdc1 (160 GiB)")
+	// (e.g. "/dev/sdb1 (64.00 GiB) and /dev/sdc1 (160.00 GiB)")
 	Text text = _( "%1$s is cached by %2$s" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        dev_list_text.translated.c_str() );
+	return sformat(text, get_bcache_name(), blk_devices_text());
     }
 
 
@@ -146,13 +149,10 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB)
+	// %3$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _( "Delete bcache %1$s on %2$s (%3$s)" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size());
     }
 
 
@@ -162,13 +162,10 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB)
+	// %3$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _( "Create encrypted bcache %1$s on %2$s (%3$s) for swap" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size());
     }
 
 
@@ -178,13 +175,10 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB)
+	// %3$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _( "Create bcache %1$s on %2$s (%3$s) for swap" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size());
     }
 
 
@@ -194,17 +188,13 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Create encrypted bcache %1$s on %2$s (%3$s) for %4$s with %5$s" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        get_mount_point().c_str(),
-                        get_filesystem_type().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size(),
+		       get_mount_point(), get_filesystem_type());
     }
 
 
@@ -214,15 +204,12 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Create encrypted bcache %1$s on %2$s (%3$s) with %4$s" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        get_filesystem_type().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size(),
+		       get_filesystem_type());
     }
 
 
@@ -232,13 +219,10 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB)
+	// %3$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _( "Create encrypted bcache %1$s on %2$s (%3$s)" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size());
     }
 
 
@@ -248,17 +232,13 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Create bcache %1$s on %2$s (%3$s) for %4$s with %5$s" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        get_mount_point().c_str(),
-                        get_filesystem_type().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size(), get_mount_point(),
+		       get_filesystem_type());
     }
 
 
@@ -268,15 +248,12 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Create bcache %1$s on %2$s (%3$s) with %4$s" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        get_filesystem_type().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size(),
+		       get_filesystem_type());
     }
 
 
@@ -286,13 +263,10 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB)
+	// %3$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _( "Create bcache %1$s on %2$s (%3$s)" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size());
     }
 
 
@@ -302,17 +276,13 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Encrypt bcache %1$s on %2$s (%3$s) for %4$s with %5$s" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        get_mount_point().c_str(),
-                        get_filesystem_type().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size(),
+		       get_mount_point(), get_filesystem_type());
     }
 
 
@@ -322,15 +292,12 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Encrypt bcache %1$s on %2$s (%3$s) with %4$s" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        get_filesystem_type().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size(),
+		       get_filesystem_type());
     }
 
 
@@ -340,13 +307,10 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	Text text = _( "Encrypt bcache %1$s on %2$s (%3$s)" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size());
     }
 
 
@@ -356,17 +320,13 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Format bcache %1$s on %2$s (%3$s) for %4$s with %5$s" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        get_mount_point().c_str(),
-                        get_filesystem_type().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size(),
+		       get_mount_point(), get_filesystem_type());
     }
 
 
@@ -376,15 +336,12 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the file system type (e.g. ext4)
 	Text text = _( "Format bcache %1$s on %2$s (%3$s) with %4$s" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        get_filesystem_type().c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size(),
+		       get_filesystem_type());
     }
 
 
@@ -396,15 +353,12 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the bcache name (e.g. /dev/bcache0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the mount point (e.g. /home)
 	Text text = _( "Mount bcache %1$s on %2$s (%3$s) at %4$s" );
 
-	return sformat( text,
-                        get_bcache_name().c_str(),
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        mount_point.c_str() );
+	return sformat(text, get_bcache_name(), get_device_name(), get_size(),
+		       mount_point);
     }
 
 

--- a/storage/CompoundAction/Formatter/Bcache.h
+++ b/storage/CompoundAction/Formatter/Bcache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 SUSE LLC
+ * Copyright (c) [2018-2019] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -41,6 +41,8 @@ namespace storage
     private:
 
 	Text text() const override;
+
+	Text blk_devices_text() const;
 
 	Text bcache_text() const;
 	Text bcache_cset_text() const;

--- a/storage/CompoundAction/Formatter/Btrfs.cc
+++ b/storage/CompoundAction/Formatter/Btrfs.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) [2017-2019] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -20,11 +20,10 @@
  */
 
 
-#include <boost/algorithm/string/join.hpp>
-
 #include "storage/CompoundAction/Formatter/Btrfs.h"
 #include "storage/Filesystems/MountPoint.h"
 #include "storage/Utils/Format.h"
+#include "storage/Devices/BlkDeviceImpl.h"
 
 
 namespace storage
@@ -36,14 +35,10 @@ namespace storage
     {}
 
 
-    string
-    CompoundAction::Formatter::Btrfs::blk_devices_string_representation() const
+    Text
+    CompoundAction::Formatter::Btrfs::blk_devices_text() const
     {
-	vector<string> names;
-	for (auto device : btrfs->get_blk_devices())
-	    names.push_back(device->get_displayname());
-
-	return boost::algorithm::join(names, ", ");
+	return join(btrfs->get_blk_devices(), JoinMode::COMMA, 10);
     }
 
 
@@ -77,10 +72,11 @@ namespace storage
     CompoundAction::Formatter::Btrfs::delete_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced with the names of the devices separated by comma (e.g. /dev/sda1, /dev/sda2)
+	// %1$s is replaced with the names of the devices with sizes (e.g. /dev/sda1
+	//   (10.00 GiB and /dev/sda2 (10.00 GiB))
         Text text = _("Delete file system btrfs on %1$s");
 
-        return sformat(text, blk_devices_string_representation().c_str());
+        return sformat(text, blk_devices_text());
     }
 
 
@@ -88,13 +84,13 @@ namespace storage
     CompoundAction::Formatter::Btrfs::create_and_mount_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced with the names of the devices separated by comma (e.g. /dev/sda1, /dev/sda2),
+	// %1$s is replaced with the names of the devices with sizes (e.g. /dev/sda1
+	//   (10.00 GiB) and /dev/sda2 (10.00 GiB)),
 	// %2$s is replaced with the mount point (e.g. /home)
         Text text = _("Create file system btrfs on %1$s and mount at %2$s");
 
-        return sformat(text,
-		       blk_devices_string_representation().c_str(),
-		       btrfs->get_mount_point()->get_path().c_str());
+        return sformat(text, blk_devices_text(),
+		       btrfs->get_mount_point()->get_path());
     }
 
 
@@ -102,10 +98,11 @@ namespace storage
     CompoundAction::Formatter::Btrfs::create_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced with the names of the devices separated by comma (e.g. /dev/sda1, /dev/sda2)
+	// %1$s is replaced with the names of the devices with sizes (e.g. /dev/sda1
+	//   (10.00 GiB) and /dev/sda2 (10.00 GiB))
         Text text = _("Create file system btrfs on %1$s");
 
-        return sformat(text, blk_devices_string_representation().c_str());
+        return sformat(text, blk_devices_text());
     }
 
 
@@ -113,13 +110,12 @@ namespace storage
     CompoundAction::Formatter::Btrfs::mount_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced with the names of the devices separated by comma (e.g. /dev/sda1, /dev/sda2),
+	// %1$s is replaced with the names of the devices with sizes (e.g. /dev/sda1
+	//   (10.00 GiB) and /dev/sda2 (10.00 GiB)),
 	// %2$s is replaced with the mount point (e.g. /home)
         Text text = _("Mount file system btrfs on %1$s at %2$s");
 
-        return sformat(text,
-		       blk_devices_string_representation().c_str(),
-		       btrfs->get_mount_point()->get_path().c_str());
+        return sformat(text, blk_devices_text(), btrfs->get_mount_point()->get_path());
     }
 
 
@@ -127,13 +123,12 @@ namespace storage
     CompoundAction::Formatter::Btrfs::unmount_text() const
     {
 	// TRANSLATORS:
-	// %1$s is replaced with the names of the devices separated by comma (e.g. /dev/sda1, /dev/sda2),
+	// %1$s is replaced with the names of the devices with sizes (e.g. /dev/sda1
+	//   (10.00 GiB) and /dev/sda2 (10.00 GiB)),
 	// %2$s is replaced with the mount point (e.g. /home)
         Text text = _("Unmount file system btrfs on %1$s at %2$s");
 
-        return sformat(text,
-		       blk_devices_string_representation().c_str(),
-		       btrfs->get_mount_point()->get_path().c_str());
+        return sformat(text, blk_devices_text(), btrfs->get_mount_point()->get_path());
     }
 
 }

--- a/storage/CompoundAction/Formatter/Btrfs.h
+++ b/storage/CompoundAction/Formatter/Btrfs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) [2017-2019] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -40,7 +40,7 @@ namespace storage
 
     private:
 
-	string blk_devices_string_representation() const;
+	Text blk_devices_text() const;
 
 	Text text() const override;
 

--- a/storage/CompoundAction/Formatter/BtrfsSubvolume.cc
+++ b/storage/CompoundAction/Formatter/BtrfsSubvolume.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) [2017-2019] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -24,6 +24,7 @@
 #include "storage/Filesystems/BtrfsSubvolumeImpl.h"
 #include "storage/Filesystems/BtrfsImpl.h"
 #include "storage/Utils/Format.h"
+#include "storage/Devices/BlkDeviceImpl.h"
 
 
 namespace storage
@@ -35,10 +36,10 @@ namespace storage
     {}
 
 
-    const BlkDevice*
-    CompoundAction::Formatter::BtrfsSubvolume::get_blk_device() const
+    Text
+    CompoundAction::Formatter::BtrfsSubvolume::blk_devices_text() const
     {
-	return subvolume->get_btrfs()->get_impl().get_blk_device();
+	return join(subvolume->get_btrfs()->get_blk_devices(), JoinMode::COMMA, 10);
     }
 
 
@@ -67,10 +68,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the subvolume path (e.g. var/log),
-	// %2$s is replaced with the block device name (e.g. /dev/sda1)
+	// %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+	//   (10.00 GiB) and /dev/sdb1 (10.00 GiB))
         Text text = _("Delete subvolume %1$s on %2$s");
 
-        return sformat(text, subvolume->get_path().c_str(), get_blk_device()->get_name().c_str());
+        return sformat(text, subvolume->get_path(), blk_devices_text());
     }
 
 
@@ -79,10 +81,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the subvolume path (e.g. var/log),
-	// %2$s is replaced with the block device name (e.g. /dev/sda1)
+	// %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+	//   (10.00 GiB) and /dev/sdb1 (10.00 GiB))
         Text text = _("Create subvolume %1$s on %2$s with option 'no copy on write'");
 
-        return sformat(text, subvolume->get_path().c_str(), get_blk_device()->get_name().c_str());
+        return sformat(text, subvolume->get_path(), blk_devices_text());
     }
 
 
@@ -91,10 +94,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the subvolume path (e.g. var/log),
-	// %2$s is replaced with the block device name (e.g. /dev/sda1)
+	// %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+	//   (10.00 GiB) and /dev/sdb1 (10.00 GiB))
         Text text = _("Create subvolume %1$s on %2$s");
 
-        return sformat(text, subvolume->get_path().c_str(), get_blk_device()->get_name().c_str());
+        return sformat(text, subvolume->get_path(), blk_devices_text());
     }
 
 }

--- a/storage/CompoundAction/Formatter/BtrfsSubvolume.h
+++ b/storage/CompoundAction/Formatter/BtrfsSubvolume.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) [2017-2019] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -41,7 +41,7 @@ namespace storage
 
     private:
 
-	const BlkDevice* get_blk_device() const;
+	Text blk_devices_text() const;
 
 	Text text() const override;
 

--- a/storage/CompoundAction/Formatter/LvmLv.cc
+++ b/storage/CompoundAction/Formatter/LvmLv.cc
@@ -94,14 +94,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system)
 	Text text = _("Create encrypted LVM logical volume %1$s (%2$s) on volume group %3$s for swap");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name());
     }
 
 
@@ -110,14 +107,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system)
 	Text text = _("Create LVM logical volume %1$s (%2$s) on volume group %3$s for swap");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name());
     }
 
 
@@ -126,18 +120,14 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create encrypted LVM logical volume %1$s (%2$s) on volume group %3$s for %4$s with %5$s");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str(),
-		       get_mount_point().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name(),
+		       get_mount_point(), get_filesystem_type());
     }
 
 
@@ -146,16 +136,13 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create encrypted LVM logical volume %1$s (%2$s) on volume group %3$s with %4$s");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name(),
+		       get_filesystem_type());
     }
 
 
@@ -164,14 +151,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system)
 	Text text = _("Create encrypted LVM logical volume %1$s (%2$s) on volume group %3$s");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name());
     }
 
 
@@ -180,18 +164,14 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create LVM logical volume %1$s (%2$s) on volume group %3$s for %4$s with %5$s");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str(),
-		       get_mount_point().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name(), get_mount_point(),
+		       get_filesystem_type());
     }
 
 
@@ -200,16 +180,13 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create LVM logical volume %1$s (%2$s) on volume group %3$s with %4$s");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name(),
+		       get_filesystem_type());
     }
 
 
@@ -218,14 +195,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system)
 	Text text = _("Create LVM logical volume %1$s (%2$s) on volume group %3$s");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name());
     }
 
 
@@ -234,18 +208,14 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Encrypt LVM logical volume %1$s (%2$s) on volume group %3$s for %4$s with %5$s");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str(),
-		       get_mount_point().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name(), get_mount_point(),
+		       get_filesystem_type());
     }
 
 
@@ -254,16 +224,12 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Encrypt LVM logical volume %1$s (%2$s) on volume group %3$s with %4$s");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name(), get_filesystem_type());
     }
 
 
@@ -272,14 +238,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system)
 	Text text = _("Encrypt LVM logical volume %1$s (%2$s) on volume group %3$s");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name());
     }
 
 
@@ -288,18 +251,14 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Format LVM logical volume %1$s (%2$s) on volume group %3$s for %4$s with %5$s");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str(),
-		       get_mount_point().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name(), get_mount_point(),
+		       get_filesystem_type());
     }
 
 
@@ -308,16 +267,12 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Format LVM logical volume %1$s (%2$s) on volume group %3$s with %4$s");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name(), get_filesystem_type());
     }
 
 
@@ -328,16 +283,12 @@ namespace storage
 
 	// TRANSLATORS:
 	// %1$s is replaced with the logical volume name (e.g. root),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the volume group name (e.g. system),
 	// %4$s is replaced with the mount point (e.g. /home)
 	Text text = _("Mount LVM logical volume %1$s (%2$s) on volume group %3$s at %4$s");
 
-	return sformat(text,
-		       get_lv_name().c_str(),
-		       get_size().c_str(),
-		       get_vg_name().c_str(),
-		       mount_point.c_str());
+	return sformat(text, get_lv_name(), get_size(), get_vg_name(), mount_point);
     }
 
 }

--- a/storage/CompoundAction/Formatter/LvmVg.h
+++ b/storage/CompoundAction/Formatter/LvmVg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) [2017-2019] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -42,7 +42,7 @@ namespace storage
 
     private:
 
-	std::string name_of_devices() const;
+	Text blk_devices_text() const;
 
 	Text text() const override;
 

--- a/storage/CompoundAction/Formatter/Md.cc
+++ b/storage/CompoundAction/Formatter/Md.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 SUSE LLC
+ * Copyright (c) [2018-2019] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -25,6 +25,7 @@
 #include "storage/CompoundAction/Formatter/Md.h"
 #include "storage/Filesystems/Swap.h"
 #include "storage/Utils/Format.h"
+#include "storage/Devices/BlkDeviceImpl.h"
 
 
 namespace storage
@@ -97,9 +98,9 @@ namespace storage
 
 
     Text
-    CompoundAction::Formatter::Md::devices_text() const
+    CompoundAction::Formatter::Md::blk_devices_text() const
     {
-        return format_devices_text( md->get_devices() );
+        return join(md->get_devices(), JoinMode::COMMA, 20);
     }
 
 
@@ -109,13 +110,10 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0)
-	// %3$s is replaced with the size (e.g. 2 GiB)
+	// %3$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _( "Delete %1$s %2$s (%3$s)" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size());
     }
 
 
@@ -125,18 +123,14 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0)
-	// %3$s is replaced with the size (e.g. 2 GiB)
-	// %4$s is replaced with a comma-spearated list of the devices
+	// %3$s is replaced with the size (e.g. 2.00 GiB)
+	// %4$s is replaced with a list of the devices
 	//   the RAID is built from and their sizes: e.g.
-	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	//   /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB) and /dev/sdc (512.00 GiB)
 	Text text = _( "Create encrypted %1$s %2$s (%3$s) for swap\nfrom %4$s" );
 	text += _( "\nare you serious?!" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str(),
-			devices_text().translated.c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), blk_devices_text());
     }
 
 
@@ -146,17 +140,13 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0)
-	// %3$s is replaced with the size (e.g. 2 GiB)
-	// %4$s is replaced with a comma-spearated list of the devices
+	// %3$s is replaced with the size (e.g. 2.00 GiB)
+	// %4$s is replaced with a list of the devices
 	//   the RAID is built from and their sizes: e.g.
-	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	//   /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB) and /dev/sdc (512.00 GiB)
 	Text text = _( "Create %1$s %2$s (%3$s) for swap\nfrom %4$s" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str(),
-			devices_text().translated.c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), blk_devices_text());
     }
 
 
@@ -166,21 +156,16 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md name (e.g. /dev/md0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
-	// %6$s is replaced with a comma-spearated list of the devices
+	// %6$s is replaced with a list of the devices
 	//   the RAID is built from and their sizes: e.g.
-	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	//   /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB) and /dev/sdc (512.00 GiB)
 	Text text = _( "Create encrypted %1$s %2$s (%3$s) for %4$s with %5$s\nfrom %6$s" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str(),
-			get_mount_point().c_str(),
-			get_filesystem_type().c_str(),
-			devices_text().translated.c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), get_mount_point(),
+		       get_filesystem_type(), blk_devices_text());
     }
 
 
@@ -190,19 +175,15 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md name (e.g. /dev/md0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the file system name (e.g. ext4)
-	// %5$s is replaced with a comma-spearated list of the devices
+	// %5$s is replaced with a list of the devices
 	//   the RAID is built from and their sizes: e.g.
-	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	//   /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB) and /dev/sdc (512.00 GiB)
 	Text text = _( "Create encrypted %1$s %2$s (%3$s) with %4$s\nfrom %5$s" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str(),
-			get_filesystem_type().c_str(),
-			devices_text().translated.c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), get_filesystem_type(),
+		       blk_devices_text());
     }
 
 
@@ -212,17 +193,13 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md name (e.g. /dev/md0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB)
-	// %4$s is replaced with a comma-spearated list of the devices
+	// %3$s is replaced with the size (e.g. 2.00 GiB)
+	// %4$s is replaced with a list of the devices
 	//   the RAID is built from and their sizes: e.g.
-	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	//   /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB) and /dev/sdc (512.00 GiB)
 	Text text = _( "Create encrypted %1$s %2$s (%3$s)\nfrom %4$s" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str(),
-			devices_text().translated.c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), blk_devices_text());
     }
 
 
@@ -232,21 +209,16 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
-	// %6$s is replaced with a comma-spearated list of the devices
+	// %6$s is replaced with a list of the devices
 	//   the RAID is built from and their sizes: e.g.
-	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	//   /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB) and /dev/sdc (512.00 GiB)
 	Text text = _( "Create %1$s %2$s (%3$s) for %4$s with %5$s\nfrom %6$s" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str(),
-			get_mount_point().c_str(),
-			get_filesystem_type().c_str(),
-			devices_text().translated.c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), get_mount_point(),
+		       get_filesystem_type(), blk_devices_text());
     }
 
 
@@ -256,19 +228,15 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md name (e.g. /dev/md0),
 	// %2$s is replaced with the device name (e.g. /dev/sda1),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the file system name (e.g. ext4)
-	// %5$s is replaced with a comma-spearated list of the devices
+	// %5$s is replaced with a list of the devices
 	//   the RAID is built from and their sizes: e.g.
-	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	//   /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB) and /dev/sdc (512.00 GiB)
 	Text text = _( "Create %1$s %2$s (%3$s) with %4$s\nfrom %5$s" );
 
-	return sformat ( text,
-			 get_md_level().c_str(),
-			 get_md_name().c_str(),
-			 get_size().c_str(),
-			 get_filesystem_type().c_str(),
-			 devices_text().translated.c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), get_filesystem_type(),
+		       blk_devices_text());
     }
 
 
@@ -278,17 +246,13 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0),
-	// %3$s is replaced with the size (e.g. 2 GiB),
-	// %4$s is replaced with a comma-spearated list of the devices
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
+	// %4$s is replaced with a list of the devices
 	//   the RAID is built from and their sizes: e.g.
-	//   /dev/sda (512 GiB), /dev/sdb (512 GiB), /dev/sdc (512 GiB)
+	//   /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB) and /dev/sdc (512.00 GiB)
 	Text text = _( "Create %1$s %2$s (%3$s) from %4$s" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str(),
-			devices_text().translated.c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), blk_devices_text());
     }
 
 
@@ -298,17 +262,13 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Encrypt %1$s %2$s (%3$s) for %4$s with %5$s" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str(),
-			get_mount_point().c_str(),
-			get_filesystem_type().c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), get_mount_point(),
+		       get_filesystem_type());
     }
 
 
@@ -318,15 +278,11 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Encrypt %1$s %2$s (%3$s) with %4$s" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str(),
-			get_filesystem_type().c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), get_filesystem_type());
     }
 
 
@@ -336,13 +292,10 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	Text text = _( "Encrypt %1$s %2$s (%3$s)" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size());
     }
 
 
@@ -352,17 +305,13 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the mount point (e.g. /home),
 	// %5$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Format %1$s %2$s (%3$s) for %4$s with %5$s" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str(),
-			get_mount_point().c_str(),
-			get_filesystem_type().c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), get_mount_point(),
+		       get_filesystem_type());
     }
 
 
@@ -372,15 +321,11 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the file system type (e.g. ext4)
 	Text text = _( "Format %1$s %2$s (%3$s) with %4$s" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str(),
-			get_filesystem_type().c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), get_filesystem_type());
     }
 
 
@@ -392,15 +337,11 @@ namespace storage
 	// TRANSLATORS:
 	// %1$s is replaced with the md level (e.g. RAID1),
 	// %2$s is replaced with the md name (e.g. /dev/md0),
-	// %3$s is replaced with the size (e.g. 2 GiB),
+	// %3$s is replaced with the size (e.g. 2.00 GiB),
 	// %4$s is replaced with the mount point (e.g. /home)
 	Text text = _( "Mount %1$s %2$s (%3$s) at %4$s" );
 
-	return sformat( text,
-			get_md_level().c_str(),
-			get_md_name().c_str(),
-			get_size().c_str(),
-			mount_point.c_str() );
+	return sformat(text, get_md_level(), get_md_name(), get_size(), mount_point);
     }
 
 }

--- a/storage/CompoundAction/Formatter/Md.h
+++ b/storage/CompoundAction/Formatter/Md.h
@@ -42,7 +42,8 @@ namespace storage
     private:
 
 	Text text() const override;
-	Text devices_text() const;
+
+	Text blk_devices_text() const;
 
 	Text delete_text() const;
 

--- a/storage/CompoundAction/Formatter/Nfs.cc
+++ b/storage/CompoundAction/Formatter/Nfs.cc
@@ -56,9 +56,7 @@ namespace storage
 	// %2$s is replaced with the mount point (e.g. /home)
         Text text = _("Mount NFS %1$s on %2$s");
 
-        return sformat(text,
-		       nfs->get_displayname().c_str(),
-		       nfs->get_mount_point()->get_path().c_str());
+        return sformat(text, nfs->get_displayname(), nfs->get_mount_point()->get_path());
     }
 
 
@@ -70,9 +68,7 @@ namespace storage
 	// %2$s is replaced with the mount point (e.g. /home)
         Text text = _("Unmount NFS %1$s at %2$s");
 
-        return sformat(text,
-		       nfs->get_displayname().c_str(),
-		       nfs->get_mount_point()->get_path().c_str());
+        return sformat(text, nfs->get_displayname(), nfs->get_mount_point()->get_path());
     }
 
 }

--- a/storage/CompoundAction/Formatter/Partition.cc
+++ b/storage/CompoundAction/Formatter/Partition.cc
@@ -117,10 +117,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB)
+	// %2$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _("Delete partition %1$s (%2$s)");
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -129,10 +129,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB)
+	// %2$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _("Create encrypted partition %1$s (%2$s) as LVM physical volume");
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -141,10 +141,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB)
+	// %2$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _("Create partition %1$s (%2$s) as LVM physical volume");
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -153,10 +153,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB)
+	// %2$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _("Create LVM physical volume over encrypted %1$s (%2$s)");
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -165,10 +165,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB)
+	// %2$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _("Create LVM volume device over %1$s (%2$s)");
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -177,12 +177,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB)
+	// %2$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _("Create encrypted partition %1$s (%2$s) for swap");
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str());
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -191,12 +189,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB)
+	// %2$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _("Create partition %1$s (%2$s) for swap");
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str());
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -205,16 +201,13 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the mount point (e.g. /home),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create encrypted partition %1$s (%2$s) for %3$s with %4$s");
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_mount_point().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_device_name(), get_size(), get_mount_point(),
+		       get_filesystem_type());
     }
 
 
@@ -223,14 +216,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create encrypted partition %1$s (%2$s) with %3$s");
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_device_name(), get_size(), get_filesystem_type());
     }
 
 
@@ -239,10 +229,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB)
+	// %2$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _("Create encrypted partition %1$s (%2$s)");
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -251,16 +241,13 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the mount point (e.g. /home),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create partition %1$s (%2$s) for %3$s with %4$s");
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_mount_point().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_device_name(), get_size(), get_mount_point(),
+		       get_filesystem_type());
     }
 
 
@@ -269,14 +256,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Create partition %1$s (%2$s) with %3$s");
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_device_name(), get_size(), get_filesystem_type());
     }
 
 
@@ -289,7 +273,7 @@ namespace storage
 	{
 	    // TRANSLATORS:
 	    // %1$s is replaced with the partition name (e.g. /dev/sda1),
-	    // %2$s is replaced with the size (e.g. 2 GiB),
+	    // %2$s is replaced with the size (e.g. 2.00 GiB),
 	    // %3$s is replaced with the partition id string (e.g. Linux LVM)
 	    Text text = _("Create partition %1$s (%2$s) as %3$s");
 
@@ -299,11 +283,10 @@ namespace storage
 	{
 	    // TRANSLATORS:
 	    // %1$s is replaced with the partition name (e.g. /dev/sda1),
-	    // %2$s is replaced with the size (e.g. 2 GiB)
+	    // %2$s is replaced with the size (e.g. 2.00 GiB)
 	    Text text = _("Create partition %1$s (%2$s)");
 
-	    return sformat(text, get_device_name().c_str(),
-			   get_size().c_str());
+	    return sformat(text, get_device_name(), get_size());
 	}
     }
 
@@ -313,16 +296,13 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the mount point (e.g. /home),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Encrypt partition %1$s (%2$s) for %3$s with %4$s");
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_mount_point().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_device_name(), get_size(), get_mount_point(),
+		       get_filesystem_type());
     }
 
 
@@ -331,14 +311,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Encrypt partition %1$s (%2$s) with %3$s");
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_device_name(), get_size(), get_filesystem_type());
     }
 
 
@@ -347,10 +324,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	Text text = _("Encrypt partition %1$s (%2$s)");
 
-	return sformat(text, get_device_name().c_str(), get_size().c_str());
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -359,16 +336,13 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the mount point (e.g. /home),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Format partition %1$s (%2$s) for %3$s with %4$s");
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_mount_point().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_device_name(), get_size(), get_mount_point(),
+		       get_filesystem_type());
     }
 
 
@@ -377,14 +351,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the file system name (e.g. ext4)
 	Text text = _("Format partition %1$s (%2$s) with %3$s");
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-		       get_filesystem_type().c_str());
+	return sformat(text, get_device_name(), get_size(), get_filesystem_type());
     }
 
 
@@ -395,14 +366,11 @@ namespace storage
 
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the mount point (e.g. /home)
 	Text text = _("Mount partition %1$s (%2$s) at %3$s");
 
-	return sformat(text,
-		       get_device_name().c_str(),
-		       get_size().c_str(),
-                       mount_point.c_str());
+	return sformat(text, get_device_name(), get_size(), mount_point);
     }
 
 }

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.cc
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.cc
@@ -85,10 +85,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB)
+	// %2$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _( "Format partition %1$s (%2$s) as swap" );
 
-	return sformat( text, get_device_name().c_str(), get_size().c_str() );
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -97,10 +97,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB)
+	// %2$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _( "Format partition %1$s (%2$s) as encryped swap" );
 
-	return sformat( text, get_device_name().c_str(), get_size().c_str() );
+	return sformat(text, get_device_name(), get_size());
     }
 
     Text
@@ -108,10 +108,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB)
+	// %2$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _( "Create LVM physical volume over encrypted %1$s (%2$s)" );
 
-	return sformat( text, get_device_name().c_str(), get_size().c_str() );
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -120,10 +120,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB)
+	// %2$s is replaced with the size (e.g. 2.00 GiB)
 	Text text = _( "Create LVM physical volume over %1$s (%2$s)" );
 
-	return sformat( text, get_device_name().c_str(), get_size().c_str() );
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -132,16 +132,13 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the mount point (e.g. /home),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Encrypt partition %1$s (%2$s) for %3$s with %4$s" );
 
-	return sformat( text,
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        get_mount_point().c_str(),
-                        get_filesystem_type().c_str() );
+	return sformat(text, get_device_name(), get_size(), get_mount_point(),
+		       get_filesystem_type() );
     }
 
 
@@ -150,14 +147,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Encrypt partition %1$s (%2$s) with %3$s" );
 
-	return sformat( text,
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        get_filesystem_type().c_str() );
+	return sformat(text, get_device_name(), get_size(), get_filesystem_type());
     }
 
 
@@ -166,10 +160,10 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	Text text = _( "Encrypt partition %1$s (%2$s)" );
 
-	return sformat( text, get_device_name().c_str(), get_size().c_str() );
+	return sformat(text, get_device_name(), get_size());
     }
 
 
@@ -178,16 +172,13 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the mount point (e.g. /home),
 	// %4$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Format partition %1$s (%2$s) for %3$s with %4$s" );
 
-	return sformat( text,
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        get_mount_point().c_str(),
-                        get_filesystem_type().c_str() );
+	return sformat(text, get_device_name(), get_size(), get_mount_point(),
+		       get_filesystem_type());
     }
 
 
@@ -196,14 +187,11 @@ namespace storage
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the file system name (e.g. ext4)
 	Text text = _( "Format partition %1$s (%2$s) with %3$s" );
 
-	return sformat( text,
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        get_filesystem_type().c_str() );
+	return sformat(text, get_device_name(), get_size(), get_filesystem_type());
     }
 
 
@@ -214,14 +202,11 @@ namespace storage
 
 	// TRANSLATORS:
 	// %1$s is replaced with the partition name (e.g. /dev/sda1),
-	// %2$s is replaced with the size (e.g. 2 GiB),
+	// %2$s is replaced with the size (e.g. 2.00 GiB),
 	// %3$s is replaced with the mount point (e.g. /home)
 	Text text = _( "Mount partition %1$s (%2$s) at %3$s" );
 
-	return sformat( text,
-                        get_device_name().c_str(),
-                        get_size().c_str(),
-                        mount_point.c_str() );
+	return sformat(text, get_device_name(), get_size(), mount_point);
     }
 
 }

--- a/storage/Devices/BcacheCsetImpl.cc
+++ b/storage/Devices/BcacheCsetImpl.cc
@@ -246,11 +246,11 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by device name (e.g. /dev/sda1),
-			   // %2$s is replaced by size (e.g. 2 GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Create bcache cache set on %1$s (%2$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by device name (e.g. /dev/sda1),
-			   // %2$s is replaced by size (e.g. 2 GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Creating bcache cache set %1$s (%2$s)"));
 
 	return sformat(text, blk_device->get_name(), blk_device->get_impl().get_size_text());
@@ -296,11 +296,11 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by device name (e.g. /dev/sda1),
-			   // %2$s is replaced by size (e.g. 2 GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Delete bcache cache set on %1$s (%2$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by device name (e.g. /dev/sda1),
-			   // %2$s is replaced by size (e.g. 2 GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Deleting bcache cache set on %1$s (%2$s)"));
 
 	return sformat(text, blk_device->get_name(), blk_device->get_impl().get_size_text());
@@ -325,11 +325,11 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by device name (e.g. /dev/sda1),
-			   // %2$s is replaced by size (e.g. 2 GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Deactivate bcache cache set on %1$s (%2$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by device name (e.g. /dev/sda1),
-			   // %2$s is replaced by size (e.g. 2 GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Deactivating bcache cache set on %1$s (%2$s)"));
 
 	return sformat(text, blk_device->get_name(), blk_device->get_impl().get_size_text());

--- a/storage/Devices/BcacheImpl.cc
+++ b/storage/Devices/BcacheImpl.cc
@@ -659,11 +659,11 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by device name (e.g. /dev/bcache0),
-			   // %2$s is replaced by size (e.g. 2 GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Create bcache %1$s (%2$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by device name (e.g. /dev/bcache0),
-			   // %2$s is replaced by size (e.g. 2 GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Creating bcache %1$s (%2$s)"));
 
 	return sformat(text, get_name(), get_size_text());
@@ -700,11 +700,11 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by device name (e.g. /dev/bcache0),
-			   // %2$s is replaced by size (e.g. 2 GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Delete bcache %1$s (%2$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by device name (e.g. /dev/bcache0),
-			   // %2$s is replaced by size (e.g. 2 GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Deleting bcache %1$s (%2$s)"));
 
 	return sformat(text, get_name(), get_size_text());
@@ -727,11 +727,11 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by device name (e.g. /dev/bcache0),
-			   // %2$s is replaced by size (e.g. 2 GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Deactivate bcache %1$s (%2$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by device name (e.g. /dev/bcache0),
-			   // %2$s is replaced by size (e.g. 2 GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Deactivating bcache %1$s (%2$s)"));
 
 	return sformat(text, get_displayname(), get_size_text());
@@ -762,12 +762,12 @@ namespace storage
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by device name (e.g. /dev/sda1),
 			   // %2$s is replaced by device name (e.g. /dev/bcache0),
-			   // %3$s is replaced by size (e.g. 2 GiB)
+			   // %3$s is replaced by size (e.g. 2.00 GiB)
 			   _("Attach bcache cache set on %1$s to bcache %2$s (%3$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by device name (e.g. /dev/sda1),
 			   // %2$s is replaced by device name (e.g. /dev/bcache0),
-			   // %3$s is replaced by size (e.g. 2 GiB)
+			   // %3$s is replaced by size (e.g. 2.00 GiB)
 			   _("Attaching bcache cache set on %1$s to bcache %2$s (%3$s)"));
 
 	return sformat(text, blk_device->get_name(), get_name(), get_size_text());
@@ -794,12 +794,12 @@ namespace storage
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by device name (e.g. /dev/sda1),
 			   // %2$s is replaced by device name (e.g. /dev/bcache0),
-			   // %3$s is replaced by size (e.g. 2 GiB)
+			   // %3$s is replaced by size (e.g. 2.00 GiB)
 			   _("Detach bcache cache set on %1$s from bcache %2$s (%3$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by device name (e.g. /dev/sda1),
 			   // %2$s is replaced by device name (e.g. /dev/bcache0),
-			   // %3$s is replaced by size (e.g. 2 GiB)
+			   // %3$s is replaced by size (e.g. 2.00 GiB)
 			   _("Detaching bcache cache set on %1$s from bcache %2$s (%3$s)"));
 
 	return sformat(text, blk_device->get_name(), get_name(), get_size_text());
@@ -821,12 +821,12 @@ namespace storage
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by cache mode (e.g. writeback),
 			   // %2$s is replaced by device name (e.g. /dev/bcache0),
-			   // %3$s is replaced by size (e.g. 2 GiB)
+			   // %3$s is replaced by size (e.g. 2.00 GiB)
 			   _("Set cache mode to %1$s for bcache %2$s (%3$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by cache mode (e.g. writeback),
 			   // %2$s is replaced by device name (e.g. /dev/bcache0),
-			   // %3$s is replaced by size (e.g. 2 GiB)
+			   // %3$s is replaced by size (e.g. 2.00 GiB)
 			   _("Setting cache mode to %1$s for bcache %2$s (%3$s)"));
 
 	return sformat(text, toString(get_cache_mode()), get_name(), get_size_text());

--- a/storage/Devices/BlkDeviceImpl.cc
+++ b/storage/Devices/BlkDeviceImpl.cc
@@ -1017,7 +1017,7 @@ namespace storage
 	{
 	    // TRANSLATORS:
 	    // %1$s is replaced with the device name (e.g. /dev/sdc1),
-	    // %2$s is replaced with the size (e.g. 60 GiB)
+	    // %2$s is replaced with the size (e.g. 60.00 GiB)
 	    tmp.push_back(sformat(_("%1$s (%2$s)"), blk_device->get_name(),
 				  blk_device->get_size_string()));
 	}

--- a/storage/Devices/DiskImpl.cc
+++ b/storage/Devices/DiskImpl.cc
@@ -311,11 +311,11 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by the device name (e.g. /dev/vda),
-			   // %2$s is replaced by the size (e.g. 20 GiB)
+			   // %2$s is replaced by the size (e.g. 20.00 GiB)
 			   _("Create hard disk %1$s (%2$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by the device name (e.g. /dev/vda),
-			   // %2$s is replaced by the size (e.g. 20 GiB)
+			   // %2$s is replaced by the size (e.g. 20.00 GiB)
 			   _("Creating hard disk %1$s (%2$s)"));
 
 	return sformat(text, get_displayname(), get_size_text());

--- a/storage/Devices/EncryptionImpl.cc
+++ b/storage/Devices/EncryptionImpl.cc
@@ -454,13 +454,13 @@ namespace storage
 		text = tenser(commit_data.tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by partition name (e.g. /dev/sda1),
-			      // %2$s is replaced by old size (e.g. 2.0 GiB),
-			      // %3$s is replaced by new size (e.g. 1.0 GiB)
+			      // %2$s is replaced by old size (e.g. 2.00 GiB),
+			      // %3$s is replaced by new size (e.g. 1.00 GiB)
 			      _("Shrink encryption layer device on %1$s from %2$s to %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by partition name (e.g. /dev/sda1),
-			      // %2$s is replaced by old size (e.g. 2.0 GiB),
-			      // %3$s is replaced by new size (e.g. 1.0 GiB)
+			      // %2$s is replaced by old size (e.g. 2.00 GiB),
+			      // %3$s is replaced by new size (e.g. 1.00 GiB)
 			      _("Shrinking encryption layer device on %1$s from %2$s to %3$s"));
 		break;
 
@@ -468,13 +468,13 @@ namespace storage
 		text = tenser(commit_data.tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by partition name (e.g. /dev/sda1),
-			      // %2$s is replaced by old size (e.g. 1.0 GiB),
-			      // %3$s is replaced by new size (e.g. 2.0 GiB)
+			      // %2$s is replaced by old size (e.g. 1.00 GiB),
+			      // %3$s is replaced by new size (e.g. 2.00 GiB)
 			      _("Grow encryption layer device on %1$s from %2$s to %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by partition name (e.g. /dev/sda1),
-			      // %2$s is replaced by old size (e.g. 1.0 GiB),
-			      // %3$s is replaced by new size (e.g. 2.0 GiB)
+			      // %2$s is replaced by old size (e.g. 1.00 GiB),
+			      // %3$s is replaced by new size (e.g. 2.00 GiB)
 			      _("Growing encryption layer device on %1$s from %2$s to %3$s"));
 		break;
 

--- a/storage/Devices/LvmLvImpl.cc
+++ b/storage/Devices/LvmLvImpl.cc
@@ -745,12 +745,12 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Create thin pool logical volume %1$s (%2$s) on volume group %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Creating thin pool logical volume %1$s (%2$s) on volume group %3$s"));
 		break;
@@ -759,12 +759,12 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Create thin logical volume %1$s (%2$s) on volume group %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Creating thin logical volume %1$s (%2$s) on volume group %3$s"));
 		break;
@@ -773,12 +773,12 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Create logical volume %1$s (%2$s) on volume group %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Creating logical volume %1$s (%2$s) on volume group %3$s"));
 		break;
@@ -902,14 +902,14 @@ namespace storage
 				      // TRANSLATORS: displayed before action,
 				      // %1$s is replaced by logical volume name (e.g. root),
 				      // %2$s is replaced by volume group name (e.g. system),
-				      // %3$s is replaced by old size (e.g. 2.0 GiB),
-				      // %4$s is replaced by new size (e.g. 1.0 GiB)
+				      // %3$s is replaced by old size (e.g. 2.00 GiB),
+				      // %4$s is replaced by new size (e.g. 1.00 GiB)
 				      _("Shrink thin pool logical volume %1$s on volume group %2$s from %3$s to %4$s"),
 				      // TRANSLATORS: displayed during action,
 				      // %1$s is replaced by logical volume name (e.g. root),
 				      // %2$s is replaced by volume group name (e.g. system),
-				      // %3$s is replaced by old size (e.g. 2.0 GiB),
-				      // %4$s is replaced by new size (e.g. 1.0 GiB)
+				      // %3$s is replaced by old size (e.g. 2.00 GiB),
+				      // %4$s is replaced by new size (e.g. 1.00 GiB)
 				      _("Shrinking thin pool logical volume %1$s on volume group %2$s from %3$s to %4$s"));
 			break;
 
@@ -918,14 +918,14 @@ namespace storage
 				      // TRANSLATORS: displayed before action,
 				      // %1$s is replaced by logical volume name (e.g. root),
 				      // %2$s is replaced by volume group name (e.g. system),
-				      // %3$s is replaced by old size (e.g. 2.0 GiB),
-				      // %4$s is replaced by new size (e.g. 1.0 GiB)
+				      // %3$s is replaced by old size (e.g. 2.00 GiB),
+				      // %4$s is replaced by new size (e.g. 1.00 GiB)
 				      _("Shrink thin logical volume %1$s on volume group %2$s from %3$s to %4$s"),
 				      // TRANSLATORS: displayed during action,
 				      // %1$s is replaced by logical volume name (e.g. root),
 				      // %2$s is replaced by volume group name (e.g. system),
-				      // %3$s is replaced by old size (e.g. 2.0 GiB),
-				      // %4$s is replaced by new size (e.g. 1.0 GiB)
+				      // %3$s is replaced by old size (e.g. 2.00 GiB),
+				      // %4$s is replaced by new size (e.g. 1.00 GiB)
 				      _("Shrinking thin logical volume %1$s on volume group %2$s from %3$s to %4$s"));
 			break;
 
@@ -934,14 +934,14 @@ namespace storage
 				      // TRANSLATORS: displayed before action,
 				      // %1$s is replaced by logical volume name (e.g. root),
 				      // %2$s is replaced by volume group name (e.g. system),
-				      // %3$s is replaced by old size (e.g. 2.0 GiB),
-				      // %4$s is replaced by new size (e.g. 1.0 GiB)
+				      // %3$s is replaced by old size (e.g. 2.00 GiB),
+				      // %4$s is replaced by new size (e.g. 1.00 GiB)
 				      _("Shrink logical volume %1$s on volume group %2$s from %3$s to %4$s"),
 				      // TRANSLATORS: displayed during action,
 				      // %1$s is replaced by logical volume name (e.g. root),
 				      // %2$s is replaced by volume group name (e.g. system),
-				      // %3$s is replaced by old size (e.g. 2.0 GiB),
-				      // %4$s is replaced by new size (e.g. 1.0 GiB)
+				      // %3$s is replaced by old size (e.g. 2.00 GiB),
+				      // %4$s is replaced by new size (e.g. 1.00 GiB)
 				      _("Shrinking logical volume %1$s on volume group %2$s from %3$s to %4$s"));
 			break;
 		}
@@ -956,14 +956,14 @@ namespace storage
 				      // TRANSLATORS: displayed before action,
 				      // %1$s is replaced by logical volume name (e.g. root),
 				      // %2$s is replaced by volume group name (e.g. system),
-				      // %3$s is replaced by old size (e.g. 1.0 GiB),
-				      // %4$s is replaced by new size (e.g. 2.0 GiB)
+				      // %3$s is replaced by old size (e.g. 1.00 GiB),
+				      // %4$s is replaced by new size (e.g. 2.00 GiB)
 				      _("Grow thin pool logical volume %1$s on volume group %2$s from %3$s to %4$s"),
 				      // TRANSLATORS: displayed during action,
 				      // %1$s is replaced by logical volume name (e.g. root),
 				      // %2$s is replaced by volume group name (e.g. system),
-				      // %3$s is replaced by old size (e.g. 1.0 GiB),
-				      // %4$s is replaced by new size (e.g. 2.0 GiB)
+				      // %3$s is replaced by old size (e.g. 1.00 GiB),
+				      // %4$s is replaced by new size (e.g. 2.00 GiB)
 				      _("Growing thin pool logical volume %1$s on volume group %2$s from %3$s to %4$s"));
 			break;
 
@@ -972,14 +972,14 @@ namespace storage
 				      // TRANSLATORS: displayed before action,
 				      // %1$s is replaced by logical volume name (e.g. root),
 				      // %2$s is replaced by volume group name (e.g. system),
-				      // %3$s is replaced by old size (e.g. 1.0 GiB),
-				      // %4$s is replaced by new size (e.g. 2.0 GiB)
+				      // %3$s is replaced by old size (e.g. 1.00 GiB),
+				      // %4$s is replaced by new size (e.g. 2.00 GiB)
 				      _("Grow thin logical volume %1$s on volume group %2$s from %3$s to %4$s"),
 				      // TRANSLATORS: displayed during action,
 				      // %1$s is replaced by logical volume name (e.g. root),
 				      // %2$s is replaced by volume group name (e.g. system),
-				      // %3$s is replaced by old size (e.g. 1.0 GiB),
-				      // %4$s is replaced by new size (e.g. 2.0 GiB)
+				      // %3$s is replaced by old size (e.g. 1.00 GiB),
+				      // %4$s is replaced by new size (e.g. 2.00 GiB)
 				      _("Growing thin logical volume %1$s on volume group %2$s from %3$s to %4$s"));
 			break;
 
@@ -988,14 +988,14 @@ namespace storage
 				      // TRANSLATORS: displayed before action,
 				      // %1$s is replaced by logical volume name (e.g. root),
 				      // %2$s is replaced by volume group name (e.g. system),
-				      // %3$s is replaced by old size (e.g. 1.0 GiB),
-				      // %4$s is replaced by new size (e.g. 2.0 GiB)
+				      // %3$s is replaced by old size (e.g. 1.00 GiB),
+				      // %4$s is replaced by new size (e.g. 2.00 GiB)
 				      _("Grow logical volume %1$s on volume group %2$s from %3$s to %4$s"),
 				      // TRANSLATORS: displayed during action,
 				      // %1$s is replaced by logical volume name (e.g. root),
 				      // %2$s is replaced by volume group name (e.g. system),
-				      // %3$s is replaced by old size (e.g. 1.0 GiB),
-				      // %4$s is replaced by new size (e.g. 2.0 GiB)
+				      // %3$s is replaced by old size (e.g. 1.00 GiB),
+				      // %4$s is replaced by new size (e.g. 2.00 GiB)
 				      _("Growing logical volume %1$s on volume group %2$s from %3$s to %4$s"));
 			break;
 		}
@@ -1043,12 +1043,12 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Delete thin pool logical volume %1$s (%2$s) on volume group %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Deleting thin pool logical volume %1$s (%2$s) on volume group %3$s"));
 		break;
@@ -1057,12 +1057,12 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Delete thin logical volume %1$s (%2$s) on volume group %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Deleting thin logical volume %1$s (%2$s) on volume group %3$s"));
 		break;
@@ -1071,12 +1071,12 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Delete logical volume %1$s (%2$s) on volume group %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Deleting logical volume %1$s (%2$s) on volume group %3$s"));
 		break;
@@ -1110,12 +1110,12 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Activate thin pool logical volume %1$s (%2$s) on volume group %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Activating thin pool logical volume %1$s (%2$s) on volume group %3$s"));
 		break;
@@ -1124,12 +1124,12 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Activate thin logical volume %1$s (%2$s) on volume group %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Activating thin logical volume %1$s (%2$s) on volume group %3$s"));
 		break;
@@ -1138,12 +1138,12 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Activate logical volume %1$s (%2$s) on volume group %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Activating logical volume %1$s (%2$s) on volume group %3$s"));
 		break;
@@ -1177,12 +1177,12 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Deactivate thin pool logical volume %1$s (%2$s) on volume group %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Deactivating thin pool logical volume %1$s (%2$s) on volume group %3$s"));
 		break;
@@ -1191,12 +1191,12 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Deactivate thin logical volume %1$s (%2$s) on volume group %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Deactivating thin logical volume %1$s (%2$s) on volume group %3$s"));
 		break;
@@ -1205,12 +1205,12 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Deactivate logical volume %1$s (%2$s) on volume group %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by logical volume name (e.g. root),
-			      // %2$s is replaced by size (e.g. 2GiB),
+			      // %2$s is replaced by size (e.g. 2.00 GiB),
 			      // %3$s is replaced by volume group name (e.g. system)
 			      _("Deactivating logical volume %1$s (%2$s) on volume group %3$s"));
 		break;

--- a/storage/Devices/LvmPvImpl.cc
+++ b/storage/Devices/LvmPvImpl.cc
@@ -370,13 +370,13 @@ namespace storage
 		text = tenser(commit_data.tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by device name (e.g. /dev/sdb1),
-			      // %2$s is replaced by old size (e.g. 2.0 GiB),
-			      // %3$s is replaced by new size (e.g. 1.0 GiB)
+			      // %2$s is replaced by old size (e.g. 2.00 GiB),
+			      // %3$s is replaced by new size (e.g. 1.00 GiB)
 			      _("Shrink physical volume on %1$s from %2$s to %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by device name (e.g. /dev/sdb1),
-			      // %2$s is replaced by old size (e.g. 2.0 GiB),
-			      // %3$s is replaced by new size (e.g. 1.0 GiB)
+			      // %2$s is replaced by old size (e.g. 2.00 GiB),
+			      // %3$s is replaced by new size (e.g. 1.00 GiB)
 			      _("Shrinking physical volume on %1$s from %2$s to %3$s"));
 		break;
 
@@ -384,13 +384,13 @@ namespace storage
 		text = tenser(commit_data.tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by device name (e.g. /dev/sdb1),
-			      // %2$s is replaced by old size (e.g. 1.0 GiB),
-			      // %3$s is replaced by new size (e.g. 2.0 GiB)
+			      // %2$s is replaced by old size (e.g. 1.00 GiB),
+			      // %3$s is replaced by new size (e.g. 2.00 GiB)
 			      _("Grow physical volume on %1$s from %2$s to %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by device name (e.g. /dev/sdb1),
-			      // %2$s is replaced by old size (e.g. 1.0 GiB),
-			      // %3$s is replaced by new size (e.g. 2.0 GiB)
+			      // %2$s is replaced by old size (e.g. 1.00 GiB),
+			      // %3$s is replaced by new size (e.g. 2.00 GiB)
 			      _("Growing physical volume on %1$s from %2$s to %3$s"));
 		break;
 

--- a/storage/Devices/LvmVgImpl.cc
+++ b/storage/Devices/LvmVgImpl.cc
@@ -530,15 +530,15 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by volume group name (e.g. system),
-			   // %2$s is replaced by size (e.g. 2 GiB),
-			   // %3$s is replaced by one or more devices (e.g /dev/sda1 (1 GiB) and
-			   // /dev/sdb2 (1 GiB))
+			   // %2$s is replaced by size (e.g. 2.00 GiB),
+			   // %3$s is replaced by one or more devices (e.g /dev/sda1 (1.00 GiB) and
+			   // /dev/sdb2 (1.00 GiB))
 			   _("Create volume group %1$s (%2$s) from %3$s"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by volume group name (e.g. system),
-			   // %2$s is replaced by size (e.g. 2 GiB),
-			   // %3$s is replaced by one or more devices (e.g /dev/sda1 (1 GiB) and
-			   // /dev/sdb2 (1 GiB))
+			   // %2$s is replaced by size (e.g. 2.00 GiB),
+			   // %3$s is replaced by one or more devices (e.g /dev/sda1 (1.00 GiB) and
+			   // /dev/sdb2 (1.00 GiB))
 			   _("Creating volume group %1$s (%2$s) from %3$s"));
 
 	vector<const BlkDevice*> blk_devices;
@@ -580,11 +580,11 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by volume group name (e.g. system),
-			   // %2$s is replaced by size (e.g. 2GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Delete volume group %1$s (%2$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by volume group name (e.g. system),
-			   // %2$s is replaced by size (e.g. 2GiB)
+			   // %2$s is replaced by size (e.g. 2.00 GiB)
 			   _("Deleting volume group %1$s (%2$s)"));
 
 	return sformat(text, vg_name, get_size_text());

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -930,16 +930,16 @@ namespace storage
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by RAID level (e.g. RAID0),
 			   // %2$s is replaced by RAID name (e.g. /dev/md0),
-			   // %3$s is replaced by size (e.g. 2 GiB),
-			   // %4$s is replaced by one or more devices (e.g /dev/sda1 (1 GiB) and
-			   // /dev/sdb2 (1 GiB))
+			   // %3$s is replaced by size (e.g. 2.00 GiB),
+			   // %4$s is replaced by one or more devices (e.g /dev/sda1 (1.00 GiB) and
+			   // /dev/sdb2 (1.00 GiB))
 			   _("Create MD %1$s %2$s (%3$s) from %4$s"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by RAID level (e.g. RAID0),
 			   // %2$s is replaced by RAID name (e.g. /dev/md0),
-			   // %3$s is replaced by size (e.g. 2 GiB),
-			   // %4$s is replaced by one or more devices (e.g /dev/sda1 (1 GiB) and
-			   // /dev/sdb2 (1 GiB))
+			   // %3$s is replaced by size (e.g. 2.00 GiB),
+			   // %4$s is replaced by one or more devices (e.g /dev/sda1 (1.00 GiB) and
+			   // /dev/sdb2 (1.00 GiB))
 			   _("Creating MD %1$s %2$s (%3$s) from %4$s"));
 
 	return sformat(text, get_md_level_name(md_level), get_displayname(),
@@ -1021,12 +1021,12 @@ namespace storage
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by RAID level (e.g. RAID0),
 			   // %2$s is replaced by RAID name (e.g. /dev/md0),
-			   // %3$s is replaced by size (e.g. 2GiB)
+			   // %3$s is replaced by size (e.g. 2.00 GiB)
 			   _("Delete MD %1$s %2$s (%3$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by RAID level (e.g. RAID0),
 			   // %2$s is replaced by RAID name (e.g. /dev/md0),
-			   // %3$s is replaced by size (e.g. 2GiB)
+			   // %3$s is replaced by size (e.g. 2.00 GiB)
 			   _("Deleting MD %1$s %2$s (%3$s)"));
 
 	return sformat(text, get_md_level_name(md_level), get_displayname(), get_size_text());
@@ -1197,12 +1197,12 @@ namespace storage
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by RAID level (e.g. RAID0),
 			   // %2$s is replaced by RAID name (e.g. /dev/md0),
-			   // %3$s is replaced by size (e.g. 2 GiB)
+			   // %3$s is replaced by size (e.g. 2.00 GiB)
 			   _("Deactivate MD %1$s %2$s (%3$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by RAID level (e.g. RAID0),
 			   // %2$s is replaced by RAID name (e.g. /dev/md0),
-			   // %3$s is replaced by size (e.g. 2 GiB)
+			   // %3$s is replaced by size (e.g. 2.00 GiB)
 			   _("Deactivating MD %1$s %2$s (%3$s)"));
 
 	return sformat(text, get_md_level_name(md_level), get_displayname(), get_size_text());

--- a/storage/Devices/MultipathImpl.cc
+++ b/storage/Devices/MultipathImpl.cc
@@ -328,11 +328,11 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by multipath name (e.g. /dev/mapper/36005076305ffc73a00000000000013b4),
-			   // %2$s is replaced by size (e.g. 1 TiB)
+			   // %2$s is replaced by size (e.g. 1.00 TiB)
 			   _("Deactivate multipath %1$s (%2$s)"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by multipath name (e.g. /dev/mapper/36005076305ffc73a00000000000013b4),
-			   // %2$s is replaced by size (e.g. 1 TiB)
+			   // %2$s is replaced by size (e.g. 1.00 TiB)
 			   _("Deactivating multipath %1$s (%2$s)"));
 
 	return sformat(text, get_displayname(), get_size_text());

--- a/storage/Devices/PartitionImpl.cc
+++ b/storage/Devices/PartitionImpl.cc
@@ -648,11 +648,11 @@ namespace storage
 	    text = tenser(tense,
 			  // TRANSLATORS: displayed before action,
 			  // %1$s is replaced by partition name (e.g. /dev/dasda1),
-			  // %2$s is replaced by size (e.g. 2 GiB)
+			  // %2$s is replaced by size (e.g. 2.00 GiB)
 			  _("Create implicit partition %1$s (%2$s)"),
 			  // TRANSLATORS: displayed during action,
 			  // %1$s is replaced by partition name (e.g. /dev/dasda1),
-			  // %2$s is replaced by size (e.g. 2 GiB)
+			  // %2$s is replaced by size (e.g. 2.00 GiB)
 			  _("Creating implicit partition %1$s (%2$s)"));
 	}
 	else if (!is_msdos(get_partition_table()))
@@ -660,11 +660,11 @@ namespace storage
 	    text = tenser(tense,
 			  // TRANSLATORS: displayed before action,
 			  // %1$s is replaced by partition name (e.g. /dev/sda1),
-			  // %2$s is replaced by size (e.g. 2 GiB)
+			  // %2$s is replaced by size (e.g. 2.00 GiB)
 			  _("Create partition %1$s (%2$s)"),
 			  // TRANSLATORS: displayed during action,
 			  // %1$s is replaced by partition name (e.g. /dev/sda1),
-			  // %2$s is replaced by size (e.g. 2 GiB)
+			  // %2$s is replaced by size (e.g. 2.00 GiB)
 			  _("Creating partition %1$s (%2$s)"));
 	}
 	else
@@ -675,11 +675,11 @@ namespace storage
 		    text = tenser(tense,
 				  // TRANSLATORS: displayed before action,
 				  // %1$s is replaced by partition name (e.g. /dev/sda1),
-				  // %2$s is replaced by size (e.g. 2 GiB)
+				  // %2$s is replaced by size (e.g. 2.00 GiB)
 				  _("Create primary partition %1$s (%2$s)"),
 				  // TRANSLATORS: displayed during action,
 				  // %1$s is replaced by partition name (e.g. /dev/sda1),
-				  // %2$s is replaced by size (e.g. 2 GiB)
+				  // %2$s is replaced by size (e.g. 2.00 GiB)
 				  _("Creating primary partition %1$s (%2$s)"));
 		    break;
 
@@ -687,11 +687,11 @@ namespace storage
 		    text = tenser(tense,
 				  // TRANSLATORS: displayed before action,
 				  // %1$s is replaced by partition name (e.g. /dev/sda1),
-				  // %2$s is replaced by size (e.g. 2 GiB)
+				  // %2$s is replaced by size (e.g. 2.00 GiB)
 				  _("Create extended partition %1$s (%2$s)"),
 				  // TRANSLATORS: displayed during action,
 				  // %1$s is replaced by partition name (e.g. /dev/sda1),
-				  // %2$s is replaced by size (e.g. 2 GiB)
+				  // %2$s is replaced by size (e.g. 2.00 GiB)
 				  _("Creating extended partition %1$s (%2$s)"));
 		    break;
 
@@ -699,11 +699,11 @@ namespace storage
 		    text = tenser(tense,
 				  // TRANSLATORS: displayed before action,
 				  // %1$s is replaced by partition name (e.g. /dev/sda1),
-				  // %2$s is replaced by size (e.g. 2 GiB)
+				  // %2$s is replaced by size (e.g. 2.00 GiB)
 				  _("Create logical partition %1$s (%2$s)"),
 				  // TRANSLATORS: displayed during action,
 				  // %1$s is replaced by partition name (e.g. /dev/sda1),
-				  // %2$s is replaced by size (e.g. 2 GiB)
+				  // %2$s is replaced by size (e.g. 2.00 GiB)
 				  _("Creating logical partition %1$s (%2$s)"));
 		    break;
 	    }
@@ -1000,11 +1000,11 @@ namespace storage
 	    text = tenser(tense,
 			  // TRANSLATORS: displayed before action,
 			  // %1$s is replaced by partition name (e.g. /dev/dasda1),
-			  // %2$s is replaced by size (e.g. 2 GiB)
+			  // %2$s is replaced by size (e.g. 2.00 GiB)
 			  _("Delete implicit partition %1$s (%2$s)"),
 			  // TRANSLATORS: displayed during action,
 			  // %1$s is replaced by partition name (e.g. /dev/dasda1),
-			  // %2$s is replaced by size (e.g. 2 GiB)
+			  // %2$s is replaced by size (e.g. 2.00 GiB)
 			  _("Deleting implicit partition %1$s (%2$s)"));
 	}
 	else if (!is_msdos(get_partition_table()))
@@ -1012,11 +1012,11 @@ namespace storage
 	    text = tenser(tense,
 			  // TRANSLATORS: displayed before action,
 			  // %1$s is replaced by partition name (e.g. /dev/sda1),
-			  // %2$s is replaced by size (e.g. 2 GiB)
+			  // %2$s is replaced by size (e.g. 2.00 GiB)
 			  _("Delete partition %1$s (%2$s)"),
 			  // TRANSLATORS: displayed during action,
 			  // %1$s is replaced by partition name (e.g. /dev/sda1),
-			  // %2$s is replaced by size (e.g. 2 GiB)
+			  // %2$s is replaced by size (e.g. 2.00 GiB)
 			  _("Deleting partition %1$s (%2$s)"));
 	}
 	else
@@ -1027,11 +1027,11 @@ namespace storage
 		    text = tenser(tense,
 				  // TRANSLATORS: displayed before action,
 				  // %1$s is replaced by partition name (e.g. /dev/sda1),
-				  // %2$s is replaced by size (e.g. 2 GiB)
+				  // %2$s is replaced by size (e.g. 2.00 GiB)
 				  _("Delete primary partition %1$s (%2$s)"),
 				  // TRANSLATORS: displayed during action,
 				  // %1$s is replaced by partition name (e.g. /dev/sda1),
-				  // %2$s is replaced by size (e.g. 2 GiB)
+				  // %2$s is replaced by size (e.g. 2.00 GiB)
 				  _("Deleting primary partition %1$s (%2$s)"));
 		    break;
 
@@ -1039,11 +1039,11 @@ namespace storage
 		    text = tenser(tense,
 				  // TRANSLATORS: displayed before action,
 				  // %1$s is replaced by partition name (e.g. /dev/sda1),
-				  // %2$s is replaced by size (e.g. 2 GiB)
+				  // %2$s is replaced by size (e.g. 2.00 GiB)
 				  _("Delete extended partition %1$s (%2$s)"),
 				  // TRANSLATORS: displayed during action,
 				  // %1$s is replaced by partition name (e.g. /dev/sda1),
-				  // %2$s is replaced by size (e.g. 2 GiB)
+				  // %2$s is replaced by size (e.g. 2.00 GiB)
 				  _("Deleting extended partition %1$s (%2$s)"));
 		    break;
 
@@ -1051,11 +1051,11 @@ namespace storage
 		    text = tenser(tense,
 				  // TRANSLATORS: displayed before action,
 				  // %1$s is replaced by partition name (e.g. /dev/sda1),
-				  // %2$s is replaced by size (e.g. 2 GiB)
+				  // %2$s is replaced by size (e.g. 2.00 GiB)
 				  _("Delete logical partition %1$s (%2$s)"),
 				  // TRANSLATORS: displayed during action,
 				  // %1$s is replaced by partition name (e.g. /dev/sda1),
-				  // %2$s is replaced by size (e.g. 2 GiB)
+				  // %2$s is replaced by size (e.g. 2.00 GiB)
 				  _("Deleting logical partition %1$s (%2$s)"));
 		    break;
 	    }
@@ -1111,13 +1111,13 @@ namespace storage
 		text = tenser(commit_data.tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by partition name (e.g. /dev/sda1),
-			      // %2$s is replaced by old size (e.g. 2.0 GiB),
-			      // %3$s is replaced by new size (e.g. 1.0 GiB)
+			      // %2$s is replaced by old size (e.g. 2.00 GiB),
+			      // %3$s is replaced by new size (e.g. 1.00 GiB)
 			      _("Shrink partition %1$s from %2$s to %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by partition name (e.g. /dev/sda1),
-			      // %2$s is replaced by old size (e.g. 2.0 GiB),
-			      // %3$s is replaced by new size (e.g. 1.0 GiB)
+			      // %2$s is replaced by old size (e.g. 2.00 GiB),
+			      // %3$s is replaced by new size (e.g. 1.00 GiB)
 			      _("Shrinking partition %1$s from %2$s to %3$s"));
 		break;
 
@@ -1125,13 +1125,13 @@ namespace storage
 		text = tenser(commit_data.tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by partition name (e.g. /dev/sda1),
-			      // %2$s is replaced by old size (e.g. 1.0 GiB),
-			      // %3$s is replaced by new size (e.g. 2.0 GiB)
+			      // %2$s is replaced by old size (e.g. 1.00 GiB),
+			      // %3$s is replaced by new size (e.g. 2.00 GiB)
 			      _("Grow partition %1$s from %2$s to %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by partition name (e.g. /dev/sda1),
-			      // %2$s is replaced by old size (e.g. 1.0 GiB),
-			      // %3$s is replaced by new size (e.g. 2.0 GiB)
+			      // %2$s is replaced by old size (e.g. 1.00 GiB),
+			      // %3$s is replaced by new size (e.g. 2.00 GiB)
 			      _("Growing partition %1$s from %2$s to %3$s"));
 		break;
 

--- a/storage/Filesystems/BlkFilesystemImpl.cc
+++ b/storage/Filesystems/BlkFilesystemImpl.cc
@@ -737,13 +737,13 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by file system name (e.g. ext4),
-			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.0 GiB) and
-			   // /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.00 GiB) and
+			   // /dev/sdb2 (1.00 GiB))
 			   _("Create %1$s on %2$s"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by file system name (e.g. ext4),
-			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.0 GiB) and
-			   // /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.00 GiB) and
+			   // /dev/sdb2 (1.00 GiB))
 			   _("Creating %1$s on %2$s"));
 
 	return sformat(text, get_displayname(), get_message_name());
@@ -756,14 +756,14 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by file system name (e.g. ext4),
-			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.0 GiB) and
-			   // /dev/sdb2 (1.0 GiB)),
+			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.00 GiB) and
+			   // /dev/sdb2 (1.00 GiB)),
 			   // %3$s is replaced by label (e.g. ROOT)
 			   _("Set label of %1$s on %2$s to %3$s"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by file system name (e.g. ext4),
-			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.0 GiB) and
-			   // /dev/sdb2 (1.0 GiB)),
+			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.00 GiB) and
+			   // /dev/sdb2 (1.00 GiB)),
 			   // %3$s is replaced by label (e.g. ROOT)
 			   _("Setting label of %1$s on %2$s to %3$s"));
 
@@ -784,14 +784,14 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by file system name (e.g. ext4),
-			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.0 GiB) and
-			   // /dev/sdb2 (1.0 GiB)),
+			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.00 GiB) and
+			   // /dev/sdb2 (1.00 GiB)),
 			   // %3$s is replaced by UUID (e.g. 3cfa63b5-4d29-43e6-8658-57b74f68fd7f)
 			   _("Set UUID of %1$s on %2$s to %3$s"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by file system name (e.g. ext4),
-			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.0 GiB) and
-			   // /dev/sdb2 (1.0 GiB)),
+			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.00 GiB) and
+			   // /dev/sdb2 (1.00 GiB)),
 			   // %3$s is replaced by UUID (e.g. 3cfa63b5-4d29-43e6-8658-57b74f68fd7f)
 			   _("Setting UUID of %1$s on %2$s to %3$s"));
 
@@ -812,13 +812,13 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by file system name (e.g. ext4),
-			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.0 GiB) and
-			   // /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.00 GiB) and
+			   // /dev/sdb2 (1.00 GiB))
 			   _("Set tune options of %1$s on %2$s"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by file system name (e.g. ext4),
-			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.0 GiB) and
-			   // /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more devices (e.g /dev/sda1 (1.00 GiB) and
+			   // /dev/sdb2 (1.00 GiB))
 			   _("Setting tune options of %1$s on %2$s"));
 
 	return sformat(text, get_displayname(), get_message_name());
@@ -849,14 +849,14 @@ namespace storage
 				  // TRANSLATORS: displayed before action,
 				  // %1$s is replaced by file system (e.g. ext4),
 				  // %2$s is replaced by device name (e.g. /dev/sda1),
-				  // %3$s is replaced by old size (e.g. 2.0 GiB),
-				  // %4$s is replaced by new size (e.g. 1.0 GiB)
+				  // %3$s is replaced by old size (e.g. 2.00 GiB),
+				  // %4$s is replaced by new size (e.g. 1.00 GiB)
 				  _("Shrink %1$s on %2$s from %3$s to %4$s"),
 				  // TRANSLATORS: displayed during action,
 				  // %1$s is replaced by file system (e.g. ext4),
 				  // %2$s is replaced by device name (e.g. /dev/sda1),
-				  // %3$s is replaced by old size (e.g. 2.0 GiB),
-				  // %4$s is replaced by new size (e.g. 1.0 GiB)
+				  // %3$s is replaced by old size (e.g. 2.00 GiB),
+				  // %4$s is replaced by new size (e.g. 1.00 GiB)
 				  _("Shrinking %1$s on %2$s from %3$s to %4$s"));
 		    break;
 
@@ -865,14 +865,14 @@ namespace storage
 				  // TRANSLATORS: displayed before action,
 				  // %1$s is replaced by file system (e.g. ext4),
 				  // %2$s is replaced by device name (e.g. /dev/sda1),
-				  // %3$s is replaced by old size (e.g. 1.0 GiB),
-				  // %4$s is replaced by new size (e.g. 2.0 GiB)
+				  // %3$s is replaced by old size (e.g. 1.00 GiB),
+				  // %4$s is replaced by new size (e.g. 2.00 GiB)
 				  _("Grow %1$s on %2$s from %3$s to %4$s"),
 				  // TRANSLATORS: displayed during action,
 				  // %1$s is replaced by file system (e.g. ext4),
 				  // %2$s is replaced by device name (e.g. /dev/sda1),
-				  // %3$s is replaced by old size (e.g. 1.0 GiB),
-				  // %4$s is replaced by new size (e.g. 2.0 GiB)
+				  // %3$s is replaced by old size (e.g. 1.00 GiB),
+				  // %4$s is replaced by new size (e.g. 2.00 GiB)
 				  _("Growing %1$s on %2$s from %3$s to %4$s"));
 		    break;
 
@@ -895,18 +895,18 @@ namespace storage
 				  // TRANSLATORS: displayed before action,
 				  // %1$s is replaced by device name (e.g. /dev/sda1),
 				  // %2$s is replaced by file system (e.g. ext4),
-				  // %3$s is replaced by several devices (e.g /dev/sda1 (1.0 GiB) and
-				  // /dev/sdb2 (1.0 GiB)),
-				  // %4$s is replaced by old size (e.g. 2.0 GiB),
-				  // %5$s is replaced by new size (e.g. 1.0 GiB)
+				  // %3$s is replaced by several devices (e.g /dev/sda1 (1.00 GiB) and
+				  // /dev/sdb2 (1.00 GiB)),
+				  // %4$s is replaced by old size (e.g. 2.00 GiB),
+				  // %5$s is replaced by new size (e.g. 1.00 GiB)
 				  _("Shrink %1$s of %2$s on %3$s from %4$s to %5$s"),
 				  // TRANSLATORS: displayed during action,
 				  // %1$s is replaced by device name (e.g. /dev/sda1),
 				  // %2$s is replaced by file system (e.g. ext4),
-				  // %3$s is replaced by several devices (e.g /dev/sda1 (1.0 GiB) and
-				  // /dev/sdb2 (1.0 GiB)),
-				  // %4$s is replaced by old size (e.g. 2.0 GiB),
-				  // %5$s is replaced by new size (e.g. 1.0 GiB)
+				  // %3$s is replaced by several devices (e.g /dev/sda1 (1.00 GiB) and
+				  // /dev/sdb2 (1.00 GiB)),
+				  // %4$s is replaced by old size (e.g. 2.00 GiB),
+				  // %5$s is replaced by new size (e.g. 1.00 GiB)
 				  _("Shrinking %1$s of %2$s on %3$s from %4$s to %5$s"));
 		    break;
 
@@ -915,18 +915,18 @@ namespace storage
 				  // TRANSLATORS: displayed before action,
 				  // %1$s is replaced by device name (e.g. /dev/sda1),
 				  // %2$s is replaced by file system (e.g. ext4),
-				  // %3$s is replaced by several devices (e.g /dev/sda1 (1.0 GiB) and
-				  // /dev/sdb2 (1.0 GiB)),
-				  // %4$s is replaced by old size (e.g. 1.0 GiB),
-				  // %5$s is replaced by new size (e.g. 2.0 GiB)
+				  // %3$s is replaced by several devices (e.g /dev/sda1 (1.00 GiB) and
+				  // /dev/sdb2 (1.00 GiB)),
+				  // %4$s is replaced by old size (e.g. 1.00 GiB),
+				  // %5$s is replaced by new size (e.g. 2.00 GiB)
 				  _("Grow %1$s of %2$s on %3$s from %4$s to %5$s"),
 				  // TRANSLATORS: displayed during action,
 				  // %1$s is replaced by device name (e.g. /dev/sda1),
 				  // %2$s is replaced by file system (e.g. ext4),
-				  // %3$s is replaced by several devices (e.g /dev/sda1 (1.0 GiB) and
-				  // /dev/sdb2 (1.0 GiB)),
-				  // %4$s is replaced by old size (e.g. 1.0 GiB),
-				  // %5$s is replaced by new size (e.g. 2.0 GiB)
+				  // %3$s is replaced by several devices (e.g /dev/sda1 (1.00 GiB) and
+				  // /dev/sdb2 (1.00 GiB)),
+				  // %4$s is replaced by old size (e.g. 1.00 GiB),
+				  // %5$s is replaced by new size (e.g. 2.00 GiB)
 				  _("Growing %1$s of %2$s on %3$s from %4$s to %5$s"));
 		    break;
 
@@ -949,13 +949,13 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by file system name (e.g. ext4),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Delete %1$s on %2$s"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by file system name (e.g. ext4),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Deleting %1$s on %2$s"));
 
 	return sformat(text, get_displayname(), get_message_name());

--- a/storage/Filesystems/BtrfsImpl.cc
+++ b/storage/Filesystems/BtrfsImpl.cc
@@ -824,15 +824,15 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by the device name (e.g. /dev/sdc1),
-			      // %2$s is replaced by the device size (e.g. 2.0 GiB),
-			      // %3$s is replaced by one or more devices (e.g /dev/sda1 (2.0 GiB)
-			      // and /dev/sdb2 (2.0 GiB))
+			      // %2$s is replaced by the device size (e.g. 2.00 GiB),
+			      // %3$s is replaced by one or more devices (e.g /dev/sda1 (2.00 GiB)
+			      // and /dev/sdb2 (2.00 GiB))
 			      _("Remove %1$s (%2$s) from btrfs on %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by the device name (e.g. /dev/sdc1),
-			      // %2$s is replaced by the device size (e.g. 2.0 GiB),
-			      // %3$s is replaced by one or more devices (e.g /dev/sda1 (2.0 GiB)
-			      // and /dev/sdb2 (2.0 GiB))
+			      // %2$s is replaced by the device size (e.g. 2.00 GiB),
+			      // %3$s is replaced by one or more devices (e.g /dev/sda1 (2.00 GiB)
+			      // and /dev/sdb2 (2.00 GiB))
 			      _("Removing %1$s (%2$s) from btrfs on %3$s"));
 		break;
 
@@ -840,15 +840,15 @@ namespace storage
 		text = tenser(tense,
 			      // TRANSLATORS: displayed before action,
 			      // %1$s is replaced by the device name (e.g. /dev/sdc1),
-			      // %2$s is replaced by the device size (e.g. 2.0 GiB),
-			      // %3$s is replaced by one or more devices (e.g /dev/sda1 (2.0 GiB)
-			      // and /dev/sdb2 (2.0 GiB))
+			      // %2$s is replaced by the device size (e.g. 2.00 GiB),
+			      // %3$s is replaced by one or more devices (e.g /dev/sda1 (2.00 GiB)
+			      // and /dev/sdb2 (2.00 GiB))
 			      _("Add %1$s (%2$s) to btrfs on %3$s"),
 			      // TRANSLATORS: displayed during action,
 			      // %1$s is replaced by the device name (e.g. /dev/sdc1),
-			      // %2$s is replaced by the device size (e.g. 2.0 GiB),
-			      // %3$s is replaced by one or more devices (e.g /dev/sda1 (2.0 GiB)
-			      // and /dev/sdb2 (2.0 GiB))
+			      // %2$s is replaced by the device size (e.g. 2.00 GiB),
+			      // %3$s is replaced by one or more devices (e.g /dev/sda1 (2.00 GiB)
+			      // and /dev/sdb2 (2.00 GiB))
 			      _("Adding %1$s (%2$s) to btrfs on %3$s"));
 		break;
 

--- a/storage/Filesystems/BtrfsSubvolumeImpl.cc
+++ b/storage/Filesystems/BtrfsSubvolumeImpl.cc
@@ -424,13 +424,13 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by subvolume path (e.g. var/log),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Create subvolume %1$s on %2$s"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by subvolume path (e.g. var/log),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Creating subvolume %1$s on %2$s"));
 
 	return sformat(text, path, get_message_name());
@@ -479,14 +479,14 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by the subvolume path (e.g. home),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB)),
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB)),
 			   // %3$s is replaced by the mount point (e.g. /home)
 			   _("Mount subvolume %1$s on %2$s at %3$s"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by the subvolume path (e.g. home),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   // %3$s is replaced by the mount point (e.g. /home)
 			   _("Mounting subvolume %1$s on %2$s at %3$s"));
 
@@ -500,14 +500,14 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by the subvolume path (e.g. home),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   // %3$s is replaced by the mount point (e.g. /home)
 			   _("Unmount subvolume %1$s on %2$s at %3$s"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by the subvolume path (e.g. home),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB)),
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB)),
 			   // %3$s is replaced by the mount point (e.g. /home)
 			   _("Unmounting subvolume %1$s on %2$s at %3$s"));
 
@@ -522,14 +522,14 @@ namespace storage
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by the mount point (e.g. /home),
 			   // %2$s is replaced by the subvolume path (e.g. home),
-			   // %3$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %3$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Add mount point %1$s of subvolume %2$s on %3$s to /etc/fstab"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by the mount point (e.g. /home),
 			   // %2$s is replaced by the subvolume path (e.g. home),
-			   // %3$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %3$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Adding mount point %1$s of subvolume %2$s on %3$s to /etc/fstab"));
 
 	return sformat(text, mount_point->get_path(), path, get_message_name());
@@ -543,14 +543,14 @@ namespace storage
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by the mount point (e.g. /home),
 			   // %2$s is replaced by the subvolume path (e.g. home),
-			   // %3$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %3$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Remove mount point %1$s of subvolume %2$s on %3$s from /etc/fstab"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by the mount point (e.g. /home),
 			   // %2$s is replaced by the subvolume path (e.g. home),
-			   // %3$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %3$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Removing mount point %1$s of subvolume %2$s on %3$s from /etc/fstab"));
 
 	return sformat(text, mount_point->get_path(), path, get_message_name());
@@ -566,25 +566,25 @@ namespace storage
 	    text = tenser(tense,
 			  // TRANSLATORS: displayed before action,
 			  // %1$s is replaced by the subvolume path (e.g. var/log),
-			  // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			  // and /dev/sdb2 (1.0 GiB))
+			  // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			  // and /dev/sdb2 (1.00 GiB))
 			  _("Set option 'no copy on write' for subvolume %1$s on %2$s"),
 			  // TRANSLATORS: displayed during action,
 			  // %1$s is replaced by the subvolume path (e.g. var/log),
-			  // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			  // and /dev/sdb2 (1.0 GiB))
+			  // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			  // and /dev/sdb2 (1.00 GiB))
 			  _("Setting option 'no copy on write' for subvolume %1$s on %2$s"));
 	else
 	    text = tenser(tense,
 			  // TRANSLATORS: displayed before action,
 			  // %1$s is replaced by the subvolume path (e.g. var/log),
-			  // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			  // and /dev/sdb2 (1.0 GiB))
+			  // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			  // and /dev/sdb2 (1.00 GiB))
 			  _("Clear option 'no copy on write' for subvolume %1$s on %2$s"),
 			  // TRANSLATORS: displayed during action,
 			  // %1$s is replaced by the subvolume path (e.g. var/log),
-			  // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			  // and /dev/sdb2 (1.0 GiB))
+			  // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			  // and /dev/sdb2 (1.00 GiB))
 			  _("Clearing option 'no copy on write' for subvolume %1$s on %2$s"));
 
 	return sformat(text, get_displayname(), get_message_name());
@@ -611,13 +611,13 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by the subvolume path (e.g. var/log),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Set default subvolume to subvolume %1$s on %2$s"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by the subvolume path (e.g. var/log),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Setting default subvolume to subvolume %1$s on %2$s"));
 
 	return sformat(text, get_displayname(), get_message_name());
@@ -644,13 +644,13 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by the subvolume path (e.g. var/log),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Delete subvolume %1$s on %2$s"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by the subvolume path (e.g. var/log),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Deleting subvolume %1$s on %2$s"));
 
 	return sformat(text, path, get_message_name());

--- a/storage/Filesystems/MountableImpl.cc
+++ b/storage/Filesystems/MountableImpl.cc
@@ -346,13 +346,13 @@ namespace storage
     {
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
-			   // %1$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB)),
+			   // %1$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB)),
 			   // %2$s is replaced by the mount point (e.g. /home)
 			   _("Mount %1$s at %2$s"),
 			   // TRANSLATORS: displayed during action,
-			   // %1$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB)),
+			   // %1$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB)),
 			   // %2$s is replaced by the mount point (e.g. /home)
 			   _("Mounting %1$s at %2$s"));
 
@@ -380,13 +380,13 @@ namespace storage
     {
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
-			   // %1$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB)),
+			   // %1$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB)),
 			   // %2$s is replaced by the mount point (e.g. /home)
 			   _("Unmount %1$s at %2$s"),
 			   // TRANSLATORS: displayed during action,
-			   // %1$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB)),
+			   // %1$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB)),
 			   // %2$s is replaced by the mount point (e.g. /home)
 			   _("Unmounting %1$s at %2$s"));
 
@@ -407,13 +407,13 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by the mount point (e.g. /home),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Add mount point %1$s of %2$s to /etc/fstab"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by the mount point (e.g. /home),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Adding mount point %1$s of %2$s to /etc/fstab"));
 
 	return sformat(text, mount_point->get_path(), get_message_name());
@@ -445,13 +445,13 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by the mount point (e.g. /home),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Update mount point %1$s of %2$s in /etc/fstab"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by the mount point (e.g. /home),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Updating mount point %1$s of %2$s in /etc/fstab"));
 
 	return sformat(text, mount_point->get_path(), get_message_name());
@@ -486,13 +486,13 @@ namespace storage
 	Text text = tenser(tense,
 			   // TRANSLATORS: displayed before action,
 			   // %1$s is replaced by the mount point (e.g. /home),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Remove mount point %1$s of %2$s from /etc/fstab"),
 			   // TRANSLATORS: displayed during action,
 			   // %1$s is replaced by thr mount point (e.g. /home),
-			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.0 GiB)
-			   // and /dev/sdb2 (1.0 GiB))
+			   // %2$s is replaced by one or more device names (e.g /dev/sda1 (1.00 GiB)
+			   // and /dev/sdb2 (1.00 GiB))
 			   _("Removing mount point %1$s of %2$s from /etc/fstab"));
 
 	return sformat(text, mount_point->get_path(), get_message_name());

--- a/testsuite/CompoundAction/btrfs-subvolume-sentence.cc
+++ b/testsuite/CompoundAction/btrfs-subvolume-sentence.cc
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(test_sentence_on_creating)
 
     BOOST_REQUIRE(compound_action);
 
-    BOOST_CHECK_EQUAL(compound_action->sentence(), "Create subvolume test on /dev/sda2");
+    BOOST_CHECK_EQUAL(compound_action->sentence(), "Create subvolume test on /dev/sda2 (500.00 MiB)");
 }
 
 
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(test_sentence_on_creating_nocow)
 
     BOOST_REQUIRE(compound_action);
 
-    BOOST_CHECK_EQUAL(compound_action->sentence(), "Create subvolume test on /dev/sda2 with option 'no copy on write'");
+    BOOST_CHECK_EQUAL(compound_action->sentence(), "Create subvolume test on /dev/sda2 (500.00 MiB) with option 'no copy on write'");
 }
 
 
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(test_sentence_on_deleting)
 
     BOOST_REQUIRE(compound_action);
 
-    BOOST_CHECK_EQUAL(compound_action->sentence(), "Delete subvolume @/tmp on /dev/sda2");
+    BOOST_CHECK_EQUAL(compound_action->sentence(), "Delete subvolume @/tmp on /dev/sda2 (28.50 GiB)");
 }
 
 

--- a/testsuite/CompoundAction/lvm-vg-sentence.cc
+++ b/testsuite/CompoundAction/lvm-vg-sentence.cc
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(test_sentence_on_creating)
 
     BOOST_REQUIRE(compound_action);
 
-    BOOST_CHECK_EQUAL(compound_action->sentence(), "Create volume group vg-name (496.00 MiB) with /dev/sda2");
+    BOOST_CHECK_EQUAL(compound_action->sentence(), "Create volume group vg-name (496.00 MiB) with /dev/sda2 (500.00 MiB)");
 }
 
 

--- a/testsuite/CompoundAction/md-sentence.cc
+++ b/testsuite/CompoundAction/md-sentence.cc
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE( test_create_format_mount )
 
     string expected =
         "Create RAID6 /dev/md0 (1023.75 GiB) for /data with ext4\n"
-        "from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB), /dev/sdc (512.00 GiB), /dev/sdd (512.00 GiB)";
+        "from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB), /dev/sdc (512.00 GiB) and /dev/sdd (512.00 GiB)";
 
     BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
 
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE( test_create_encrypt_format_mount )
 
     string expected =
         "Create encrypted RAID1 /dev/md0 (511.87 GiB) for /secret with xfs\n"
-        "from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB)";
+        "from /dev/sda (512.00 GiB) and /dev/sdb (512.00 GiB)";
 
     BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
 
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE( test_create_encrypt_format_no_mount )
 
     string expected =
         "Create encrypted RAID1 /dev/md0 (511.87 GiB) with xfs\n"
-        "from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB)";
+        "from /dev/sda (512.00 GiB) and /dev/sdb (512.00 GiB)";
 
     BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
 
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE( test_just_create )
     BOOST_REQUIRE( compound_action ) ;
 
     string expected =
-        "Create RAID1 /dev/md0 (511.87 GiB) from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB)";
+        "Create RAID1 /dev/md0 (511.87 GiB) from /dev/sda (512.00 GiB) and /dev/sdb (512.00 GiB)";
 
     BOOST_CHECK_EQUAL( compound_action->sentence(), expected );
 
@@ -269,7 +269,7 @@ BOOST_AUTO_TEST_CASE( test_create_encrypted_swap )
 
     string expected =
         "Create encrypted RAID1 /dev/md1 (511.87 GiB) for swap\n"
-        "from /dev/sda (512.00 GiB), /dev/sdb (512.00 GiB)"
+        "from /dev/sda (512.00 GiB) and /dev/sdb (512.00 GiB)"
         "\nare you serious?!";
 
     BOOST_CHECK_EQUAL( compound_action->sentence(), expected );


### PR DESCRIPTION
For https://trello.com/c/SNWmNOzY/1489-1-sles15-sp2-p2-1152523-build-451-creation-of-subvolumes-is-displayed-as-assigned-always-to-1st-partition or https://bugzilla.suse.com/show_bug.cgi?id=1152523.

The main problem was that compound action texts for btrfs subvolumes did only contain one block device of the btrfs which, although irrelevant, confused some users. The texts include now all block devices including the sizes.

For some other compound action texts from Btrfs, LVM, MD, Bcache the code was improved to reuse the join function from BlkDeviceImpl.cc.

And finally the explanations for translators now always include the example sizes in the correct format.