### PR TITLE
- improved sort-key for block devices

### DIFF
--- a/storage/Devices/BcacheImpl.cc
+++ b/storage/Devices/BcacheImpl.cc
@@ -113,7 +113,7 @@ namespace storage
     Bcache::Impl::get_name_sort_key() const
     {
 	static const vector<NameSchema> name_schemata = {
-	    NameSchema(regex(DEV_DIR "/bcache([0-9]+)", regex::extended), { { 3, '0' } }),
+	    NameSchema(regex(DEV_DIR "/bcache([0-9]+)", regex::extended), { { PadInfo::N1, 3 } }),
 	};
 
 	return format_to_name_schemata(get_name(), name_schemata);

--- a/storage/Devices/BlkDevice.h
+++ b/storage/Devices/BlkDevice.h
@@ -260,6 +260,8 @@ namespace storage
 
 	/**
 	 * Compare (less than) two BlkDevices by DM table name.
+	 *
+	 * The comparison is locale unaware.
 	 */
 	static bool compare_by_dm_table_name(const BlkDevice* lhs, const BlkDevice* rhs);
 

--- a/storage/Devices/DasdImpl.cc
+++ b/storage/Devices/DasdImpl.cc
@@ -102,8 +102,8 @@ namespace storage
     Dasd::Impl::get_name_sort_key() const
     {
 	static const vector<NameSchema> name_schemata = {
-	    NameSchema(regex(DEV_DIR "/dasd([a-z]+)", regex::extended), { { 4, ' ' } }),
-	    NameSchema(regex(DEV_DIR "/vd([a-z]+)", regex::extended), { { 4, ' ' } })
+	    NameSchema(regex(DEV_DIR "/dasd([a-z]+)", regex::extended), { { PadInfo::A1, 5, } }),
+	    NameSchema(regex(DEV_DIR "/vd([a-z]+)", regex::extended), { { PadInfo::A1, 5 } })
 	};
 
 	return format_to_name_schemata(get_name(), name_schemata);

--- a/storage/Devices/Device.h
+++ b/storage/Devices/Device.h
@@ -192,6 +192,8 @@ namespace storage
 	 * The comparison fulfills strict weak ordering. The exact ordering
 	 * may change in future versions.
 	 *
+	 * The comparison is locale unaware.
+	 *
 	 * @throw Exception
 	 */
 	static bool compare_by_name(const Device* lhs, const Device* rhs);

--- a/storage/Devices/DiskImpl.cc
+++ b/storage/Devices/DiskImpl.cc
@@ -93,14 +93,15 @@ namespace storage
 	// TODO maybe generally pad numbers
 
 	static const vector<NameSchema> name_schemata = {
-	    NameSchema(regex(DEV_DIR "/sd([a-z]+)", regex::extended), { { 4, ' ' } }),
-	    NameSchema(regex(DEV_DIR "/vd([a-z]+)", regex::extended), { { 4, ' ' } }),
-	    NameSchema(regex(DEV_DIR "/mmcblk([0-9]+)", regex::extended), { { 3, '0' } }),
-	    NameSchema(regex(DEV_DIR "/rsxx([0-9]+)", regex::extended), { { 3, '0' } }),
-	    NameSchema(regex(DEV_DIR "/pmem([0-9]+)s?", regex::extended), { { 3, '0' } }),
-	    NameSchema(regex(DEV_DIR "/pmem([0-9]+)\\.([0-9]+)s?", regex::extended), { { 3, '0' }, { 3, '0' } }),
-	    NameSchema(regex(DEV_DIR "/nvme([0-9]+)n([0-9]+)", regex::extended), { { 3, '0' }, { 3, '0' } }),
-	    NameSchema(regex(DEV_DIR "/xvd([a-z]+)", regex::extended), { { 4, ' ' } }),
+	    NameSchema(regex(DEV_DIR "/sd([a-z]+)", regex::extended), { { PadInfo::A1, 5 } }),
+	    NameSchema(regex(DEV_DIR "/vd([a-z]+)", regex::extended), { { PadInfo::A1, 5 } }),
+	    NameSchema(regex(DEV_DIR "/mmcblk([0-9]+)", regex::extended), { { PadInfo::N1, 3 } }),
+	    NameSchema(regex(DEV_DIR "/rsxx([0-9]+)", regex::extended), { { PadInfo::N1, 3 } }),
+	    NameSchema(regex(DEV_DIR "/pmem([0-9]+)s?", regex::extended), { { PadInfo::N1, 3 } }),
+	    NameSchema(regex(DEV_DIR "/pmem([0-9]+)\\.([0-9]+)s?", regex::extended), { { PadInfo::N1, 3 }, { PadInfo::N1, 3 } }),
+	    NameSchema(regex(DEV_DIR "/nvme([0-9]+)n([0-9]+)", regex::extended), { { PadInfo::N1, 3 }, { PadInfo::N1, 3 } }),
+	    NameSchema(regex(DEV_DIR "/xvd([a-z]+)", regex::extended), { { PadInfo::A1, 5 } }),
+	    NameSchema(regex(DEV_DIR "/ram([0-9]+)", regex::extended), { { PadInfo::N1, 3 } })
 	};
 
 	return format_to_name_schemata(get_name(), name_schemata);

--- a/storage/Devices/LvmLv.h
+++ b/storage/Devices/LvmLv.h
@@ -150,6 +150,8 @@ namespace storage
 
 	/**
 	 * Compare (less than) two LvmLvs by lv-name.
+	 *
+	 * The comparison is locale unaware.
 	 */
 	static bool compare_by_lv_name(const LvmLv* lhs, const LvmLv* rhs);
 

--- a/storage/Devices/LvmVg.h
+++ b/storage/Devices/LvmVg.h
@@ -193,6 +193,8 @@ namespace storage
 
 	/**
 	 * Compare (less than) two LvmVgs by vg-name.
+	 *
+	 * The comparison is locale unaware.
 	 */
 	static bool compare_by_vg_name(const LvmVg* lhs, const LvmVg* rhs);
 

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -142,7 +142,7 @@ namespace storage
     Md::Impl::get_name_sort_key() const
     {
 	static const vector<NameSchema> name_schemata = {
-	    NameSchema(regex(DEV_DIR "/md([0-9]+)", regex::extended), { { 4, '0' } })
+	    NameSchema(regex(DEV_DIR "/md([0-9]+)", regex::extended), { { PadInfo::N1, 4 } })
 	};
 
 	return format_to_name_schemata(get_name(), name_schemata);

--- a/storage/Devices/PartitionImpl.cc
+++ b/storage/Devices/PartitionImpl.cc
@@ -94,7 +94,12 @@ namespace storage
     {
 	const Partitionable* partitionable = get_partitionable();
 
-	return partitionable->get_impl().get_name_sort_key() + pad_front(to_string(get_number()), 3, '0');
+	string sort_key = partitionable->get_impl().get_name_sort_key();
+	if (isdigit(sort_key.back()))
+	    sort_key += 'p';
+	sort_key += pad_front(to_string(get_number()), 3, '0');
+
+	return sort_key;
     }
 
 

--- a/storage/Devices/StrayBlkDeviceImpl.cc
+++ b/storage/Devices/StrayBlkDeviceImpl.cc
@@ -60,7 +60,7 @@ namespace storage
     StrayBlkDevice::Impl::get_name_sort_key() const
     {
 	static const vector<NameSchema> name_schemata = {
-	    NameSchema(regex(DEV_DIR "/xvd([a-z]+)([0-9]+)", regex::extended), { { 4, ' ' }, { 3, '0' } })
+	    NameSchema(regex(DEV_DIR "/xvd([a-z]+)([0-9]+)", regex::extended), { { PadInfo::A1, 5 }, { PadInfo::N1, 3 } })
 	};
 
 	return format_to_name_schemata(get_name(), name_schemata);

--- a/storage/Utils/AppUtil.cc
+++ b/storage/Utils/AppUtil.cc
@@ -511,6 +511,21 @@ namespace storage
     }
 
 
+    /**
+     * Enumerates string containing 'a' to 'z'. "a" is 1, "z" is 26, "aa" is 27 and so on.
+     */
+    unsigned int
+    enumerate_strings(const string& s)
+    {
+	unsigned int i = 0;
+
+	for (char c : s)
+	    i = (26 * i) + (c - 'a' + 1);
+
+	return i;
+    }
+
+
     string
     format_to_name_schemata(const string& s, const vector<NameSchema>& name_schemata)
     {
@@ -524,10 +539,22 @@ namespace storage
 
 		for (size_t i = match.size() - 1; i > 0; --i)
 		{
-		    const pair<size_t, char>& pad_info = name_schema.pad_infos[i - 1];
+		    const PadInfo& pad_info = name_schema.pad_infos[i - 1];
 
-		    ret.replace(match.position(i), match.length(i),
-				pad_front(match.str(i), pad_info.first, pad_info.second));
+		    string replacement;
+
+		    switch (pad_info.method)
+		    {
+			case PadInfo::N1:
+			    replacement = pad_front(match.str(i), pad_info.size, '0');
+			    break;
+
+			case PadInfo::A1:
+			    replacement = pad_front(to_string(enumerate_strings(match.str(i))), pad_info.size, '0');
+			    break;
+		    }
+
+		    ret.replace(match.position(i), match.length(i), replacement);
 		}
 
 		return ret;

--- a/storage/Utils/AppUtil.h
+++ b/storage/Utils/AppUtil.h
@@ -136,11 +136,41 @@ namespace storage
 
 
     /**
+     * Padding informations for NameSchema.
+     */
+    struct PadInfo
+    {
+	enum Method
+	{
+	    /**
+	     * Numeric pad. The number is padded with zeros.
+	     */
+	    N1,
+
+	    /**
+	     * Alphabetical pad. The string (must only contain 'a' to
+	     * 'z') is transformed to a number and that number is
+	     * padded with zeros.
+	     *
+	     * This method should be locale invariant. E.g. simply
+	     * padding the string with spaces is not locale invariant.
+	     */
+	    A1
+	};
+
+	PadInfo(Method method, size_t size) : method(method), size(size) {}
+
+	const Method method;
+	const size_t size;
+    };
+
+
+    /**
      * Definition of a name schema used by format_to_name_schemata().
      */
     struct NameSchema
     {
-	NameSchema(regex re, const vector<pair<size_t, char>>& pad_infos)
+	NameSchema(regex re, const vector<PadInfo>& pad_infos)
 	    : re(re), pad_infos(pad_infos) {}
 
 	/**
@@ -152,7 +182,7 @@ namespace storage
 	 * Width and char to which the sub-matches of the regular
 	 * expression will be padded.
 	 */
-	const vector<pair<size_t, char>> pad_infos;
+	const vector<PadInfo> pad_infos;
     };
 
 

--- a/testsuite/sorting/format.cc
+++ b/testsuite/sorting/format.cc
@@ -14,13 +14,14 @@ using namespace storage;
 BOOST_AUTO_TEST_CASE(format)
 {
     static const vector<NameSchema> name_schemata = {
-	NameSchema(regex("/dev/sd([a-z]+)", regex::extended), { { 4, ' ' } }),
-	NameSchema(regex("/dev/md([0-9]+)", regex::extended), { { 3, '0' } }),
-	NameSchema(regex("/dev/nvme([0-9]+)n([0-9]+)", regex::extended), { { 3, '0' }, { 3, '0' } }),
-	NameSchema(regex("/dev/xvd([a-z]+)([0-9]+)", regex::extended), { { 4, ' ' }, { 3, '0' } }),
+	NameSchema(regex("/dev/sd([a-z]+)", regex::extended), { { PadInfo::A1, 5 } }),
+	NameSchema(regex("/dev/md([0-9]+)", regex::extended), { { PadInfo::N1, 3 } }),
+	NameSchema(regex("/dev/nvme([0-9]+)n([0-9]+)", regex::extended), { { PadInfo::N1, 3 }, { PadInfo::N1, 3 } }),
     };
 
-    BOOST_CHECK_EQUAL(format_to_name_schemata("/dev/sda", name_schemata), "/dev/sd   a");
+    BOOST_CHECK_EQUAL(format_to_name_schemata("/dev/sda", name_schemata), "/dev/sd00001");
+    BOOST_CHECK_EQUAL(format_to_name_schemata("/dev/sdaa", name_schemata), "/dev/sd00027");
+    BOOST_CHECK_EQUAL(format_to_name_schemata("/dev/sdaaa", name_schemata), "/dev/sd00703");
 
     BOOST_CHECK_EQUAL(format_to_name_schemata("/dev/md", name_schemata), "/dev/md");
 
@@ -30,6 +31,4 @@ BOOST_AUTO_TEST_CASE(format)
     BOOST_CHECK_EQUAL(format_to_name_schemata("/dev/md1234", name_schemata), "/dev/md1234");
 
     BOOST_CHECK_EQUAL(format_to_name_schemata("/dev/nvme1n2", name_schemata), "/dev/nvme001n002");
-
-    BOOST_CHECK_EQUAL(format_to_name_schemata("/dev/xvda1", name_schemata), "/dev/xvd   a001");
 }


### PR DESCRIPTION
This PR improves the sort-key for block devices by making it locale unaware where desired, e.g. for disks but not for LVM logical volumes. This is done by modifying the NameSchema class and adding a new pad method, from the source code:

Alphabetical pad. The string (must only contain 'a' to 'z') is transformed to a number and that number is padded with zeros.

This method should be locale invariant. E.g. simply padding the string with spaces is not locale invariant.