### PR TITLE
- use udevadm from /usr/bin instead of /sbin

### DIFF
--- a/storage/Filesystems/XfsImpl.cc
+++ b/storage/Filesystems/XfsImpl.cc
@@ -88,7 +88,7 @@ namespace storage
     {
 	const BlkDevice* blk_device = get_blk_device();
 
-	string cmd_line = MKFSXFSBIN " -q -f -m crc=1 " + get_mkfs_options() + " " +
+	string cmd_line = MKFS_XFS_BIN " -q -f " + get_mkfs_options() + " " +
 	    quote(blk_device->get_name());
 
 	wait_for_devices();

--- a/storage/Utils/StorageDefines.h
+++ b/storage/Utils/StorageDefines.h
@@ -98,7 +98,7 @@
 #define DASDFMTBIN "/sbin/dasdfmt"
 #define DASDVIEWBIN "/sbin/dasdview"
 
-#define UDEVADM_BIN "/sbin/udevadm"
+#define UDEVADM_BIN "/usr/bin/udevadm"
 #define UDEVADM_BIN_SETTLE UDEVADM_BIN " settle --timeout=20"
 
 #define RPCBINDBIN     "/sbin/rpcbind"

--- a/storage/Utils/StorageDefines.h
+++ b/storage/Utils/StorageDefines.h
@@ -123,7 +123,7 @@
 #define DUMPE2FS_BIN "/sbin/dumpe2fs"
 
 #define MKSWAPBIN      "/sbin/mkswap"
-#define MKFSXFSBIN     "/sbin/mkfs.xfs"
+#define MKFS_XFS_BIN "/sbin/mkfs.xfs"
 #define MKFSJFSBIN "/sbin/mkfs.jfs"
 #define MKFSFATBIN	"/sbin/mkfs.fat"
 #define MKFSNTFSBIN	"/sbin/mkfs.ntfs"

--- a/testsuite/dependencies/btrfs/create2-mockup.xml
+++ b/testsuite/dependencies/btrfs/create2-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/mkfs.btrfs --force --metadata=RAID1 --data=RAID0 --nodiscard '/dev/sda' '/dev/sdb' '/dev/sdc' '/dev/sdd'</name>

--- a/testsuite/dependencies/lvm/complex1-mockup.xml
+++ b/testsuite/dependencies/lvm/complex1-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/lvresize --force 'testvg/secondlv' --extents 640</name>

--- a/testsuite/dependencies/md/create1-mockup.xml
+++ b/testsuite/dependencies/md/create1-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/mdadm --create '/dev/md0' --run --level=raid10 --metadata=1.0 --homehost=any --bitmap=internal --chunk=512 --raid-devices=4 '/dev/sda' '/dev/sdc' '/dev/sdb' '/dev/sdd'</name>

--- a/testsuite/dependencies/md/extend1-mockup.xml
+++ b/testsuite/dependencies/md/extend1-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/mdadm --add-spare '/dev/md0' '/dev/sdd'</name>

--- a/testsuite/dependencies/partition-tables/repair1-mockup.xml
+++ b/testsuite/dependencies/partition-tables/repair1-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/echo -e -n 'Fix\n' | /usr/sbin/parted ---pretend-input-tty '/dev/sdb' print</name>

--- a/testsuite/dependencies/partitions/dasd1-mockup.xml
+++ b/testsuite/dependencies/partitions/dasd1-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/sbin/parted --script '/dev/dasda' unit s print</name>

--- a/testsuite/dependencies/resize/btrfs/grow-multi1-mockup.xml
+++ b/testsuite/dependencies/resize/btrfs/grow-multi1-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/sbin/parted --script --ignore-busy '/dev/sdc' unit s resizepart 1 23070719</name>

--- a/testsuite/dependencies/resize/btrfs/grow1-mockup.xml
+++ b/testsuite/dependencies/resize/btrfs/grow1-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/sbin/parted --script --ignore-busy '/dev/sdc' unit s resizepart 1 23070719</name>

--- a/testsuite/dependencies/resize/btrfs/shrink-multi1-mockup.xml
+++ b/testsuite/dependencies/resize/btrfs/shrink-multi1-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/btrfs filesystem resize 1:9663676416 '/test'</name>

--- a/testsuite/dependencies/resize/btrfs/shrink1-mockup.xml
+++ b/testsuite/dependencies/resize/btrfs/shrink1-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/btrfs filesystem resize 1:9663676416 '/test'</name>

--- a/testsuite/dependencies/resize/ext4/grow1-mockup.xml
+++ b/testsuite/dependencies/resize/ext4/grow1-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/sbin/parted --script --ignore-busy '/dev/sdc' unit s resizepart 1 23070719</name>

--- a/testsuite/dependencies/resize/ext4/grow2-mockup.xml
+++ b/testsuite/dependencies/resize/ext4/grow2-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/sbin/parted --script '/dev/sdc' rm 5</name>

--- a/testsuite/dependencies/resize/ext4/shrink1-mockup.xml
+++ b/testsuite/dependencies/resize/ext4/shrink1-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/sbin/parted --script --ignore-busy '/dev/sdc' unit s resizepart 1 18876415</name>

--- a/testsuite/dependencies/resize/ext4/shrink2-mockup.xml
+++ b/testsuite/dependencies/resize/ext4/shrink2-mockup.xml
@@ -2,7 +2,7 @@
 <Mockup>
   <Commands>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/sbin/resize2fs -f '/dev/sdc6' 9437184K</name>

--- a/testsuite/probe/ambiguous1-mockup.xml
+++ b/testsuite/probe/ambiguous1-mockup.xml
@@ -40,7 +40,7 @@
       <name>/sbin/multipath -d -v 2 -ll</name>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB4fc3dfc5-aa799b6b</stdout>
@@ -102,7 +102,7 @@
       <stdout>E: USEC_INITIALIZED=2865031</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata4/host3/target3:0:0/3:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -167,7 +167,7 @@
       <stdout>E: USEC_INITIALIZED=2854940</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/bcache1-mockup.xml
+++ b/testsuite/probe/bcache1-mockup.xml
@@ -120,8 +120,8 @@
       <stderr>  WARNING: Failed to connect to lvmetad. Falling back to device scanning.</stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/bcache0'</name>
-      <name>/sbin/udevadm info '/dev/block/253:0'</name>
+      <name>/usr/bin/udevadm info '/dev/bcache0'</name>
+      <name>/usr/bin/udevadm info '/dev/block/253:0'</name>
       <stdout>P: /devices/virtual/block/bcache0</stdout>
       <stdout>N: bcache0</stdout>
       <stdout>E: DEVNAME=/dev/bcache0</stdout>
@@ -137,7 +137,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/bcache0p1'</name>
+      <name>/usr/bin/udevadm info '/dev/bcache0p1'</name>
       <stdout>P: /devices/virtual/block/bcache0/bcache0p1</stdout>
       <stdout>N: bcache0p1</stdout>
       <stdout>S: disk/by-partlabel/ext4</stdout>
@@ -172,8 +172,8 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/bcache1'</name>
-      <name>/sbin/udevadm info '/dev/block/253:128'</name>
+      <name>/usr/bin/udevadm info '/dev/bcache1'</name>
+      <name>/usr/bin/udevadm info '/dev/block/253:128'</name>
       <stdout>P: /devices/virtual/block/bcache1</stdout>
       <stdout>N: bcache1</stdout>
       <stdout>E: DEVNAME=/dev/bcache1</stdout>
@@ -187,8 +187,8 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/bcache2'</name>
-      <name>/sbin/udevadm info '/dev/block/253:256'</name>
+      <name>/usr/bin/udevadm info '/dev/bcache2'</name>
+      <name>/usr/bin/udevadm info '/dev/block/253:256'</name>
       <stdout>P: /devices/virtual/block/bcache2</stdout>
       <stdout>N: bcache2</stdout>
       <stdout>E: DEVNAME=/dev/bcache2</stdout>
@@ -202,7 +202,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/bcache2p1'</name>
+      <name>/usr/bin/udevadm info '/dev/bcache2p1'</name>
       <stdout>P: /devices/virtual/block/bcache2/bcache2p1</stdout>
       <stdout>N: bcache2p1</stdout>
       <stdout>S: disk/by-partuuid/b45acfb7-8e6e-44c6-b0d2-7ffebe7bb8d0</stdout>
@@ -226,7 +226,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/block/252:0'</name>
+      <name>/usr/bin/udevadm info '/dev/block/252:0'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>S: disk/by-id/dm-name-my_vg-bcache2</stdout>
@@ -258,7 +258,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/block/254:32'</name>
+      <name>/usr/bin/udevadm info '/dev/block/254:32'</name>
       <stdout>P: /devices/pci0000:00/0000:00:0b.0/virtio6/block/vdc</stdout>
       <stdout>N: vdc</stdout>
       <stdout>S: disk/by-path/pci-0000:00:0b.0</stdout>
@@ -282,7 +282,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/block/254:51'</name>
+      <name>/usr/bin/udevadm info '/dev/block/254:51'</name>
       <stdout>P: /devices/pci0000:00/0000:00:0c.0/virtio7/block/vdd/vdd3</stdout>
       <stdout>N: vdd3</stdout>
       <stdout>S: disk/by-partuuid/03b85105-5241-47f1-9369-80603c76da62</stdout>
@@ -317,7 +317,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/my_vg-bcache2'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/my_vg-bcache2'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>S: disk/by-id/dm-name-my_vg-bcache2</stdout>
@@ -349,7 +349,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/my_vg/bcache2'</name>
+      <name>/usr/bin/udevadm info '/dev/my_vg/bcache2'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>S: disk/by-id/dm-name-my_vg-bcache2</stdout>
@@ -381,7 +381,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:01.1/ata1/host0/target0:0:0/0:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -417,7 +417,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/vda'</name>
+      <name>/usr/bin/udevadm info '/dev/vda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:07.0/virtio2/block/vda</stdout>
       <stdout>N: vda</stdout>
       <stdout>S: disk/by-path/pci-0000:00:07.0</stdout>
@@ -438,7 +438,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/vda1'</name>
+      <name>/usr/bin/udevadm info '/dev/vda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:07.0/virtio2/block/vda/vda1</stdout>
       <stdout>N: vda1</stdout>
       <stdout>S: disk/by-partuuid/859d0fce-3cd9-4069-a6b6-d78431a99e60</stdout>
@@ -468,7 +468,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/vda2'</name>
+      <name>/usr/bin/udevadm info '/dev/vda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:07.0/virtio2/block/vda/vda2</stdout>
       <stdout>N: vda2</stdout>
       <stdout>S: disk/by-partuuid/0a89f532-fb02-420b-b9a7-ff5469a3888b</stdout>
@@ -504,8 +504,8 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/vdb'</name>
-      <name>/sbin/udevadm info '/dev/block/254:16'</name>
+      <name>/usr/bin/udevadm info '/dev/vdb'</name>
+      <name>/usr/bin/udevadm info '/dev/block/254:16'</name>
       <stdout>P: /devices/pci0000:00/0000:00:08.0/virtio3/block/vdb</stdout>
       <stdout>N: vdb</stdout>
       <stdout>S: disk/by-path/pci-0000:00:08.0</stdout>
@@ -529,7 +529,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/vdc'</name>
+      <name>/usr/bin/udevadm info '/dev/vdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:0b.0/virtio6/block/vdc</stdout>
       <stdout>N: vdc</stdout>
       <stdout>S: disk/by-path/pci-0000:00:0b.0</stdout>
@@ -553,7 +553,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/vdd'</name>
+      <name>/usr/bin/udevadm info '/dev/vdd'</name>
       <stdout>P: /devices/pci0000:00/0000:00:0c.0/virtio7/block/vdd</stdout>
       <stdout>N: vdd</stdout>
       <stdout>S: disk/by-path/pci-0000:00:0c.0</stdout>
@@ -574,7 +574,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/vdd1'</name>
+      <name>/usr/bin/udevadm info '/dev/vdd1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:0c.0/virtio7/block/vdd/vdd1</stdout>
       <stdout>N: vdd1</stdout>
       <stdout>S: disk/by-id/lvm-pv-uuid-gRdH2t-ZrTe-myQe-clC8-7Klc-rXZD-iFPA44</stdout>
@@ -614,7 +614,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/vdd2'</name>
+      <name>/usr/bin/udevadm info '/dev/vdd2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:0c.0/virtio7/block/vdd/vdd2</stdout>
       <stdout>N: vdd2</stdout>
       <stdout>S: disk/by-partuuid/c4168674-d2f0-4a45-b47c-ccbdf74a182b</stdout>
@@ -650,7 +650,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/vdd3'</name>
+      <name>/usr/bin/udevadm info '/dev/vdd3'</name>
       <stdout>P: /devices/pci0000:00/0000:00:0c.0/virtio7/block/vdd/vdd3</stdout>
       <stdout>N: vdd3</stdout>
       <stdout>S: disk/by-partuuid/03b85105-5241-47f1-9369-80603c76da62</stdout>
@@ -685,7 +685,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/vgs --reportformat json --units b --nosuffix --options vg_name,vg_uuid,vg_attr,vg_extent_size,vg_extent_count,vg_free_count</name>

--- a/testsuite/probe/bcache2-mockup.xml
+++ b/testsuite/probe/bcache2-mockup.xml
@@ -78,8 +78,8 @@
       <exit-code>127</exit-code>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/bcache0'</name>
-      <name>/sbin/udevadm info '/dev/block/254:0'</name>
+      <name>/usr/bin/udevadm info '/dev/bcache0'</name>
+      <name>/usr/bin/udevadm info '/dev/block/254:0'</name>
       <stdout>P: /devices/virtual/block/bcache0</stdout>
       <stdout>N: bcache0</stdout>
       <stdout>S: disk/by-uuid/63edf5de-e0ed-4b2c-850b-7a8f2ebd6391</stdout>
@@ -100,8 +100,8 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/bcache1'</name>
-      <name>/sbin/udevadm info '/dev/block/254:128'</name>
+      <name>/usr/bin/udevadm info '/dev/bcache1'</name>
+      <name>/usr/bin/udevadm info '/dev/block/254:128'</name>
       <stdout>P: /devices/virtual/block/bcache1</stdout>
       <stdout>N: bcache1</stdout>
       <stdout>E: DEVNAME=/dev/bcache1</stdout>
@@ -117,7 +117,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/bcache1p1'</name>
+      <name>/usr/bin/udevadm info '/dev/bcache1p1'</name>
       <stdout>P: /devices/virtual/block/bcache1/bcache1p1</stdout>
       <stdout>N: bcache1p1</stdout>
       <stdout>S: disk/by-partuuid/495b0fc3-2188-3b40-b056-170d32ebd7f4</stdout>
@@ -150,7 +150,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/bcache1p2'</name>
+      <name>/usr/bin/udevadm info '/dev/bcache1p2'</name>
       <stdout>P: /devices/virtual/block/bcache1/bcache1p2</stdout>
       <stdout>N: bcache1p2</stdout>
       <stdout>S: disk/by-partuuid/b6e26781-5021-cb4d-bdd0-de47119068d4</stdout>
@@ -183,8 +183,8 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/bcache2'</name>
-      <name>/sbin/udevadm info '/dev/block/254:256'</name>
+      <name>/usr/bin/udevadm info '/dev/bcache2'</name>
+      <name>/usr/bin/udevadm info '/dev/block/254:256'</name>
       <stdout>P: /devices/virtual/block/bcache2</stdout>
       <stdout>N: bcache2</stdout>
       <stdout>S: disk/by-uuid/f995a0d1-ff12-4b0e-9190-0c1d39a6968c</stdout>
@@ -205,7 +205,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/block/8:17'</name>
+      <name>/usr/bin/udevadm info '/dev/block/8:17'</name>
       <stdout>P: /devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:1.0/host3/target3:0:0/3:0:0:0/block/sdb/sdb1</stdout>
       <stdout>N: sdb1</stdout>
       <stdout>S: disk/by-id/usb-Generic_Flash_Disk_11A43B87-0:0-part1</stdout>
@@ -267,7 +267,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/block/8:18'</name>
+      <name>/usr/bin/udevadm info '/dev/block/8:18'</name>
       <stdout>P: /devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:1.0/host3/target3:0:0/3:0:0:0/block/sdb/sdb2</stdout>
       <stdout>N: sdb2</stdout>
       <stdout>S: disk/by-id/usb-Generic_Flash_Disk_11A43B87-0:0-part2</stdout>
@@ -329,7 +329,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBe18006b0-58cecc64</stdout>
@@ -378,7 +378,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBe18006b0-58cecc64-part1</stdout>
@@ -442,7 +442,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBe18006b0-58cecc64-part2</stdout>
@@ -501,7 +501,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda3'</name>
+      <name>/usr/bin/udevadm info '/dev/sda3'</name>
       <stdout>P: /devices/pci0000:00/0000:00:0d.0/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda3</stdout>
       <stdout>N: sda3</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBe18006b0-58cecc64-part3</stdout>
@@ -565,7 +565,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:1.0/host3/target3:0:0/3:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/usb-Generic_Flash_Disk_11A43B87-0:0</stdout>
@@ -612,7 +612,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:1.0/host3/target3:0:0/3:0:0:0/block/sdb/sdb1</stdout>
       <stdout>N: sdb1</stdout>
       <stdout>S: disk/by-id/usb-Generic_Flash_Disk_11A43B87-0:0-part1</stdout>
@@ -674,7 +674,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:1.0/host3/target3:0:0/3:0:0:0/block/sdb/sdb2</stdout>
       <stdout>N: sdb2</stdout>
       <stdout>S: disk/by-id/usb-Generic_Flash_Disk_11A43B87-0:0-part2</stdout>
@@ -736,7 +736,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb3'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb3'</name>
       <stdout>P: /devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:1.0/host3/target3:0:0/3:0:0:0/block/sdb/sdb3</stdout>
       <stdout>N: sdb3</stdout>
       <stdout>S: disk/by-id/usb-Generic_Flash_Disk_11A43B87-0:0-part3</stdout>
@@ -793,7 +793,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb4'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb4'</name>
       <stdout>P: /devices/pci0000:00/0000:00:06.0/usb1/1-2/1-2:1.0/host3/target3:0:0/3:0:0:0/block/sdb/sdb4</stdout>
       <stdout>N: sdb4</stdout>
       <stdout>S: disk/by-id/usb-Generic_Flash_Disk_11A43B87-0:0-part4</stdout>
@@ -850,7 +850,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:01.1/ata3/host2/target2:0:0/2:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -897,7 +897,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/df --block-size=1 --output=size,used,avail,fstype '/home/ivan/projects'</name>

--- a/testsuite/probe/bitlocker1-mockup.xml
+++ b/testsuite/probe/bitlocker1-mockup.xml
@@ -97,7 +97,7 @@
       <name>/sbin/multipath -d -v 2 -ll</name>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/disk/by-id/ata-VBOX_CD-ROM_VB1-1a2b3c4d'</name>
+      <name>/usr/bin/udevadm info '/dev/disk/by-id/ata-VBOX_CD-ROM_VB1-1a2b3c4d'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -165,7 +165,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop0'</name>
+      <name>/usr/bin/udevadm info '/dev/loop0'</name>
       <stdout>P: /devices/virtual/block/loop0</stdout>
       <stdout>N: loop0</stdout>
       <stdout>L: 0</stdout>
@@ -183,7 +183,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop1'</name>
+      <name>/usr/bin/udevadm info '/dev/loop1'</name>
       <stdout>P: /devices/virtual/block/loop1</stdout>
       <stdout>N: loop1</stdout>
       <stdout>L: 0</stdout>
@@ -201,7 +201,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop2'</name>
+      <name>/usr/bin/udevadm info '/dev/loop2'</name>
       <stdout>P: /devices/virtual/block/loop2</stdout>
       <stdout>N: loop2</stdout>
       <stdout>L: 0</stdout>
@@ -219,7 +219,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop3'</name>
+      <name>/usr/bin/udevadm info '/dev/loop3'</name>
       <stdout>P: /devices/virtual/block/loop3</stdout>
       <stdout>N: loop3</stdout>
       <stdout>L: 0</stdout>
@@ -237,7 +237,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop4'</name>
+      <name>/usr/bin/udevadm info '/dev/loop4'</name>
       <stdout>P: /devices/virtual/block/loop4</stdout>
       <stdout>N: loop4</stdout>
       <stdout>L: 0</stdout>
@@ -255,7 +255,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop5'</name>
+      <name>/usr/bin/udevadm info '/dev/loop5'</name>
       <stdout>P: /devices/virtual/block/loop5</stdout>
       <stdout>N: loop5</stdout>
       <stdout>L: 0</stdout>
@@ -273,7 +273,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop6'</name>
+      <name>/usr/bin/udevadm info '/dev/loop6'</name>
       <stdout>P: /devices/virtual/block/loop6</stdout>
       <stdout>N: loop6</stdout>
       <stdout>L: 0</stdout>
@@ -291,7 +291,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>L: 0</stdout>
@@ -349,7 +349,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>L: 0</stdout>
@@ -425,7 +425,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>L: 0</stdout>
@@ -495,7 +495,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -563,7 +563,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/btrfs1-mockup.xml
+++ b/testsuite/probe/btrfs1-mockup.xml
@@ -67,7 +67,7 @@
       <stdout>ID 294 gen 191 parent 258 top level 258 path &lt;FS_TREE&gt;/@/.snapshots/8/snapshot</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB09d89637-d9690549</stdout>
@@ -118,7 +118,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB09d89637-d9690549-part1</stdout>
@@ -184,7 +184,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB09d89637-d9690549-part2</stdout>
@@ -253,7 +253,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata4/host3/target3:0:0/3:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -322,7 +322,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/lsattr -d (device:/dev/sda2 path:@)</name>

--- a/testsuite/probe/btrfs2-mockup.xml
+++ b/testsuite/probe/btrfs2-mockup.xml
@@ -70,7 +70,7 @@
       <exit-code>127</exit-code>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB4fc3dfc5-aa799b6b</stdout>
@@ -123,7 +123,7 @@
       <stdout>E: USEC_INITIALIZED=6341600</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB4fc3dfc5-aa799b6b-part1</stdout>
@@ -185,7 +185,7 @@
       <stdout>E: USEC_INITIALIZED=7700475</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB4fc3dfc5-aa799b6b-part2</stdout>
@@ -254,7 +254,7 @@
       <stdout>E: USEC_INITIALIZED=7584297</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda3'</name>
+      <name>/usr/bin/udevadm info '/dev/sda3'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda3</stdout>
       <stdout>N: sda3</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB4fc3dfc5-aa799b6b-part3</stdout>
@@ -322,7 +322,7 @@
       <stdout>E: USEC_INITIALIZED=7720243</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB4649dc61-b06d8b58</stdout>
@@ -375,7 +375,7 @@
       <stdout>E: USEC_INITIALIZED=6547871</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb1</stdout>
       <stdout>N: sdb1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB4649dc61-b06d8b58-part1</stdout>
@@ -445,7 +445,7 @@
       <stdout>E: USEC_INITIALIZED=8168703</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB01e5cf40-184ff1c7</stdout>
@@ -498,7 +498,7 @@
       <stdout>E: USEC_INITIALIZED=6490326</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc/sdc1</stdout>
       <stdout>N: sdc1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB01e5cf40-184ff1c7-part1</stdout>
@@ -568,7 +568,7 @@
       <stdout>E: USEC_INITIALIZED=6634238</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdd'</name>
+      <name>/usr/bin/udevadm info '/dev/sdd'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata4/host3/target3:0:0/3:0:0:0/block/sdd</stdout>
       <stdout>N: sdd</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB8eb60729-ee6542cf</stdout>
@@ -622,7 +622,7 @@
       <stdout>E: USEC_INITIALIZED=6484905</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdd1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdd1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata4/host3/target3:0:0/3:0:0:0/block/sdd/sdd1</stdout>
       <stdout>N: sdd1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB8eb60729-ee6542cf-part1</stdout>
@@ -693,7 +693,7 @@
       <stdout>E: USEC_INITIALIZED=8173278</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sde'</name>
+      <name>/usr/bin/udevadm info '/dev/sde'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata5/host4/target4:0:0/4:0:0:0/block/sde</stdout>
       <stdout>N: sde</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB1dbb6c8d-bfa29af4</stdout>
@@ -747,7 +747,7 @@
       <stdout>E: USEC_INITIALIZED=6471316</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sde1'</name>
+      <name>/usr/bin/udevadm info '/dev/sde1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata5/host4/target4:0:0/4:0:0:0/block/sde/sde1</stdout>
       <stdout>N: sde1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB1dbb6c8d-bfa29af4-part1</stdout>
@@ -818,7 +818,7 @@
       <stdout>E: USEC_INITIALIZED=6637697</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata7/host6/target6:0:0/6:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -884,7 +884,7 @@
       <stdout>E: USEC_INITIALIZED=6365146</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/btrfs3-mockup.xml
+++ b/testsuite/probe/btrfs3-mockup.xml
@@ -43,7 +43,7 @@
       <name>/sbin/multipath -d -v 2 -ll</name>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>L: 0</stdout>
@@ -94,7 +94,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc/sdc1</stdout>
       <stdout>N: sdc1</stdout>
       <stdout>L: 0</stdout>
@@ -153,7 +153,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/dasd1-mockup.xml
+++ b/testsuite/probe/dasd1-mockup.xml
@@ -68,7 +68,7 @@
       <stdout>                         000cc040 4fd356c0  02030000 0000a000</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasda'</name>
+      <name>/usr/bin/udevadm info '/dev/dasda'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasda</stdout>
       <stdout>N: dasda</stdout>
       <stdout>S: disk/by-id/ccw-0X0150</stdout>
@@ -95,8 +95,8 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasda1'</name>
-      <name>/sbin/udevadm info '/dev/disk/by-path/ccw-0.0.0150-part1'</name>
+      <name>/usr/bin/udevadm info '/dev/dasda1'</name>
+      <name>/usr/bin/udevadm info '/dev/disk/by-path/ccw-0.0.0150-part1'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasda/dasda1</stdout>
       <stdout>N: dasda1</stdout>
       <stdout>S: disk/by-id/ccw-0X0150-part1</stdout>
@@ -130,8 +130,8 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasda2'</name>
-      <name>/sbin/udevadm info '/dev/disk/by-path/ccw-0.0.0150-part2'</name>
+      <name>/usr/bin/udevadm info '/dev/dasda2'</name>
+      <name>/usr/bin/udevadm info '/dev/disk/by-path/ccw-0.0.0150-part2'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasda/dasda2</stdout>
       <stdout>N: dasda2</stdout>
       <stdout>S: disk/by-id/ccw-0X0150-part2</stdout>
@@ -165,8 +165,8 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasda3'</name>
-      <name>/sbin/udevadm info '/dev/disk/by-path/ccw-0.0.0150-part3'</name>
+      <name>/usr/bin/udevadm info '/dev/dasda3'</name>
+      <name>/usr/bin/udevadm info '/dev/disk/by-path/ccw-0.0.0150-part3'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasda/dasda3</stdout>
       <stdout>N: dasda3</stdout>
       <stdout>S: disk/by-id/ccw-0X0150-part3</stdout>
@@ -201,7 +201,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/df --block-size=1 --output=size,used,avail,fstype '/suse/aschnell'</name>

--- a/testsuite/probe/dasd2-mockup.xml
+++ b/testsuite/probe/dasd2-mockup.xml
@@ -177,7 +177,7 @@
       <exit-code>127</exit-code>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasda'</name>
+      <name>/usr/bin/udevadm info '/dev/dasda'</name>
       <stdout>P: /devices/css0/0.0.0016/0.0.3333/block/dasda</stdout>
       <stdout>N: dasda</stdout>
       <stdout>S: disk/by-path/ccw-0.0.3333</stdout>
@@ -196,7 +196,7 @@
       <stdout>E: USEC_INITIALIZED=6835278</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasda1'</name>
+      <name>/usr/bin/udevadm info '/dev/dasda1'</name>
       <stdout>P: /devices/css0/0.0.0016/0.0.3333/block/dasda/dasda1</stdout>
       <stdout>N: dasda1</stdout>
       <stdout>S: disk/by-path/ccw-0.0.3333-part1</stdout>
@@ -216,7 +216,7 @@
       <stdout>E: USEC_INITIALIZED=14104054324</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasdb'</name>
+      <name>/usr/bin/udevadm info '/dev/dasdb'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasdb</stdout>
       <stdout>N: dasdb</stdout>
       <stdout>S: disk/by-id/ccw-0X0150</stdout>
@@ -241,7 +241,7 @@
       <stdout>E: USEC_INITIALIZED=6835334</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasdb1'</name>
+      <name>/usr/bin/udevadm info '/dev/dasdb1'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasdb/dasdb1</stdout>
       <stdout>N: dasdb1</stdout>
       <stdout>S: disk/by-id/ccw-0X0150-part1</stdout>
@@ -273,7 +273,7 @@
       <stdout>E: USEC_INITIALIZED=6956324</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasdb2'</name>
+      <name>/usr/bin/udevadm info '/dev/dasdb2'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasdb/dasdb2</stdout>
       <stdout>N: dasdb2</stdout>
       <stdout>S: disk/by-id/ccw-0X0150-part2</stdout>
@@ -305,7 +305,7 @@
       <stdout>E: USEC_INITIALIZED=6907660</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasdb3'</name>
+      <name>/usr/bin/udevadm info '/dev/dasdb3'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasdb/dasdb3</stdout>
       <stdout>N: dasdb3</stdout>
       <stdout>S: disk/by-id/ccw-0X0150-part3</stdout>
@@ -337,7 +337,7 @@
       <stdout>E: USEC_INITIALIZED=6957187</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasdc'</name>
+      <name>/usr/bin/udevadm info '/dev/dasdc'</name>
       <stdout>P: /devices/css0/0.0.0004/0.0.0160/block/dasdc</stdout>
       <stdout>N: dasdc</stdout>
       <stdout>S: disk/by-id/ccw-0X0160</stdout>
@@ -362,7 +362,7 @@
       <stdout>E: USEC_INITIALIZED=6831972</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasdc1'</name>
+      <name>/usr/bin/udevadm info '/dev/dasdc1'</name>
       <stdout>P: /devices/css0/0.0.0004/0.0.0160/block/dasdc/dasdc1</stdout>
       <stdout>N: dasdc1</stdout>
       <stdout>S: disk/by-id/ccw-0X0160-part1</stdout>
@@ -394,7 +394,7 @@
       <stdout>E: USEC_INITIALIZED=6845855</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/dasd3-mockup.xml
+++ b/testsuite/probe/dasd3-mockup.xml
@@ -10,7 +10,7 @@
       <name>/sbin/blkid -c '/dev/null'</name>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/vda'</name>
+      <name>/usr/bin/udevadm info '/dev/vda'</name>
       <stdout>P: /devices/css0/0.0.0000/0.0.0000/virtio0/block/vda</stdout>
       <stdout>N: vda</stdout>
       <stdout>S: disk/by-path/ccw-0.0.0000</stdout>
@@ -26,7 +26,7 @@
       <stdout>E: TAGS=:systemd:</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/disk-mockup.xml
+++ b/testsuite/probe/disk-mockup.xml
@@ -17,7 +17,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2</stdout>
@@ -66,7 +66,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2-part1</stdout>
@@ -128,7 +128,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2-part2</stdout>
@@ -192,7 +192,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB43911086-715441bd</stdout>
@@ -248,7 +248,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata4/host3/target3:0:0/3:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -317,7 +317,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/disk-zoned1-mockup.xml
+++ b/testsuite/probe/disk-zoned1-mockup.xml
@@ -26,7 +26,7 @@
       <name>/sbin/multipath -d -v 2 -ll</name>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:11.5/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>L: 0</stdout>
@@ -100,7 +100,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:11.5/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>L: 0</stdout>
@@ -183,7 +183,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:11.5/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>L: 0</stdout>
@@ -272,7 +272,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda3'</name>
+      <name>/usr/bin/udevadm info '/dev/sda3'</name>
       <stdout>P: /devices/pci0000:00/0000:00:11.5/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda3</stdout>
       <stdout>N: sda3</stdout>
       <stdout>L: 0</stdout>
@@ -360,7 +360,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:11.5/ata6/host5/target5:0:0/5:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>L: 0</stdout>
@@ -433,7 +433,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/dmraid1-mockup.xml
+++ b/testsuite/probe/dmraid1-mockup.xml
@@ -45,7 +45,7 @@
       <stderr>bash: /sbin/multipath: No such file or directory</stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/isw_ddgdcbibhd_test1'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/isw_ddgdcbibhd_test1'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>L: 50</stdout>
@@ -82,7 +82,7 @@
       <stdout>E: USEC_INITIALIZED=57938318</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/isw_ddgdcbibhd_test1-part1'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/isw_ddgdcbibhd_test1-part1'</name>
       <stdout>P: /devices/virtual/block/dm-2</stdout>
       <stdout>N: dm-2</stdout>
       <stdout>L: 50</stdout>
@@ -133,7 +133,7 @@
       <stdout>E: USEC_INITIALIZED=58275587</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/isw_ddgdcbibhd_test1-part2'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/isw_ddgdcbibhd_test1-part2'</name>
       <stdout>P: /devices/virtual/block/dm-3</stdout>
       <stdout>N: dm-3</stdout>
       <stdout>L: 50</stdout>
@@ -183,7 +183,7 @@
       <stdout>E: USEC_INITIALIZED=58289852</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/isw_ddgdcbibhd_test2'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/isw_ddgdcbibhd_test2'</name>
       <stdout>P: /devices/virtual/block/dm-1</stdout>
       <stdout>N: dm-1</stdout>
       <stdout>L: 50</stdout>
@@ -224,7 +224,7 @@
       <stdout>E: USEC_INITIALIZED=57990951</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB777f5d67-56603f01</stdout>
@@ -274,7 +274,7 @@
       <stdout>E: USEC_INITIALIZED=9788636</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB777f5d67-56603f01-part1</stdout>
@@ -339,7 +339,7 @@
       <stdout>E: USEC_INITIALIZED=10023547</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB777f5d67-56603f01-part2</stdout>
@@ -406,7 +406,7 @@
       <stdout>E: USEC_INITIALIZED=10043423</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB6a9bf539-bed09c6d</stdout>
@@ -458,18 +458,18 @@
     </Command>
     <Command>
       <!-- output faked and incomplete -->
-      <name>/sbin/udevadm info '/dev/sdb1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb1</stdout>
       <stdout>N: sdb1</stdout>
     </Command>>
     <Command>
       <!-- output faked and incomplete -->
-      <name>/sbin/udevadm info '/dev/sdb2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb2</stdout>
       <stdout>N: sdb2</stdout>
     </Command>>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBe0e2de48-b05a036b</stdout>
@@ -521,18 +521,18 @@
     </Command>
     <Command>
       <!-- output faked and incomplete -->
-      <name>/sbin/udevadm info '/dev/sdc1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc/sdc1</stdout>
       <stdout>N: sdc1</stdout>
     </Command>
     <Command>
       <!-- output faked and incomplete -->
-      <name>/sbin/udevadm info '/dev/sdc2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc/sdc2</stdout>
       <stdout>N: sdc2</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata7/host6/target6:0:0/6:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -600,7 +600,7 @@
       <stdout>E: USEC_INITIALIZED=9808171</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/external-journal-mockup.xml
+++ b/testsuite/probe/external-journal-mockup.xml
@@ -22,7 +22,7 @@
       <name>/sbin/multipath -d -v 2 -ll</name>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBfe1a188b-41f5c00a</stdout>
@@ -72,7 +72,7 @@
       <stdout>E: USEC_INITIALIZED=9860636</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBfe1a188b-41f5c00a-part1</stdout>
@@ -137,7 +137,7 @@
       <stdout>E: USEC_INITIALIZED=9989459</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBfe1a188b-41f5c00a-part2</stdout>
@@ -204,7 +204,7 @@
       <stdout>E: USEC_INITIALIZED=10051049</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda3'</name>
+      <name>/usr/bin/udevadm info '/dev/sda3'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda3</stdout>
       <stdout>N: sda3</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBfe1a188b-41f5c00a-part3</stdout>
@@ -269,7 +269,7 @@
       <stdout>E: USEC_INITIALIZED=165365265</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda4'</name>
+      <name>/usr/bin/udevadm info '/dev/sda4'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda4</stdout>
       <stdout>N: sda4</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBfe1a188b-41f5c00a-part4</stdout>
@@ -330,7 +330,7 @@
       <stdout>E: USEC_INITIALIZED=180888564</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB5b99f565-832be514</stdout>
@@ -380,7 +380,7 @@
       <stdout>E: USEC_INITIALIZED=9775553</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb1</stdout>
       <stdout>N: sdb1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB5b99f565-832be514-part1</stdout>
@@ -445,7 +445,7 @@
       <stdout>E: USEC_INITIALIZED=1724182665</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb2</stdout>
       <stdout>N: sdb2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB5b99f565-832be514-part2</stdout>
@@ -509,7 +509,7 @@
       <stdout>E: USEC_INITIALIZED=1724166180</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata7/host6/target6:0:0/6:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -577,7 +577,7 @@
       <stdout>E: USEC_INITIALIZED=9773037</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/luks+lvm1-mockup.xml
+++ b/testsuite/probe/luks+lvm1-mockup.xml
@@ -74,7 +74,7 @@
       <stdout>  }</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dm-1'</name>
+      <name>/usr/bin/udevadm info '/dev/dm-1'</name>
       <stdout>P: /devices/virtual/block/dm-1</stdout>
       <stdout>N: dm-1</stdout>
       <stdout>S: disk/by-id/dm-name-system-swap</stdout>
@@ -107,7 +107,7 @@
       <stdout>E: USEC_INITIALIZED=19274229</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/cr_sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/cr_sda2'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>S: disk/by-id/dm-name-cr_sda2</stdout>
@@ -141,7 +141,7 @@
       <stdout>E: USEC_INITIALIZED=19141001</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/system-home'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/system-home'</name>
       <stdout>P: /devices/virtual/block/dm-3</stdout>
       <stdout>N: dm-3</stdout>
       <stdout>S: disk/by-id/dm-name-system-home</stdout>
@@ -173,7 +173,7 @@
       <stdout>E: USEC_INITIALIZED=25219973</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/system-root'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/system-root'</name>
       <stdout>P: /devices/virtual/block/dm-2</stdout>
       <stdout>N: dm-2</stdout>
       <stdout>S: disk/by-id/dm-name-system-root</stdout>
@@ -206,7 +206,7 @@
       <stdout>E: USEC_INITIALIZED=19444034</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/system-swap'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/system-swap'</name>
       <stdout>P: /devices/virtual/block/dm-1</stdout>
       <stdout>N: dm-1</stdout>
       <stdout>S: disk/by-id/dm-name-system-swap</stdout>
@@ -239,7 +239,7 @@
       <stdout>E: USEC_INITIALIZED=19274229</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBd96ee5ae-bffc995c</stdout>
@@ -292,7 +292,7 @@
       <stdout>E: USEC_INITIALIZED=23828005</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBd96ee5ae-bffc995c-part1</stdout>
@@ -354,7 +354,7 @@
       <stdout>E: USEC_INITIALIZED=23916907</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBd96ee5ae-bffc995c-part2</stdout>
@@ -423,7 +423,7 @@
       <stdout>E: USEC_INITIALIZED=23839474</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata5/host4/target4:0:0/4:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -489,7 +489,7 @@
       <stdout>E: USEC_INITIALIZED=23705874</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/system/home'</name>
+      <name>/usr/bin/udevadm info '/dev/system/home'</name>
       <stdout>P: /devices/virtual/block/dm-3</stdout>
       <stdout>N: dm-3</stdout>
       <stdout>S: disk/by-id/dm-name-system-home</stdout>
@@ -521,7 +521,7 @@
       <stdout>E: USEC_INITIALIZED=25219973</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/system/root'</name>
+      <name>/usr/bin/udevadm info '/dev/system/root'</name>
       <stdout>P: /devices/virtual/block/dm-2</stdout>
       <stdout>N: dm-2</stdout>
       <stdout>S: disk/by-id/dm-name-system-root</stdout>
@@ -554,7 +554,7 @@
       <stdout>E: USEC_INITIALIZED=19444034</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/system/swap'</name>
+      <name>/usr/bin/udevadm info '/dev/system/swap'</name>
       <stdout>P: /devices/virtual/block/dm-1</stdout>
       <stdout>N: dm-1</stdout>
       <stdout>S: disk/by-id/dm-name-system-swap</stdout>
@@ -587,7 +587,7 @@
       <stdout>E: USEC_INITIALIZED=19274229</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/vgs --reportformat json --units b --nosuffix --options vg_name,vg_uuid,vg_attr,vg_extent_size,vg_extent_count,vg_free_count</name>

--- a/testsuite/probe/luks1-mockup.xml
+++ b/testsuite/probe/luks1-mockup.xml
@@ -28,7 +28,7 @@
       <stdout>cr_home: 0 16779264 crypt aes-xts-plain64 0000000000000000000000000000000000000000000000000000000000000000 0 8:2 4096</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/cr_home'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/cr_home'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>L: 50</stdout>
@@ -68,7 +68,7 @@
       <stdout>E: USEC_INITIALIZED=32865604</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB56faa9ee-37629d93</stdout>
@@ -117,7 +117,7 @@
       <stdout>E: USEC_INITIALIZED=5248818</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB56faa9ee-37629d93-part1</stdout>
@@ -181,7 +181,7 @@
       <stdout>E: USEC_INITIALIZED=5648925</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB56faa9ee-37629d93-part2</stdout>
@@ -243,7 +243,7 @@
       <stdout>E: USEC_INITIALIZED=5718331</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata3/host2/target2:0:0/2:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -311,7 +311,7 @@
       <stdout>E: USEC_INITIALIZED=5360379</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/disk/by-id/ata-VBOX_HARDDISK_VB56faa9ee-37629d93-part2'</name>
+      <name>/usr/bin/udevadm info '/dev/disk/by-id/ata-VBOX_HARDDISK_VB56faa9ee-37629d93-part2'</name>
       <!-- output faked and incomplete -->
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
@@ -319,7 +319,7 @@
       <stdout>E: MINOR=2</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/luks2-mockup.xml
+++ b/testsuite/probe/luks2-mockup.xml
@@ -67,7 +67,7 @@
       <name>/sbin/multipath -d -v 2 -ll</name>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/cr-test1'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/cr-test1'</name>
       <stdout>P: /devices/virtual/block/dm-6</stdout>
       <stdout>N: dm-6</stdout>
       <stdout>S: disk/by-id/dm-name-cr-test1</stdout>
@@ -92,7 +92,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/cr-test3'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/cr-test3'</name>
       <stdout>P: /devices/virtual/block/dm-8</stdout>
       <stdout>N: dm-8</stdout>
       <stdout>S: disk/by-id/dm-name-cr-test3</stdout>
@@ -117,7 +117,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.3/1-1.3:1.0/host6/target6:0:0/6:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/usb-WD_My_Passport_25E2_575842314436354C33384445-0:0</stdout>
@@ -165,7 +165,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.3/1-1.3:1.0/host6/target6:0:0/6:0:0:0/block/sdb/sdb1</stdout>
       <stdout>N: sdb1</stdout>
       <stdout>S: disk/by-id/usb-WD_My_Passport_25E2_575842314436354C33384445-0:0-part1</stdout>
@@ -227,7 +227,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.3/1-1.3:1.0/host6/target6:0:0/6:0:0:0/block/sdb/sdb2</stdout>
       <stdout>N: sdb2</stdout>
       <stdout>S: disk/by-id/usb-WD_My_Passport_25E2_575842314436354C33384445-0:0-part2</stdout>
@@ -289,7 +289,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb3'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb3'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.3/1-1.3:1.0/host6/target6:0:0/6:0:0:0/block/sdb/sdb3</stdout>
       <stdout>N: sdb3</stdout>
       <stdout>S: disk/by-id/usb-WD_My_Passport_25E2_575842314436354C33384445-0:0-part3</stdout>
@@ -351,7 +351,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb4'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb4'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.3/1-1.3:1.0/host6/target6:0:0/6:0:0:0/block/sdb/sdb4</stdout>
       <stdout>N: sdb4</stdout>
       <stdout>S: disk/by-id/usb-WD_My_Passport_25E2_575842314436354C33384445-0:0-part4</stdout>
@@ -413,7 +413,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/luks3-mockup.xml
+++ b/testsuite/probe/luks3-mockup.xml
@@ -32,12 +32,12 @@
       <name>/sbin/multipath -d -v 2 -ll</name>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/disk/by-uuid/39334baa-941f-42ab-a0a4-7c20a427aff2'</name>
+      <name>/usr/bin/udevadm info '/dev/disk/by-uuid/39334baa-941f-42ab-a0a4-7c20a427aff2'</name>
       <stderr>Unknown device, --name=, --path=, or absolute path in /dev/ or /sys expected.</stderr>
       <exit-code>4</exit-code>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/cr-test2'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/cr-test2'</name>
       <stdout>P: /devices/virtual/block/dm-5</stdout>
       <stdout>N: dm-5</stdout>
       <stdout>S: disk/by-id/dm-name-cr-test2</stdout>
@@ -68,7 +68,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>S: disk/by-id/usb-WD_My_Passport_25E2_57584D31454135463654544A-0:0</stdout>
@@ -117,7 +117,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc/sdc1</stdout>
       <stdout>N: sdc1</stdout>
       <stdout>S: disk/by-id/usb-WD_My_Passport_25E2_57584D31454135463654544A-0:0-part1</stdout>
@@ -181,7 +181,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/lvm+luks1-mockup.xml
+++ b/testsuite/probe/lvm+luks1-mockup.xml
@@ -74,7 +74,7 @@
       <stdout>  }</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dm-0'</name>
+      <name>/usr/bin/udevadm info '/dev/dm-0'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>S: disk/by-id/dm-name-system-swap</stdout>
@@ -107,7 +107,7 @@
       <stdout>E: USEC_INITIALIZED=3414685</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/cr_home'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/cr_home'</name>
       <stdout>P: /devices/virtual/block/dm-3</stdout>
       <stdout>N: dm-3</stdout>
       <stdout>S: disk/by-id/dm-name-cr_home</stdout>
@@ -136,7 +136,7 @@
       <stdout>E: USEC_INITIALIZED=39223741</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/system-home'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/system-home'</name>
       <stdout>P: /devices/virtual/block/dm-2</stdout>
       <stdout>N: dm-2</stdout>
       <stdout>S: disk/by-id/dm-name-system-home</stdout>
@@ -168,7 +168,7 @@
       <stdout>E: USEC_INITIALIZED=8962918</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/system-root'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/system-root'</name>
       <stdout>P: /devices/virtual/block/dm-1</stdout>
       <stdout>N: dm-1</stdout>
       <stdout>S: disk/by-id/dm-name-system-root</stdout>
@@ -201,7 +201,7 @@
       <stdout>E: USEC_INITIALIZED=3525820</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/system-swap'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/system-swap'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>S: disk/by-id/dm-name-system-swap</stdout>
@@ -234,7 +234,7 @@
       <stdout>E: USEC_INITIALIZED=3414685</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBd96ee5ae-bffc995c</stdout>
@@ -287,7 +287,7 @@
       <stdout>E: USEC_INITIALIZED=7573532</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBd96ee5ae-bffc995c-part1</stdout>
@@ -349,7 +349,7 @@
       <stdout>E: USEC_INITIALIZED=7926380</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBd96ee5ae-bffc995c-part2</stdout>
@@ -421,7 +421,7 @@
       <stdout>E: USEC_INITIALIZED=7615881</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata5/host4/target4:0:0/4:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -487,7 +487,7 @@
       <stdout>E: USEC_INITIALIZED=7598295</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/system/home'</name>
+      <name>/usr/bin/udevadm info '/dev/system/home'</name>
       <stdout>P: /devices/virtual/block/dm-2</stdout>
       <stdout>N: dm-2</stdout>
       <stdout>S: disk/by-id/dm-name-system-home</stdout>
@@ -519,7 +519,7 @@
       <stdout>E: USEC_INITIALIZED=8962918</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/system/root'</name>
+      <name>/usr/bin/udevadm info '/dev/system/root'</name>
       <stdout>P: /devices/virtual/block/dm-1</stdout>
       <stdout>N: dm-1</stdout>
       <stdout>S: disk/by-id/dm-name-system-root</stdout>
@@ -552,7 +552,7 @@
       <stdout>E: USEC_INITIALIZED=3525820</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/system/swap'</name>
+      <name>/usr/bin/udevadm info '/dev/system/swap'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>S: disk/by-id/dm-name-system-swap</stdout>
@@ -585,7 +585,7 @@
       <stdout>E: USEC_INITIALIZED=3414685</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/vgs --reportformat json --units b --nosuffix --options vg_name,vg_uuid,vg_attr,vg_extent_size,vg_extent_count,vg_free_count</name>

--- a/testsuite/probe/lvm-errors1-mockup.xml
+++ b/testsuite/probe/lvm-errors1-mockup.xml
@@ -68,7 +68,7 @@
       <stderr>  Couldn't find device with uuid lv08LY-exMW-YKNh-GgX7-q0Ja-dW8H-lJ9Ejw.</stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBb0b74e3e-a4b92e47</stdout>
@@ -121,7 +121,7 @@
       <stdout>E: USEC_INITIALIZED=145504322</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb1</stdout>
       <stdout>N: sdb1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBb0b74e3e-a4b92e47-part1</stdout>
@@ -189,7 +189,7 @@
       <stdout>E: USEC_INITIALIZED=145518907</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb2</stdout>
       <stdout>N: sdb2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBb0b74e3e-a4b92e47-part2</stdout>
@@ -257,7 +257,7 @@
       <stdout>E: USEC_INITIALIZED=145526549</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB91c9f2aa-0392f4ef</stdout>
@@ -310,7 +310,7 @@
       <stdout>E: USEC_INITIALIZED=7387725923</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc/sdc1</stdout>
       <stdout>N: sdc1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB91c9f2aa-0392f4ef-part1</stdout>
@@ -378,7 +378,7 @@
       <stdout>E: USEC_INITIALIZED=7387753153</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc/sdc2</stdout>
       <stdout>N: sdc2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB91c9f2aa-0392f4ef-part2</stdout>
@@ -442,7 +442,7 @@
       <stdout>E: USEC_INITIALIZED=7387744935</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/vgs --reportformat json --units b --nosuffix --options vg_name,vg_uuid,vg_attr,vg_extent_size,vg_extent_count,vg_free_count</name>

--- a/testsuite/probe/lvm-unsupported1-mockup.xml
+++ b/testsuite/probe/lvm-unsupported1-mockup.xml
@@ -170,7 +170,7 @@
       <stderr>  WARNING: Failed to connect to lvmetad. Falling back to device scanning.</stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/disk/by-id/ata-VBOX_CD-ROM_VB2-01700376'</name>
+      <name>/usr/bin/udevadm info '/dev/disk/by-id/ata-VBOX_CD-ROM_VB2-01700376'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata5/host4/target4:0:0/4:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -235,7 +235,7 @@
       <stdout>E: USEC_INITIALIZED=4133182</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop0'</name>
+      <name>/usr/bin/udevadm info '/dev/loop0'</name>
       <stdout>P: /devices/virtual/block/loop0</stdout>
       <stdout>N: loop0</stdout>
       <stdout>E: DEVNAME=/dev/loop0</stdout>
@@ -251,7 +251,7 @@
       <stdout>E: USEC_INITIALIZED=3852365</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop1'</name>
+      <name>/usr/bin/udevadm info '/dev/loop1'</name>
       <stdout>P: /devices/virtual/block/loop1</stdout>
       <stdout>N: loop1</stdout>
       <stdout>E: DEVNAME=/dev/loop1</stdout>
@@ -267,7 +267,7 @@
       <stdout>E: USEC_INITIALIZED=3853232</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop2'</name>
+      <name>/usr/bin/udevadm info '/dev/loop2'</name>
       <stdout>P: /devices/virtual/block/loop2</stdout>
       <stdout>N: loop2</stdout>
       <stdout>E: DEVNAME=/dev/loop2</stdout>
@@ -283,7 +283,7 @@
       <stdout>E: USEC_INITIALIZED=3903528</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop3'</name>
+      <name>/usr/bin/udevadm info '/dev/loop3'</name>
       <stdout>P: /devices/virtual/block/loop3</stdout>
       <stdout>N: loop3</stdout>
       <stdout>E: DEVNAME=/dev/loop3</stdout>
@@ -299,7 +299,7 @@
       <stdout>E: USEC_INITIALIZED=3919530</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop4'</name>
+      <name>/usr/bin/udevadm info '/dev/loop4'</name>
       <stdout>P: /devices/virtual/block/loop4</stdout>
       <stdout>N: loop4</stdout>
       <stdout>E: DEVNAME=/dev/loop4</stdout>
@@ -315,7 +315,7 @@
       <stdout>E: USEC_INITIALIZED=3947204</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop5'</name>
+      <name>/usr/bin/udevadm info '/dev/loop5'</name>
       <stdout>P: /devices/virtual/block/loop5</stdout>
       <stdout>N: loop5</stdout>
       <stdout>E: DEVNAME=/dev/loop5</stdout>
@@ -331,7 +331,7 @@
       <stdout>E: USEC_INITIALIZED=3979080</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop6'</name>
+      <name>/usr/bin/udevadm info '/dev/loop6'</name>
       <stdout>P: /devices/virtual/block/loop6</stdout>
       <stdout>N: loop6</stdout>
       <stdout>E: DEVNAME=/dev/loop6</stdout>
@@ -347,7 +347,7 @@
       <stdout>E: USEC_INITIALIZED=4005592</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/test-cached'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/test-cached'</name>
       <stdout>P: /devices/virtual/block/dm-14</stdout>
       <stdout>N: dm-14</stdout>
       <stdout>S: disk/by-id/dm-name-test-cached</stdout>
@@ -380,7 +380,7 @@
       <stdout>E: USEC_INITIALIZED=828993779</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/test-normal1'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/test-normal1'</name>
       <stdout>P: /devices/virtual/block/dm-7</stdout>
       <stdout>N: dm-7</stdout>
       <stdout>S: disk/by-id/dm-name-test-normal1</stdout>
@@ -413,7 +413,7 @@
       <stdout>E: USEC_INITIALIZED=827967360</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/test-normal1--snapshot'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/test-normal1--snapshot'</name>
       <stdout>P: /devices/virtual/block/dm-9</stdout>
       <stdout>N: dm-9</stdout>
       <stdout>L: -100</stdout>
@@ -448,7 +448,7 @@
       <stdout>E: USEC_INITIALIZED=827983219</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/test-normal2'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/test-normal2'</name>
       <stdout>P: /devices/virtual/block/dm-10</stdout>
       <stdout>N: dm-10</stdout>
       <stdout>S: disk/by-id/dm-name-test-normal2</stdout>
@@ -481,7 +481,7 @@
       <stdout>E: USEC_INITIALIZED=828745320</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/test-thin1'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/test-thin1'</name>
       <stdout>P: /devices/virtual/block/dm-4</stdout>
       <stdout>N: dm-4</stdout>
       <stdout>S: disk/by-id/dm-name-test-thin1</stdout>
@@ -514,7 +514,7 @@
       <stdout>E: USEC_INITIALIZED=827918212</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/test-thin2'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/test-thin2'</name>
       <stdout>P: /devices/virtual/block/dm-5</stdout>
       <stdout>N: dm-5</stdout>
       <stdout>S: disk/by-id/dm-name-test-thin2</stdout>
@@ -547,7 +547,7 @@
       <stdout>E: USEC_INITIALIZED=827941128</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB098dbc19-95da593f</stdout>
@@ -601,7 +601,7 @@
       <stdout>E: USEC_INITIALIZED=4577990</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB098dbc19-95da593f-part1</stdout>
@@ -669,7 +669,7 @@
       <stdout>E: USEC_INITIALIZED=4586856</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB6e143016-eabee17c</stdout>
@@ -724,7 +724,7 @@
       <stdout>E: USEC_INITIALIZED=4582868</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb1</stdout>
       <stdout>N: sdb1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB6e143016-eabee17c-part1</stdout>
@@ -793,7 +793,7 @@
       <stdout>E: USEC_INITIALIZED=4587856</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata5/host4/target4:0:0/4:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -858,7 +858,7 @@
       <stdout>E: USEC_INITIALIZED=4133182</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/test/normal2'</name>
+      <name>/usr/bin/udevadm info '/dev/test/normal2'</name>
       <stdout>P: /devices/virtual/block/dm-10</stdout>
       <stdout>N: dm-10</stdout>
       <stdout>S: disk/by-id/dm-name-test-normal2</stdout>
@@ -891,7 +891,7 @@
       <stdout>E: USEC_INITIALIZED=828745320</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/test/thin1'</name>
+      <name>/usr/bin/udevadm info '/dev/test/thin1'</name>
       <stdout>P: /devices/virtual/block/dm-4</stdout>
       <stdout>N: dm-4</stdout>
       <stdout>S: disk/by-id/dm-name-test-thin1</stdout>
@@ -924,7 +924,7 @@
       <stdout>E: USEC_INITIALIZED=827918212</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/test/thin2'</name>
+      <name>/usr/bin/udevadm info '/dev/test/thin2'</name>
       <stdout>P: /devices/virtual/block/dm-5</stdout>
       <stdout>N: dm-5</stdout>
       <stdout>S: disk/by-id/dm-name-test-thin2</stdout>
@@ -957,7 +957,7 @@
       <stdout>E: USEC_INITIALIZED=827941128</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/vgs --reportformat json --units b --nosuffix --options vg_name,vg_uuid,vg_attr,vg_extent_size,vg_extent_count,vg_free_count</name>

--- a/testsuite/probe/lvm1-mockup.xml
+++ b/testsuite/probe/lvm1-mockup.xml
@@ -46,7 +46,7 @@
       <stdout>  }</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dm-1'</name>
+      <name>/usr/bin/udevadm info '/dev/dm-1'</name>
       <stdout>P: /devices/virtual/block/dm-1</stdout>
       <stdout>N: dm-1</stdout>
       <stdout>L: 50</stdout>
@@ -91,7 +91,7 @@
       <stdout>E: USEC_INITIALIZED=2286583</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/system-home'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/system-home'</name>
       <stdout>P: /devices/virtual/block/dm-2</stdout>
       <stdout>N: dm-2</stdout>
       <stdout>L: 50</stdout>
@@ -135,7 +135,7 @@
       <stdout>E: USEC_INITIALIZED=9271920</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/system-root'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/system-root'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>L: 50</stdout>
@@ -181,7 +181,7 @@
       <stdout>E: USEC_INITIALIZED=2201050</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/system-swap'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/system-swap'</name>
       <stdout>P: /devices/virtual/block/dm-1</stdout>
       <stdout>N: dm-1</stdout>
       <stdout>L: 50</stdout>
@@ -226,7 +226,7 @@
       <stdout>E: USEC_INITIALIZED=2286583</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBb49c5b26-db7a99ae</stdout>
@@ -275,7 +275,7 @@
       <stdout>E: USEC_INITIALIZED=5741416</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBb49c5b26-db7a99ae-part1</stdout>
@@ -340,7 +340,7 @@
       <stdout>E: USEC_INITIALIZED=5872320</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata3/host2/target2:0:0/2:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -408,7 +408,7 @@
       <stdout>E: USEC_INITIALIZED=6070299</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/system/home'</name>
+      <name>/usr/bin/udevadm info '/dev/system/home'</name>
       <stdout>P: /devices/virtual/block/dm-2</stdout>
       <stdout>N: dm-2</stdout>
       <stdout>L: 50</stdout>
@@ -452,7 +452,7 @@
       <stdout>E: USEC_INITIALIZED=9271920</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/system/root'</name>
+      <name>/usr/bin/udevadm info '/dev/system/root'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>L: 50</stdout>
@@ -498,7 +498,7 @@
       <stdout>E: USEC_INITIALIZED=2201050</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/system/swap'</name>
+      <name>/usr/bin/udevadm info '/dev/system/swap'</name>
       <stdout>P: /devices/virtual/block/dm-1</stdout>
       <stdout>N: dm-1</stdout>
       <stdout>L: 50</stdout>
@@ -543,7 +543,7 @@
       <stdout>E: USEC_INITIALIZED=2286583</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/vgs --reportformat json --units b --nosuffix --options vg_name,vg_uuid,vg_attr,vg_extent_size,vg_extent_count,vg_free_count</name>

--- a/testsuite/probe/lvm2-mockup.xml
+++ b/testsuite/probe/lvm2-mockup.xml
@@ -69,7 +69,7 @@
       <stdout>  }</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dm-4'</name>
+      <name>/usr/bin/udevadm info '/dev/dm-4'</name>
       <stdout>P: /devices/virtual/block/dm-4</stdout>
       <stdout>N: dm-4</stdout>
       <stdout>S: disk/by-id/dm-name-system-swap</stdout>
@@ -102,7 +102,7 @@
       <stdout>E: USEC_INITIALIZED=3220380</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/system-home'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/system-home'</name>
       <stdout>P: /devices/virtual/block/dm-6</stdout>
       <stdout>N: dm-6</stdout>
       <stdout>S: disk/by-id/dm-name-system-home</stdout>
@@ -134,7 +134,7 @@
       <stdout>E: USEC_INITIALIZED=14057865</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/system-root'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/system-root'</name>
       <stdout>P: /devices/virtual/block/dm-3</stdout>
       <stdout>N: dm-3</stdout>
       <stdout>S: disk/by-id/dm-name-system-root</stdout>
@@ -167,7 +167,7 @@
       <stdout>E: USEC_INITIALIZED=3105114</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/system-swap'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/system-swap'</name>
       <stdout>P: /devices/virtual/block/dm-4</stdout>
       <stdout>N: dm-4</stdout>
       <stdout>S: disk/by-id/dm-name-system-swap</stdout>
@@ -200,7 +200,7 @@
       <stdout>E: USEC_INITIALIZED=3220380</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB09d89637-d9690549</stdout>
@@ -248,7 +248,7 @@
       <stdout>E: USEC_INITIALIZED=12033392</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB09d89637-d9690549-part1</stdout>
@@ -312,7 +312,7 @@
       <stdout>E: USEC_INITIALIZED=12812805</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB09d89637-d9690549-part2</stdout>
@@ -379,7 +379,7 @@
       <stdout>E: USEC_INITIALIZED=12885390</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata4/host3/target3:0:0/3:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -446,7 +446,7 @@
       <stdout>E: USEC_INITIALIZED=11340413</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/system/home'</name>
+      <name>/usr/bin/udevadm info '/dev/system/home'</name>
       <stdout>P: /devices/virtual/block/dm-6</stdout>
       <stdout>N: dm-6</stdout>
       <stdout>S: disk/by-id/dm-name-system-home</stdout>
@@ -478,7 +478,7 @@
       <stdout>E: USEC_INITIALIZED=14057865</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/system/root'</name>
+      <name>/usr/bin/udevadm info '/dev/system/root'</name>
       <stdout>P: /devices/virtual/block/dm-3</stdout>
       <stdout>N: dm-3</stdout>
       <stdout>S: disk/by-id/dm-name-system-root</stdout>
@@ -511,7 +511,7 @@
       <stdout>E: USEC_INITIALIZED=3105114</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/system/swap'</name>
+      <name>/usr/bin/udevadm info '/dev/system/swap'</name>
       <stdout>P: /devices/virtual/block/dm-4</stdout>
       <stdout>N: dm-4</stdout>
       <stdout>S: disk/by-id/dm-name-system-swap</stdout>
@@ -544,7 +544,7 @@
       <stdout>E: USEC_INITIALIZED=3220380</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/vgs --reportformat json --units b --nosuffix --options vg_name,vg_uuid,vg_attr,vg_extent_size,vg_extent_count,vg_free_count</name>

--- a/testsuite/probe/md+lvm1-mockup.xml
+++ b/testsuite/probe/md+lvm1-mockup.xml
@@ -99,7 +99,7 @@
       <stdout>  }</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/vg--a-lv--a'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/vg--a-lv--a'</name>
       <stdout>P: /devices/virtual/block/dm-6</stdout>
       <stdout>N: dm-6</stdout>
       <stdout>L: 0</stdout>
@@ -132,7 +132,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/vg--b-lv--b'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/vg--b-lv--b'</name>
       <stdout>P: /devices/virtual/block/dm-5</stdout>
       <stdout>N: dm-5</stdout>
       <stdout>L: 0</stdout>
@@ -165,7 +165,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/md-b'</name>
+      <name>/usr/bin/udevadm info '/dev/md/md-b'</name>
       <stdout>P: /devices/virtual/block/md127</stdout>
       <stdout>N: md127</stdout>
       <stdout>L: 100</stdout>
@@ -214,7 +214,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md0'</name>
+      <name>/usr/bin/udevadm info '/dev/md0'</name>
       <stdout>P: /devices/virtual/block/md0</stdout>
       <stdout>N: md0</stdout>
       <stdout>L: 100</stdout>
@@ -260,7 +260,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md127'</name>
+      <name>/usr/bin/udevadm info '/dev/md127'</name>
       <stdout>P: /devices/virtual/block/md127</stdout>
       <stdout>N: md127</stdout>
       <stdout>L: 100</stdout>
@@ -309,7 +309,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>L: 0</stdout>
@@ -360,7 +360,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc/sdc1</stdout>
       <stdout>N: sdc1</stdout>
       <stdout>L: 0</stdout>
@@ -437,7 +437,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc/sdc2</stdout>
       <stdout>N: sdc2</stdout>
       <stdout>L: 0</stdout>
@@ -514,7 +514,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdd'</name>
+      <name>/usr/bin/udevadm info '/dev/sdd'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-8/2-8:1.0/host9/target9:0:0/9:0:0:0/block/sdd</stdout>
       <stdout>N: sdd</stdout>
       <stdout>L: 0</stdout>
@@ -565,7 +565,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdd1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdd1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-8/2-8:1.0/host9/target9:0:0/9:0:0:0/block/sdd/sdd1</stdout>
       <stdout>N: sdd1</stdout>
       <stdout>L: 0</stdout>
@@ -642,7 +642,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdd2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdd2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-8/2-8:1.0/host9/target9:0:0/9:0:0:0/block/sdd/sdd2</stdout>
       <stdout>N: sdd2</stdout>
       <stdout>L: 0</stdout>
@@ -719,7 +719,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:17.0/ata7/host6/target6:0:0/6:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -782,7 +782,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/vg-a/lv-a'</name>
+      <name>/usr/bin/udevadm info '/dev/vg-a/lv-a'</name>
       <stdout>P: /devices/virtual/block/dm-6</stdout>
       <stdout>N: dm-6</stdout>
       <stdout>L: 0</stdout>
@@ -815,7 +815,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/vg-b/lv-b'</name>
+      <name>/usr/bin/udevadm info '/dev/vg-b/lv-b'</name>
       <stdout>P: /devices/virtual/block/dm-5</stdout>
       <stdout>N: dm-5</stdout>
       <stdout>L: 0</stdout>
@@ -848,7 +848,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/sbin/vgs --reportformat json --units b --nosuffix --options vg_name,vg_uuid,vg_attr,vg_extent_size,vg_extent_count,vg_free_count</name>

--- a/testsuite/probe/md-ddf1-mockup.xml
+++ b/testsuite/probe/md-ddf1-mockup.xml
@@ -86,7 +86,7 @@
       <stderr>bash: /sbin/multipath: No such file or directory</stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/a'</name>
+      <name>/usr/bin/udevadm info '/dev/md/a'</name>
       <stdout>P: /devices/virtual/block/md126</stdout>
       <stdout>N: md126</stdout>
       <stdout>L: 100</stdout>
@@ -129,7 +129,7 @@
       <stdout>E: USEC_INITIALIZED=126338070</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/b'</name>
+      <name>/usr/bin/udevadm info '/dev/md/b'</name>
       <stdout>P: /devices/virtual/block/md125</stdout>
       <stdout>N: md125</stdout>
       <stdout>L: 100</stdout>
@@ -170,8 +170,8 @@
       <stdout>E: USEC_INITIALIZED=127183915</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/ddf0'</name>
-      <name>/sbin/udevadm info '/dev/md127'</name>
+      <name>/usr/bin/udevadm info '/dev/md/ddf0'</name>
+      <name>/usr/bin/udevadm info '/dev/md127'</name>
       <stdout>P: /devices/virtual/block/md127</stdout>
       <stdout>N: md127</stdout>
       <stdout>L: 100</stdout>
@@ -211,7 +211,7 @@
       <stdout>E: USEC_INITIALIZED=126180619</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md126'</name>
+      <name>/usr/bin/udevadm info '/dev/md126'</name>
       <stdout>P: /devices/virtual/block/md126</stdout>
       <stdout>N: md126</stdout>
       <stdout>L: 100</stdout>
@@ -254,7 +254,7 @@
       <stdout>E: USEC_INITIALIZED=126338070</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB777f5d67-56603f01</stdout>
@@ -302,7 +302,7 @@
       <stdout>E: USEC_INITIALIZED=10742109</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB777f5d67-56603f01-part1</stdout>
@@ -365,7 +365,7 @@
       <stdout>E: USEC_INITIALIZED=11617242</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB777f5d67-56603f01-part2</stdout>
@@ -429,7 +429,7 @@
       <stdout>E: USEC_INITIALIZED=11128947</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB6a9bf539-bed09c6d</stdout>
@@ -480,7 +480,7 @@
       <stdout>E: USEC_INITIALIZED=13288628</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBe0e2de48-b05a036b</stdout>
@@ -531,7 +531,7 @@
       <stdout>E: USEC_INITIALIZED=13525175</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdd'</name>
+      <name>/usr/bin/udevadm info '/dev/sdd'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata4/host3/target3:0:0/3:0:0:0/block/sdd</stdout>
       <stdout>N: sdd</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBb7981c42-298aa589</stdout>
@@ -582,7 +582,7 @@
       <stdout>E: USEC_INITIALIZED=11785195</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata7/host6/target6:0:0/6:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -648,7 +648,7 @@
       <stdout>E: USEC_INITIALIZED=11012123</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/md-imsm1-mockup.xml
+++ b/testsuite/probe/md-imsm1-mockup.xml
@@ -92,7 +92,7 @@
       <stderr>bash: /sbin/multipath: No such file or directory</stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/a'</name>
+      <name>/usr/bin/udevadm info '/dev/md/a'</name>
       <stdout>P: /devices/virtual/block/md126</stdout>
       <stdout>N: md126</stdout>
       <stdout>L: 100</stdout>
@@ -135,7 +135,7 @@
       <stdout>E: USEC_INITIALIZED=693228658</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/b'</name>
+      <name>/usr/bin/udevadm info '/dev/md/b'</name>
       <stdout>P: /devices/virtual/block/md125</stdout>
       <stdout>N: md125</stdout>
       <stdout>L: 100</stdout>
@@ -176,8 +176,8 @@
       <stdout>E: USEC_INITIALIZED=710311959</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/imsm0'</name>
-      <name>/sbin/udevadm info '/dev/md127'</name>
+      <name>/usr/bin/udevadm info '/dev/md/imsm0'</name>
+      <name>/usr/bin/udevadm info '/dev/md127'</name>
       <stdout>P: /devices/virtual/block/md127</stdout>
       <stdout>N: md127</stdout>
       <stdout>L: 100</stdout>
@@ -217,7 +217,7 @@
       <stdout>E: USEC_INITIALIZED=704100119</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md126'</name>
+      <name>/usr/bin/udevadm info '/dev/md126'</name>
       <stdout>P: /devices/virtual/block/md126</stdout>
       <stdout>N: md126</stdout>
       <stdout>L: 100</stdout>
@@ -260,7 +260,7 @@
       <stdout>E: USEC_INITIALIZED=693228658</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB777f5d67-56603f01</stdout>
@@ -308,7 +308,7 @@
       <stdout>E: USEC_INITIALIZED=10742109</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB777f5d67-56603f01-part1</stdout>
@@ -371,7 +371,7 @@
       <stdout>E: USEC_INITIALIZED=11617242</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB777f5d67-56603f01-part2</stdout>
@@ -435,7 +435,7 @@
       <stdout>E: USEC_INITIALIZED=11128947</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB6a9bf539-bed09c6d</stdout>
@@ -484,7 +484,7 @@
       <stdout>E: USEC_INITIALIZED=13288628</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBe0e2de48-b05a036b</stdout>
@@ -533,7 +533,7 @@
       <stdout>E: USEC_INITIALIZED=13525175</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdd'</name>
+      <name>/usr/bin/udevadm info '/dev/sdd'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata4/host3/target3:0:0/3:0:0:0/block/sdd</stdout>
       <stdout>N: sdd</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBb7981c42-298aa589</stdout>
@@ -582,7 +582,7 @@
       <stdout>E: USEC_INITIALIZED=11785195</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata7/host6/target6:0:0/6:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -648,7 +648,7 @@
       <stdout>E: USEC_INITIALIZED=11012123</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/md1-mockup.xml
+++ b/testsuite/probe/md1-mockup.xml
@@ -92,7 +92,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md0'</name>
+      <name>/usr/bin/udevadm info '/dev/md0'</name>
       <stdout>P: /devices/virtual/block/md0</stdout>
       <stdout>N: md0</stdout>
       <stdout>L: 100</stdout>
@@ -127,7 +127,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBb5bd49a6-9719c9ff</stdout>
@@ -183,7 +183,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB558bee5c-c4399e89</stdout>
@@ -239,7 +239,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB0eeaf303-8fd4e564</stdout>
@@ -295,7 +295,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdd'</name>
+      <name>/usr/bin/udevadm info '/dev/sdd'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata4/host3/target3:0:0/3:0:0:0/block/sdd</stdout>
       <stdout>N: sdd</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB2990e9d7-d065ff3e</stdout>
@@ -351,7 +351,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata10/host9/target9:0:0/9:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -418,7 +418,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
       <stdout></stdout>
       <stderr></stderr>
     </Command>

--- a/testsuite/probe/md2-mockup.xml
+++ b/testsuite/probe/md2-mockup.xml
@@ -97,7 +97,7 @@
       <stdout>/dev/md0p2: UUID="178825b0-311f-4914-b4d9-5a60e322150c" TYPE="ext4" PARTUUID="8bd64fbc-17e6-4de6-998f-f7027fa3b049"</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md0'</name>
+      <name>/usr/bin/udevadm info '/dev/md0'</name>
       <stdout>P: /devices/virtual/block/md0</stdout>
       <stdout>N: md0</stdout>
       <stdout>L: 100</stdout>
@@ -126,7 +126,7 @@
       <stdout>E: USEC_INITIALIZED=349261752</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md0p1'</name>
+      <name>/usr/bin/udevadm info '/dev/md0p1'</name>
       <stdout>P: /devices/virtual/block/md0/md0p1</stdout>
       <stdout>N: md0p1</stdout>
       <stdout>L: 100</stdout>
@@ -167,7 +167,7 @@
       <stdout>E: USEC_INITIALIZED=49347283</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md0p2'</name>
+      <name>/usr/bin/udevadm info '/dev/md0p2'</name>
       <stdout>P: /devices/virtual/block/md0/md0p2</stdout>
       <stdout>N: md0p2</stdout>
       <stdout>L: 100</stdout>
@@ -207,7 +207,7 @@
       <stdout>E: USEC_INITIALIZED=4449347299</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md1'</name>
+      <name>/usr/bin/udevadm info '/dev/md1'</name>
       <stdout>P: /devices/virtual/block/md1</stdout>
       <stdout>N: md1</stdout>
       <stdout>L: 100</stdout>
@@ -244,7 +244,7 @@
       <stdout>E: USEC_INITIALIZED=336772678</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md2'</name>
+      <name>/usr/bin/udevadm info '/dev/md2'</name>
       <stdout>P: /devices/virtual/block/md2</stdout>
       <stdout>N: md2</stdout>
       <stdout>L: 100</stdout>
@@ -281,7 +281,7 @@
       <stdout>E: USEC_INITIALIZED=345642759</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBb5bd49a6-9719c9ff</stdout>
@@ -336,7 +336,7 @@
       <stdout>E: USEC_INITIALIZED=82172</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB558bee5c-c4399e89</stdout>
@@ -391,7 +391,7 @@
       <stdout>E: USEC_INITIALIZED=82290</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata3/host2/target2:0:0/2:0:0:0/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB0eeaf303-8fd4e564</stdout>
@@ -446,7 +446,7 @@
       <stdout>E: USEC_INITIALIZED=82411</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdd'</name>
+      <name>/usr/bin/udevadm info '/dev/sdd'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata4/host3/target3:0:0/3:0:0:0/block/sdd</stdout>
       <stdout>N: sdd</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB2990e9d7-d065ff3e</stdout>
@@ -501,7 +501,7 @@
       <stdout>E: USEC_INITIALIZED=82583</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata10/host9/target9:0:0/9:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -567,7 +567,7 @@
       <stdout>E: USEC_INITIALIZED=66804</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/md3-mockup.xml
+++ b/testsuite/probe/md3-mockup.xml
@@ -137,7 +137,7 @@
       <stderr>bash: /sbin/multipath: No such file or directory</stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/test2'</name>
+      <name>/usr/bin/udevadm info '/dev/md/test2'</name>
       <stdout>P: /devices/virtual/block/md127</stdout>
       <stdout>N: md127</stdout>
       <stdout>L: 100</stdout>
@@ -171,7 +171,7 @@
       <stdout>E: USEC_INITIALIZED=639629673</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/test3'</name>
+      <name>/usr/bin/udevadm info '/dev/md/test3'</name>
       <stdout>P: /devices/virtual/block/md126</stdout>
       <stdout>N: md126</stdout>
       <stdout>L: 100</stdout>
@@ -201,7 +201,7 @@
       <stdout>E: USEC_INITIALIZED=642292972</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/test3p1'</name>
+      <name>/usr/bin/udevadm info '/dev/md/test3p1'</name>
       <stdout>P: /devices/virtual/block/md126/md126p1</stdout>
       <stdout>N: md126p1</stdout>
       <stdout>L: 100</stdout>
@@ -246,8 +246,8 @@
       <stdout>E: USEC_INITIALIZED=789644385</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/test4'</name>
-      <name>/sbin/udevadm info '/dev/md_test4'</name>
+      <name>/usr/bin/udevadm info '/dev/md/test4'</name>
+      <name>/usr/bin/udevadm info '/dev/md_test4'</name>
       <stdout>P: /devices/virtual/block/md_test4</stdout>
       <stdout>N: md_test4</stdout>
       <stdout>L: 100</stdout>
@@ -281,7 +281,7 @@
       <stdout>E: USEC_INITIALIZED=659580246</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/test5'</name>
+      <name>/usr/bin/udevadm info '/dev/md/test5'</name>
       <stdout>P: /devices/virtual/block/md_test5</stdout>
       <stdout>N: md_test5</stdout>
       <stdout>L: 100</stdout>
@@ -311,7 +311,7 @@
       <stdout>E: USEC_INITIALIZED=661988971</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md/test5p1'</name>
+      <name>/usr/bin/udevadm info '/dev/md/test5p1'</name>
       <stdout>P: /devices/virtual/block/md_test5/md_test5p1</stdout>
       <stdout>N: md_test5p1</stdout>
       <stdout>L: 100</stdout>
@@ -356,7 +356,7 @@
       <stdout>E: USEC_INITIALIZED=791898024</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md0'</name>
+      <name>/usr/bin/udevadm info '/dev/md0'</name>
       <stdout>P: /devices/virtual/block/md0</stdout>
       <stdout>N: md0</stdout>
       <stdout>L: 100</stdout>
@@ -388,7 +388,7 @@
       <stdout>E: USEC_INITIALIZED=634089904</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md1'</name>
+      <name>/usr/bin/udevadm info '/dev/md1'</name>
       <stdout>P: /devices/virtual/block/md1</stdout>
       <stdout>N: md1</stdout>
       <stdout>L: 100</stdout>
@@ -416,7 +416,7 @@
       <stdout>E: USEC_INITIALIZED=637189492</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md126p1'</name>
+      <name>/usr/bin/udevadm info '/dev/md126p1'</name>
       <stdout>P: /devices/virtual/block/md126/md126p1</stdout>
       <stdout>N: md126p1</stdout>
       <stdout>L: 100</stdout>
@@ -461,7 +461,7 @@
       <stdout>E: USEC_INITIALIZED=789644385</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md127'</name>
+      <name>/usr/bin/udevadm info '/dev/md127'</name>
       <stdout>P: /devices/virtual/block/md127</stdout>
       <stdout>N: md127</stdout>
       <stdout>L: 100</stdout>
@@ -495,7 +495,7 @@
       <stdout>E: USEC_INITIALIZED=639629673</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md1p1'</name>
+      <name>/usr/bin/udevadm info '/dev/md1p1'</name>
       <stdout>P: /devices/virtual/block/md1/md1p1</stdout>
       <stdout>N: md1p1</stdout>
       <stdout>L: 100</stdout>
@@ -538,7 +538,7 @@
       <stdout>E: USEC_INITIALIZED=748610962</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/md_test5p1'</name>
+      <name>/usr/bin/udevadm info '/dev/md_test5p1'</name>
       <stdout>P: /devices/virtual/block/md_test5/md_test5p1</stdout>
       <stdout>N: md_test5p1</stdout>
       <stdout>L: 100</stdout>
@@ -583,7 +583,7 @@
       <stdout>E: USEC_INITIALIZED=791898024</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB117fcb28-1410b7be</stdout>
@@ -633,7 +633,7 @@
       <stdout>E: USEC_INITIALIZED=6940780</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB117fcb28-1410b7be-part1</stdout>
@@ -703,7 +703,7 @@
       <stdout>E: USEC_INITIALIZED=7003120</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB117fcb28-1410b7be-part2</stdout>
@@ -765,7 +765,7 @@
       <stdout>E: USEC_INITIALIZED=6973185</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda3'</name>
+      <name>/usr/bin/udevadm info '/dev/sda3'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda3</stdout>
       <stdout>N: sda3</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB117fcb28-1410b7be-part3</stdout>
@@ -833,7 +833,7 @@
       <stdout>E: USEC_INITIALIZED=7136807</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c</stdout>
@@ -883,7 +883,7 @@
       <stdout>E: USEC_INITIALIZED=6947357</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb1</stdout>
       <stdout>N: sdb1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c-part1</stdout>
@@ -954,7 +954,7 @@
       <stdout>E: USEC_INITIALIZED=601691958</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb10'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb10'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb10</stdout>
       <stdout>N: sdb10</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c-part10</stdout>
@@ -1015,7 +1015,7 @@
       <stdout>E: USEC_INITIALIZED=623227513</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb11'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb11'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb11</stdout>
       <stdout>N: sdb11</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c-part11</stdout>
@@ -1085,7 +1085,7 @@
       <stdout>E: USEC_INITIALIZED=626040372</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb12'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb12'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb12</stdout>
       <stdout>N: sdb12</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c-part12</stdout>
@@ -1155,7 +1155,7 @@
       <stdout>E: USEC_INITIALIZED=628300940</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb2</stdout>
       <stdout>N: sdb2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c-part2</stdout>
@@ -1216,7 +1216,7 @@
       <stdout>E: USEC_INITIALIZED=605636281</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb3'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb3'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb3</stdout>
       <stdout>N: sdb3</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c-part3</stdout>
@@ -1286,7 +1286,7 @@
       <stdout>E: USEC_INITIALIZED=608343396</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb4'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb4'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb4</stdout>
       <stdout>N: sdb4</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c-part4</stdout>
@@ -1356,7 +1356,7 @@
       <stdout>E: USEC_INITIALIZED=610323782</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb5'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb5'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb5</stdout>
       <stdout>N: sdb5</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c-part5</stdout>
@@ -1426,7 +1426,7 @@
       <stdout>E: USEC_INITIALIZED=612369535</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb6'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb6'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb6</stdout>
       <stdout>N: sdb6</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c-part6</stdout>
@@ -1496,7 +1496,7 @@
       <stdout>E: USEC_INITIALIZED=614603471</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb7'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb7'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb7</stdout>
       <stdout>N: sdb7</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c-part7</stdout>
@@ -1566,7 +1566,7 @@
       <stdout>E: USEC_INITIALIZED=616847139</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb8'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb8'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb8</stdout>
       <stdout>N: sdb8</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c-part8</stdout>
@@ -1636,7 +1636,7 @@
       <stdout>E: USEC_INITIALIZED=618971760</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb9'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb9'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb/sdb9</stdout>
       <stdout>N: sdb9</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VBcc916f5f-e2309f1c-part9</stdout>
@@ -1706,7 +1706,7 @@
       <stdout>E: USEC_INITIALIZED=621194509</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata5/host4/target4:0:0/4:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -1772,7 +1772,7 @@
       <stdout>E: USEC_INITIALIZED=6985474</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/multi-mount-point-mockup1.xml
+++ b/testsuite/probe/multi-mount-point-mockup1.xml
@@ -17,7 +17,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2</stdout>
@@ -66,7 +66,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2-part1</stdout>
@@ -128,7 +128,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2-part2</stdout>
@@ -192,7 +192,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB43911086-715441bd</stdout>
@@ -248,7 +248,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata4/host3/target3:0:0/3:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -317,7 +317,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/multi-mount-point-mockup2.xml
+++ b/testsuite/probe/multi-mount-point-mockup2.xml
@@ -17,7 +17,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2</stdout>
@@ -66,7 +66,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2-part1</stdout>
@@ -128,7 +128,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2-part2</stdout>
@@ -192,7 +192,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB43911086-715441bd</stdout>
@@ -248,7 +248,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata4/host3/target3:0:0/3:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -317,7 +317,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/multi-mount-point-mockup3.xml
+++ b/testsuite/probe/multi-mount-point-mockup3.xml
@@ -17,7 +17,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2</stdout>
@@ -66,7 +66,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2-part1</stdout>
@@ -128,7 +128,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2-part2</stdout>
@@ -192,7 +192,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB43911086-715441bd</stdout>
@@ -248,7 +248,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata4/host3/target3:0:0/3:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -317,7 +317,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/multi-mount-point-mockup4.xml
+++ b/testsuite/probe/multi-mount-point-mockup4.xml
@@ -17,7 +17,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2</stdout>
@@ -66,7 +66,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2-part1</stdout>
@@ -128,7 +128,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB3b96ac9d-f9f14bd2-part2</stdout>
@@ -192,7 +192,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/ata-VBOX_HARDDISK_VB43911086-715441bd</stdout>
@@ -248,7 +248,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sr0'</name>
+      <name>/usr/bin/udevadm info '/dev/sr0'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1f.1/ata4/host3/target3:0:0/3:0:0:0/block/sr0</stdout>
       <stdout>N: sr0</stdout>
       <stdout>L: -100</stdout>
@@ -317,7 +317,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/multipath+luks1-mockup.xml
+++ b/testsuite/probe/multipath+luks1-mockup.xml
@@ -128,7 +128,7 @@
       <stdout>  `- 0:0:1:1085554707 sdc 8:32 active ready running</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasda'</name>
+      <name>/usr/bin/udevadm info '/dev/dasda'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasda</stdout>
       <stdout>N: dasda</stdout>
       <stdout>S: disk/by-id/ccw-0X0150</stdout>
@@ -153,7 +153,7 @@
       <stdout>E: USEC_INITIALIZED=2583927</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasda1'</name>
+      <name>/usr/bin/udevadm info '/dev/dasda1'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasda/dasda1</stdout>
       <stdout>N: dasda1</stdout>
       <stdout>S: disk/by-id/ccw-0X0150-part1</stdout>
@@ -185,7 +185,7 @@
       <stdout>E: USEC_INITIALIZED=2601208</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasda2'</name>
+      <name>/usr/bin/udevadm info '/dev/dasda2'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasda/dasda2</stdout>
       <stdout>N: dasda2</stdout>
       <stdout>S: disk/by-id/ccw-0X0150-part2</stdout>
@@ -217,7 +217,7 @@
       <stdout>E: USEC_INITIALIZED=2685096</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasda3'</name>
+      <name>/usr/bin/udevadm info '/dev/dasda3'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasda/dasda3</stdout>
       <stdout>N: dasda3</stdout>
       <stdout>S: disk/by-id/ccw-0X0150-part3</stdout>
@@ -249,7 +249,7 @@
       <stdout>E: USEC_INITIALIZED=2696227</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/36005076305ffc73a00000000000013b4'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/36005076305ffc73a00000000000013b4'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>L: 50</stdout>
@@ -282,7 +282,7 @@
       <stdout>E: USEC_INITIALIZED=1198639029</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/36005076305ffc73a00000000000013b4-part1'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/36005076305ffc73a00000000000013b4-part1'</name>
       <stdout>P: /devices/virtual/block/dm-1</stdout>
       <stdout>N: dm-1</stdout>
       <stdout>L: 50</stdout>
@@ -327,7 +327,7 @@
       <stdout>E: USEC_INITIALIZED=1288006334</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/36005076305ffc73a00000000000013b5'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/36005076305ffc73a00000000000013b5'</name>
       <stdout>P: /devices/virtual/block/dm-3</stdout>
       <stdout>N: dm-3</stdout>
       <stdout>L: 50</stdout>
@@ -364,7 +364,7 @@
       <stdout>E: USEC_INITIALIZED=284532536146</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/cr-test1'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/cr-test1'</name>
       <stdout>P: /devices/virtual/block/dm-2</stdout>
       <stdout>N: dm-2</stdout>
       <stdout>S: disk/by-id/dm-name-cr-test1</stdout>
@@ -394,7 +394,7 @@
       <stdout>E: USEC_INITIALIZED=333255756088</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/cr-test2'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/cr-test2'</name>
       <stdout>P: /devices/virtual/block/dm-4</stdout>
       <stdout>N: dm-4</stdout>
       <stdout>S: disk/by-id/dm-name-cr-test2</stdout>
@@ -424,7 +424,7 @@
       <stdout>E: USEC_INITIALIZED=333264943794</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fc00/host0/rport-0:0-0/target0:0:0/0:0:0:1085554707/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/scsi-36005076305ffc73a00000000000013b4</stdout>
@@ -478,12 +478,12 @@
     </Command>
     <Command>
       <!-- output faked and incomplete -->
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fc00/host0/rport-0:0-0/target0:0:0/0:0:0:1085554707/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fc00/host0/rport-0:0-0/target0:0:0/0:0:0:1085620243/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/scsi-36005076305ffc73a00000000000013b5</stdout>
@@ -534,7 +534,7 @@
       <stdout>E: USEC_INITIALIZED=1091495019</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fc00/host0/rport-0:0-1/target0:0:1/0:0:1:1085554707/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>S: disk/by-id/scsi-36005076305ffc73a00000000000013b4</stdout>
@@ -588,12 +588,12 @@
     </Command>
     <Command>
       <!-- output faked and incomplete -->
-      <name>/sbin/udevadm info '/dev/sdc1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc1'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fc00/host0/rport-0:0-1/target0:0:1/0:0:1:1085554707/block/sdc/sdc1</stdout>
       <stdout>N: sdc1</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdd'</name>
+      <name>/usr/bin/udevadm info '/dev/sdd'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fc00/host0/rport-0:0-1/target0:0:1/0:0:1:1085620243/block/sdd</stdout>
       <stdout>N: sdd</stdout>
       <stdout>S: disk/by-id/scsi-36005076305ffc73a00000000000013b5</stdout>
@@ -644,7 +644,7 @@
       <stdout>E: USEC_INITIALIZED=1091495024</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/multipath1-mockup.xml
+++ b/testsuite/probe/multipath1-mockup.xml
@@ -95,7 +95,7 @@
       <stdout>  `- 0:0:1:1085554707 sdc 8:32 active ready running</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasdb'</name>
+      <name>/usr/bin/udevadm info '/dev/dasdb'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasdb</stdout>
       <stdout>N: dasdb</stdout>
       <stdout>S: disk/by-id/ccw-0X0150</stdout>
@@ -122,8 +122,8 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasdb1'</name>
-      <name>/sbin/udevadm info '/dev/disk/by-path/ccw-0.0.0150-part1'</name>
+      <name>/usr/bin/udevadm info '/dev/dasdb1'</name>
+      <name>/usr/bin/udevadm info '/dev/disk/by-path/ccw-0.0.0150-part1'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasdb/dasdb1</stdout>
       <stdout>N: dasdb1</stdout>
       <stdout>S: disk/by-id/ccw-0X0150-part1</stdout>
@@ -157,8 +157,8 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasdb2'</name>
-      <name>/sbin/udevadm info '/dev/disk/by-path/ccw-0.0.0150-part2'</name>
+      <name>/usr/bin/udevadm info '/dev/dasdb2'</name>
+      <name>/usr/bin/udevadm info '/dev/disk/by-path/ccw-0.0.0150-part2'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasdb/dasdb2</stdout>
       <stdout>N: dasdb2</stdout>
       <stdout>S: disk/by-id/ccw-0X0150-part2</stdout>
@@ -192,8 +192,8 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/dasdb3'</name>
-      <name>/sbin/udevadm info '/dev/disk/by-path/ccw-0.0.0150-part3'</name>
+      <name>/usr/bin/udevadm info '/dev/dasdb3'</name>
+      <name>/usr/bin/udevadm info '/dev/disk/by-path/ccw-0.0.0150-part3'</name>
       <stdout>P: /devices/css0/0.0.0003/0.0.0150/block/dasdb/dasdb3</stdout>
       <stdout>N: dasdb3</stdout>
       <stdout>S: disk/by-id/ccw-0X0150-part3</stdout>
@@ -228,7 +228,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/36005076305ffc73a00000000000013b4'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/36005076305ffc73a00000000000013b4'</name>
       <stdout>P: /devices/virtual/block/dm-0</stdout>
       <stdout>N: dm-0</stdout>
       <stdout>L: 50</stdout>
@@ -268,7 +268,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/36005076305ffc73a00000000000013b4-part1'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/36005076305ffc73a00000000000013b4-part1'</name>
       <stdout>P: /devices/virtual/block/dm-1</stdout>
       <stdout>N: dm-1</stdout>
       <stdout>L: 50</stdout>
@@ -326,7 +326,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/36005076305ffc73a00000000000013b5'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/36005076305ffc73a00000000000013b5'</name>
       <stdout>P: /devices/virtual/block/dm-3</stdout>
       <stdout>N: dm-3</stdout>
       <stdout>L: 50</stdout>
@@ -370,7 +370,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sda'</name>
+      <name>/usr/bin/udevadm info '/dev/sda'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fa00/host0/rport-0:0-0/target0:0:0/0:0:0:1085554707/block/sda</stdout>
       <stdout>N: sda</stdout>
       <stdout>S: disk/by-id/scsi-36005076305ffc73a00000000000013b4</stdout>
@@ -423,18 +423,18 @@
     </Command>
     <Command>
       <!-- output faked and incomplete -->
-      <name>/sbin/udevadm info '/dev/sda1'</name>
+      <name>/usr/bin/udevadm info '/dev/sda1'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fa00/host0/rport-0:0-0/target0:0:0/0:0:0:1085554707/block/sda/sda1</stdout>
       <stdout>N: sda1</stdout>
     </Command>
     <Command>
       <!-- output faked and incomplete -->
-      <name>/sbin/udevadm info '/dev/sda2'</name>
+      <name>/usr/bin/udevadm info '/dev/sda2'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fa00/host0/rport-0:0-0/target0:0:0/0:0:0:1085554707/block/sda/sda2</stdout>
       <stdout>N: sda2</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdb'</name>
+      <name>/usr/bin/udevadm info '/dev/sdb'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fa00/host0/rport-0:0-0/target0:0:0/0:0:0:1085620243/block/sdb</stdout>
       <stdout>N: sdb</stdout>
       <stdout>S: disk/by-id/scsi-36005076305ffc73a00000000000013b5</stdout>
@@ -486,7 +486,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fa00/host0/rport-0:0-1/target0:0:1/0:0:1:1085554707/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>S: disk/by-id/scsi-36005076305ffc73a00000000000013b4</stdout>
@@ -539,18 +539,18 @@
     </Command>
     <Command>
       <!-- output faked and incomplete -->
-      <name>/sbin/udevadm info '/dev/sdc1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc1'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fa00/host0/rport-0:0-1/target0:0:1/0:0:1:1085554707/block/sdc/sdc1</stdout>
       <stdout>N: sdc1</stdout>
     </Command>
     <Command>
       <!-- output faked and incomplete -->
-      <name>/sbin/udevadm info '/dev/sdc2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc2'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fa00/host0/rport-0:0-1/target0:0:1/0:0:1:1085554707/block/sdc/sdc2</stdout>
       <stdout>N: sdc2</stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdd'</name>
+      <name>/usr/bin/udevadm info '/dev/sdd'</name>
       <stdout>P: /devices/css0/0.0.0008/0.0.fa00/host0/rport-0:0-1/target0:0:1/0:0:1:1085620243/block/sdd</stdout>
       <stdout>N: sdd</stdout>
       <stdout>S: disk/by-id/scsi-36005076305ffc73a00000000000013b5</stdout>
@@ -602,7 +602,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/ntfs1-mockup.xml
+++ b/testsuite/probe/ntfs1-mockup.xml
@@ -25,7 +25,7 @@
       <name>/sbin/multipath -d -v 2 -ll</name>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.6/1-1.6:1.0/host7/target7:0:0/7:0:0:0/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>S: disk/by-id/usb-WD_My_Passport_25E2_575842314436354C33384445-0:0</stdout>
@@ -72,7 +72,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.6/1-1.6:1.0/host7/target7:0:0/7:0:0:0/block/sdc/sdc1</stdout>
       <stdout>N: sdc1</stdout>
       <stdout>S: disk/by-id/usb-WD_My_Passport_25E2_575842314436354C33384445-0:0-part1</stdout>
@@ -132,7 +132,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.6/1-1.6:1.0/host7/target7:0:0/7:0:0:0/block/sdc/sdc2</stdout>
       <stdout>N: sdc2</stdout>
       <stdout>S: disk/by-id/usb-WD_My_Passport_25E2_575842314436354C33384445-0:0-part2</stdout>
@@ -192,7 +192,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc3'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc3'</name>
       <stdout>P: /devices/pci0000:00/0000:00:1a.0/usb1/1-1/1-1.6/1-1.6:1.0/host7/target7:0:0/7:0:0:0/block/sdc/sdc3</stdout>
       <stdout>N: sdc3</stdout>
       <stdout>S: disk/by-id/usb-WD_My_Passport_25E2_575842314436354C33384445-0:0-part3</stdout>
@@ -252,7 +252,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/plain-encryption1-mockup.xml
+++ b/testsuite/probe/plain-encryption1-mockup.xml
@@ -31,7 +31,7 @@
       <name>/sbin/multipath -d -v 2 -ll</name>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/cr-test3'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/cr-test3'</name>
       <stdout>P: /devices/virtual/block/dm-7</stdout>
       <stdout>N: dm-7</stdout>
       <stdout>L: 0</stdout>
@@ -62,7 +62,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/mapper/cr-test4'</name>
+      <name>/usr/bin/udevadm info '/dev/mapper/cr-test4'</name>
       <stdout>P: /devices/virtual/block/dm-8</stdout>
       <stdout>N: dm-8</stdout>
       <stdout>L: 0</stdout>
@@ -93,7 +93,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc</stdout>
       <stdout>N: sdc</stdout>
       <stdout>L: 0</stdout>
@@ -144,7 +144,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc1'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc1'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc/sdc1</stdout>
       <stdout>N: sdc1</stdout>
       <stdout>L: 0</stdout>
@@ -203,7 +203,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc2'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc2'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc/sdc2</stdout>
       <stdout>N: sdc2</stdout>
       <stdout>L: 0</stdout>
@@ -262,7 +262,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc3'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc3'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc/sdc3</stdout>
       <stdout>N: sdc3</stdout>
       <stdout>L: 0</stdout>
@@ -321,7 +321,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/sdc4'</name>
+      <name>/usr/bin/udevadm info '/dev/sdc4'</name>
       <stdout>P: /devices/pci0000:00/0000:00:14.0/usb2/2-7/2-7:1.0/host8/target8:0:0/8:0:0:0/block/sdc/sdc4</stdout>
       <stdout>N: sdc4</stdout>
       <stdout>L: 0</stdout>
@@ -380,7 +380,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>

--- a/testsuite/probe/xen1-mockup.xml
+++ b/testsuite/probe/xen1-mockup.xml
@@ -100,7 +100,7 @@
       <name>/sbin/multipath -d -v 2 -ll</name>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop0'</name>
+      <name>/usr/bin/udevadm info '/dev/loop0'</name>
       <stdout>P: /devices/virtual/block/loop0</stdout>
       <stdout>N: loop0</stdout>
       <stdout>E: DEVNAME=/dev/loop0</stdout>
@@ -117,7 +117,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop1'</name>
+      <name>/usr/bin/udevadm info '/dev/loop1'</name>
       <stdout>P: /devices/virtual/block/loop1</stdout>
       <stdout>N: loop1</stdout>
       <stdout>E: DEVNAME=/dev/loop1</stdout>
@@ -134,7 +134,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop2'</name>
+      <name>/usr/bin/udevadm info '/dev/loop2'</name>
       <stdout>P: /devices/virtual/block/loop2</stdout>
       <stdout>N: loop2</stdout>
       <stdout>E: DEVNAME=/dev/loop2</stdout>
@@ -151,7 +151,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop3'</name>
+      <name>/usr/bin/udevadm info '/dev/loop3'</name>
       <stdout>P: /devices/virtual/block/loop3</stdout>
       <stdout>N: loop3</stdout>
       <stdout>E: DEVNAME=/dev/loop3</stdout>
@@ -168,7 +168,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop4'</name>
+      <name>/usr/bin/udevadm info '/dev/loop4'</name>
       <stdout>P: /devices/virtual/block/loop4</stdout>
       <stdout>N: loop4</stdout>
       <stdout>E: DEVNAME=/dev/loop4</stdout>
@@ -185,7 +185,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop5'</name>
+      <name>/usr/bin/udevadm info '/dev/loop5'</name>
       <stdout>P: /devices/virtual/block/loop5</stdout>
       <stdout>N: loop5</stdout>
       <stdout>E: DEVNAME=/dev/loop5</stdout>
@@ -202,7 +202,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/loop6'</name>
+      <name>/usr/bin/udevadm info '/dev/loop6'</name>
       <stdout>P: /devices/virtual/block/loop6</stdout>
       <stdout>N: loop6</stdout>
       <stdout>E: DEVNAME=/dev/loop6</stdout>
@@ -219,7 +219,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/xvda'</name>
+      <name>/usr/bin/udevadm info '/dev/xvda'</name>
       <stdout>P: /devices/vbd-51712/block/xvda</stdout>
       <stdout>N: xvda</stdout>
       <stdout>S: disk/by-label/SLE-15-Installer-DVD-x86_646.001</stdout>
@@ -251,7 +251,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/xvda1'</name>
+      <name>/usr/bin/udevadm info '/dev/xvda1'</name>
       <stdout>P: /devices/vbd-51712/block/xvda/xvda1</stdout>
       <stdout>N: xvda1</stdout>
       <stdout>S: disk/by-label/SLE-15-Installer-DVD-x86_646.001</stdout>
@@ -292,7 +292,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/xvda2'</name>
+      <name>/usr/bin/udevadm info '/dev/xvda2'</name>
       <stdout>P: /devices/vbd-51712/block/xvda/xvda2</stdout>
       <stdout>N: xvda2</stdout>
       <stdout>S: disk/by-label/SLE-15-Installer-DVD-x86_646.001</stdout>
@@ -334,7 +334,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/xvdb'</name>
+      <name>/usr/bin/udevadm info '/dev/xvdb'</name>
       <stdout>P: /devices/vbd-51728/block/xvdb</stdout>
       <stdout>N: xvdb</stdout>
       <stdout>E: DEVNAME=/dev/xvdb</stdout>
@@ -351,7 +351,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/xvdb1'</name>
+      <name>/usr/bin/udevadm info '/dev/xvdb1'</name>
       <stdout>P: /devices/vbd-51728/block/xvdb/xvdb1</stdout>
       <stdout>N: xvdb1</stdout>
       <stdout>S: disk/by-partuuid/52d26b49-cad2-4092-8f0a-0310da915ae5</stdout>
@@ -384,7 +384,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/xvdb2'</name>
+      <name>/usr/bin/udevadm info '/dev/xvdb2'</name>
       <stdout>P: /devices/vbd-51728/block/xvdb/xvdb2</stdout>
       <stdout>N: xvdb2</stdout>
       <stdout>S: disk/by-partuuid/39982024-ea34-42ca-bab1-347932a878ce</stdout>
@@ -417,7 +417,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm info '/dev/xvdc1'</name>
+      <name>/usr/bin/udevadm info '/dev/xvdc1'</name>
       <stdout>P: /devices/vbd-51745/block/xvdc1</stdout>
       <stdout>N: xvdc1</stdout>
       <stdout>S: disk/by-uuid/7608bc33-8dfd-4ae0-8f38-e5923deb9631</stdout>
@@ -438,7 +438,7 @@
       <stdout></stdout>
     </Command>
     <Command>
-      <name>/sbin/udevadm settle --timeout=20</name>
+      <name>/usr/bin/udevadm settle --timeout=20</name>
     </Command>
     <Command>
       <name>/usr/bin/getconf PAGESIZE</name>


### PR DESCRIPTION
The bigger part of this PR is to use udevadm from /usr/bin instead of /sbin since the latter disappears.
The smaller part of this PR is to remove the option to enable crc from XFS from mkfs.xfs since it is the default for years anyway.