### PR TITLE
track device block size when creating an Md RAID (bsc#1164295)

### DIFF
--- a/bindings/storage-catches.i
+++ b/bindings/storage-catches.i
@@ -311,6 +311,7 @@
 %catches(storage::Exception) storage::Partitionable::get_default_partition_table_type() const;
 %catches(storage::WrongNumberOfChildren, storage::DeviceHasWrongType) storage::Partitionable::get_partition_table();
 %catches(storage::WrongNumberOfChildren, storage::DeviceHasWrongType) storage::Partitionable::get_partition_table() const;
+%catches(storage::InvalidBlockSize) storage::Region::adjust_block_size(unsigned int block_size);
 %catches(storage::Exception) storage::Region::adjust_length(long long delta);
 %catches(storage::Exception) storage::Region::adjust_start(long long delta);
 %catches(storage::Exception) storage::Region::get_end() const;

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -830,9 +830,13 @@ namespace storage
 	unsigned long long sum = 0;
 	unsigned long long smallest = std::numeric_limits<unsigned long long>::max();
 
+	unsigned int block_size = 0;
+
 	for (const BlkDevice* blk_device : devices)
 	{
 	    unsigned long long size = blk_device->get_size();
+
+	    block_size = std::max( block_size, blk_device->get_region().get_block_size() );
 
 	    const MdUser* md_user = blk_device->get_impl().get_single_out_holder_of_type<const MdUser>();
 	    bool spare = md_user->is_spare();
@@ -913,6 +917,14 @@ namespace storage
 	    case MdLevel::CONTAINER:
 	    case MdLevel::UNKNOWN:
 		break;
+	}
+
+	// adjust block size
+	if (block_size && block_size != get_region().get_block_size())
+	{
+	    Region region(get_region());
+	    region.adjust_block_size(block_size);
+	    set_region(region);
 	}
 
 	set_size(size);

--- a/storage/Utils/Region.cc
+++ b/storage/Utils/Region.cc
@@ -167,6 +167,13 @@ namespace storage
     }
 
 
+    void
+    Region::adjust_block_size(unsigned int block_size)
+    {
+	get_impl().adjust_block_size(block_size);
+    }
+
+
     unsigned long long
     Region::to_bytes(unsigned long long blocks) const
     {

--- a/storage/Utils/Region.h
+++ b/storage/Utils/Region.h
@@ -130,6 +130,13 @@ namespace storage
 	unsigned int get_block_size() const;
 	void set_block_size(unsigned int block_size);
 
+	/**
+	 * Adjusts the block size while keeping the region's sizes (in bytes).
+	 *
+	 * @throw Exception
+	 */
+	void adjust_block_size(unsigned int block_size);
+
 	unsigned long long to_bytes(unsigned long long blocks) const;
 	unsigned long long to_blocks(unsigned long long bytes) const;
 

--- a/storage/Utils/RegionImpl.cc
+++ b/storage/Utils/RegionImpl.cc
@@ -107,6 +107,27 @@ namespace storage
     }
 
 
+    void
+    Region::Impl::adjust_block_size(unsigned int block_size)
+    {
+	assert_valid_block_size(block_size);
+
+	if (block_size == Impl::block_size)
+	    return;
+
+	if (start * Impl::block_size % block_size ||
+	    length * Impl::block_size % block_size)
+	{
+	    ST_THROW(InvalidBlockSize(block_size));
+	}
+
+	start = start * Impl::block_size / block_size;
+	length = length * Impl::block_size / block_size;
+
+	Impl::block_size = block_size;
+    }
+
+
     unsigned long long
     Region::Impl::to_bytes(unsigned long long blocks) const
     {

--- a/storage/Utils/RegionImpl.h
+++ b/storage/Utils/RegionImpl.h
@@ -55,6 +55,7 @@ namespace storage
 
 	unsigned int get_block_size() const { return block_size; }
 	void set_block_size(unsigned int block_size);
+	void adjust_block_size(unsigned int block_size);
 
 	unsigned long long to_bytes(unsigned long long blocks) const;
 	unsigned long long to_blocks(unsigned long long bytes) const;

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -16,9 +16,9 @@ check_PROGRAMS =								\
 	dynamic.test ensure-mounted.test environment.test find-vertex.test	\
 	fstab.test crypttab.test output.test probe.test range.test stable.test	\
 	relatives.test mount-opts.test etc-mdadm.test mount-by.test btrfs.test	\
-	md1.test md2.test md3.test md4.test encryption1.test encryption2.test	\
-	lvm1.test lvm-pv-usable-size.test graphviz.test copy-individual.test	\
-	mountpoint.test bcache1.test
+	md1.test md2.test md3.test md4.test md5.test encryption1.test		\
+	encryption2.test lvm1.test lvm-pv-usable-size.test graphviz.test	\
+	copy-individual.test mountpoint.test bcache1.test
 
 AM_DEFAULT_SOURCE_EXT = .cc
 

--- a/testsuite/Utils/region.cc
+++ b/testsuite/Utils/region.cc
@@ -355,3 +355,25 @@ BOOST_AUTO_TEST_CASE(test_unused_regions9)
     BOOST_CHECK_EQUAL(unused_regions[1].get_start(), 80);
     BOOST_CHECK_EQUAL(unused_regions[1].get_length(), 20);
 }
+
+
+BOOST_AUTO_TEST_CASE(test_adjust_block_size1)
+{
+    Region r(100, 1000, 10);
+
+    r.adjust_block_size(20);
+
+    BOOST_CHECK_EQUAL(r.get_start(), 50);
+    BOOST_CHECK_EQUAL(r.get_length(), 500);
+    BOOST_CHECK_EQUAL(r.get_block_size(), 20);
+}
+
+
+BOOST_AUTO_TEST_CASE(test_adjust_block_size2)
+{
+    Region r1(100, 1000, 10);
+    Region r2(200, 1100, 10);
+
+    BOOST_CHECK_THROW(r1.adjust_block_size(2000), InvalidBlockSize);
+    BOOST_CHECK_THROW(r2.adjust_block_size(2000), InvalidBlockSize);
+}

--- a/testsuite/md5.cc
+++ b/testsuite/md5.cc
@@ -1,0 +1,50 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE libstorage
+
+#include <boost/test/unit_test.hpp>
+
+#include "storage/Devices/Disk.h"
+#include "storage/Devices/Md.h"
+#include "storage/Devicegraph.h"
+#include "storage/Storage.h"
+#include "storage/Environment.h"
+
+
+using namespace std;
+using namespace storage;
+
+
+BOOST_AUTO_TEST_CASE(adjust_block_size)
+{
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+
+    Storage storage(environment);
+
+    Devicegraph* staging = storage.get_staging();
+
+    Disk* sda = Disk::create(staging, "/dev/sda", Region(0, 10000000, 1024));
+    Disk* sdb = Disk::create(staging, "/dev/sdb", Region(0, 10000000, 512));
+    Disk* sdc = Disk::create(staging, "/dev/sdc", Region(0, 10000000, 4096));
+
+    Md* md0 = Md::create(staging, "/dev/md0");
+    md0->set_md_level(MdLevel::RAID0);
+
+    BOOST_CHECK_EQUAL(md0->get_region().get_block_size(), 512);
+
+    md0->add_device(sda);
+
+    BOOST_CHECK_EQUAL(md0->get_region().get_block_size(), 1024);
+
+    md0->add_device(sdb);
+
+    BOOST_CHECK_EQUAL(md0->get_region().get_block_size(), 1024);
+
+    md0->add_device(sdc);
+
+    BOOST_CHECK_EQUAL(md0->get_region().get_block_size(), 4096);
+
+    md0->remove_device(sdc);
+
+    BOOST_CHECK_EQUAL(md0->get_region().get_block_size(), 1024);
+}


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1164295
- https://trello.com/c/NIIfPuhi

A newly created RAID has the default block size of 512 bytes. But this might be wrong if the
devices it constitutes of have different sizes.

## Solution

When adding devices to a RAID, adjust RAID block size to the maximum block size of its disk devices.

## Notes

- there seems to be no documentation about this anywhere
- it was tested with different RAIDs and various setups - and the behavior is consistent
- mdadm will not complain about misaligned setups like range starts and sizes that can't be represented with the final block size - you get i/o errors from the kernel when accessing that device later
- it seems everyone just expects the admin to do the sensible thing - so I would not overengineer this on our side
- if there's need to investigate mdadm behavior more deeply (like do we really need to waste 128 MiB) I would go for a separate research PBI