### PR TITLE
simplify combining disks with different block sizes into RAID (bsc#1164295)

### DIFF
--- a/bindings/storage-catches.i
+++ b/bindings/storage-catches.i
@@ -311,7 +311,6 @@
 %catches(storage::Exception) storage::Partitionable::get_default_partition_table_type() const;
 %catches(storage::WrongNumberOfChildren, storage::DeviceHasWrongType) storage::Partitionable::get_partition_table();
 %catches(storage::WrongNumberOfChildren, storage::DeviceHasWrongType) storage::Partitionable::get_partition_table() const;
-%catches(storage::InvalidBlockSize) storage::Region::adjust_block_size(unsigned int block_size);
 %catches(storage::Exception) storage::Region::adjust_length(long long delta);
 %catches(storage::Exception) storage::Region::adjust_start(long long delta);
 %catches(storage::Exception) storage::Region::get_end() const;

--- a/doc/md-raid.md
+++ b/doc/md-raid.md
@@ -94,12 +94,9 @@ Combining disks with different block sizes
 If you combine disks with different block sizes into a RAID, the RAID device
 will have the maximum block size of its disks.
 
-This seems to work (at least most of the time) even if some parts of the
-RAID are not aligned to this block size.
+This seems to work even if some parts of the RAID are not aligned to this
+block size.
 
 Md::add_device() takes care to update Md::Region to use the correct block
-size. It is, however not possible to combine regions with different block
-sizes (in libstorage-ng) if the start or length of a region are misaligned.
-
-This is, however, not really a problem here as the region start is always 0
-and the RAID size is an approximation anyway - so we might simply round down.
+size. The RAID size estimation in Md::add_device() will be further rounded
+down to align with the maximum block size if needed.

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -921,13 +921,8 @@ namespace storage
 		break;
 	}
 
-	// adjust block size
 	if (block_size && block_size != get_region().get_block_size())
-	{
-	    Region region(get_region());
-	    region.adjust_block_size(block_size);
-	    set_region(region);
-	}
+	    set_region(Region(0, 0, block_size));
 
 	set_size(size);
 	set_topology(Topology(0, optimal_io_size));

--- a/storage/Utils/Region.cc
+++ b/storage/Utils/Region.cc
@@ -167,13 +167,6 @@ namespace storage
     }
 
 
-    void
-    Region::adjust_block_size(unsigned int block_size)
-    {
-	get_impl().adjust_block_size(block_size);
-    }
-
-
     unsigned long long
     Region::to_bytes(unsigned long long blocks) const
     {

--- a/storage/Utils/Region.h
+++ b/storage/Utils/Region.h
@@ -130,13 +130,6 @@ namespace storage
 	unsigned int get_block_size() const;
 	void set_block_size(unsigned int block_size);
 
-	/**
-	 * Adjusts the block size while keeping the region's sizes (in bytes).
-	 *
-	 * @throw Exception
-	 */
-	void adjust_block_size(unsigned int block_size);
-
 	unsigned long long to_bytes(unsigned long long blocks) const;
 	unsigned long long to_blocks(unsigned long long bytes) const;
 

--- a/storage/Utils/RegionImpl.cc
+++ b/storage/Utils/RegionImpl.cc
@@ -107,27 +107,6 @@ namespace storage
     }
 
 
-    void
-    Region::Impl::adjust_block_size(unsigned int block_size)
-    {
-	assert_valid_block_size(block_size);
-
-	if (block_size == Impl::block_size)
-	    return;
-
-	if (start * Impl::block_size % block_size ||
-	    length * Impl::block_size % block_size)
-	{
-	    ST_THROW(InvalidBlockSize(block_size));
-	}
-
-	start = start * Impl::block_size / block_size;
-	length = length * Impl::block_size / block_size;
-
-	Impl::block_size = block_size;
-    }
-
-
     unsigned long long
     Region::Impl::to_bytes(unsigned long long blocks) const
     {

--- a/storage/Utils/RegionImpl.h
+++ b/storage/Utils/RegionImpl.h
@@ -55,7 +55,6 @@ namespace storage
 
 	unsigned int get_block_size() const { return block_size; }
 	void set_block_size(unsigned int block_size);
-	void adjust_block_size(unsigned int block_size);
 
 	unsigned long long to_bytes(unsigned long long blocks) const;
 	unsigned long long to_blocks(unsigned long long bytes) const;

--- a/testsuite/Utils/region.cc
+++ b/testsuite/Utils/region.cc
@@ -355,25 +355,3 @@ BOOST_AUTO_TEST_CASE(test_unused_regions9)
     BOOST_CHECK_EQUAL(unused_regions[1].get_start(), 80);
     BOOST_CHECK_EQUAL(unused_regions[1].get_length(), 20);
 }
-
-
-BOOST_AUTO_TEST_CASE(test_adjust_block_size1)
-{
-    Region r(100, 1000, 10);
-
-    r.adjust_block_size(20);
-
-    BOOST_CHECK_EQUAL(r.get_start(), 50);
-    BOOST_CHECK_EQUAL(r.get_length(), 500);
-    BOOST_CHECK_EQUAL(r.get_block_size(), 20);
-}
-
-
-BOOST_AUTO_TEST_CASE(test_adjust_block_size2)
-{
-    Region r1(100, 1000, 10);
-    Region r2(200, 1100, 10);
-
-    BOOST_CHECK_THROW(r1.adjust_block_size(2000), InvalidBlockSize);
-    BOOST_CHECK_THROW(r2.adjust_block_size(2000), InvalidBlockSize);
-}


### PR DESCRIPTION
## Problem

This is a follow-up of https://github.com/openSUSE/libstorage-ng/pull/709.

- the code now assumes you can always combine those disks

- `Regions::adjust_block_size()` is not needed anymore and can be removed again