### PR TITLE
track device block size when creating an Md RAID (bsc#1164295)

### DIFF
--- a/doc/md-raid.md
+++ b/doc/md-raid.md
@@ -94,12 +94,9 @@ Combining disks with different block sizes
 If you combine disks with different block sizes into a RAID, the RAID device
 will have the maximum block size of its disks.
 
-This seems to work (at least most of the time) even if some parts of the
-RAID are not aligned to this block size.
+This seems to work even if some parts of the RAID are not aligned to this
+block size.
 
 Md::add_device() takes care to update Md::Region to use the correct block
-size. It is, however not possible to combine regions with different block
-sizes (in libstorage-ng) if the start or length of a region are misaligned.
-
-This is, however, not really a problem here as the region start is always 0
-and the RAID size is an approximation anyway - so we might simply round down.
+size. The RAID size estimation in Md::add_device() will be further rounded
+down to align with the maximum block size if needed.

--- a/doc/md-raid.md
+++ b/doc/md-raid.md
@@ -88,3 +88,18 @@ MdMembers can be used as generic Mds.
 
 MdContainers and MdMembers can be added to and removed from /etc/mdadm.conf.
 
+Combining disks with different block sizes
+------------------------------------------
+
+If you combine disks with different block sizes into a RAID, the RAID device
+will have the maximum block size of its disks.
+
+This seems to work (at least most of the time) even if some parts of the
+RAID are not aligned to this block size.
+
+Md::add_device() takes care to update Md::Region to use the correct block
+size. It is, however not possible to combine regions with different block
+sizes (in libstorage-ng) if the start or length of a region are misaligned.
+
+This is, however, not really a problem here as the region start is always 0
+and the RAID size is an approximation anyway - so we might simply round down.

--- a/storage/Devices/Md.h
+++ b/storage/Devices/Md.h
@@ -72,6 +72,11 @@ namespace storage
 	static Md* load(Devicegraph* devicegraph, const xmlNode* node);
 
 	/**
+	 * Add another device to a RAID.
+	 *
+	 * For combining disks with different block sizes,
+	 * see doc/md-raid.md.
+	 *
 	 * @throw WrongNumberOfChildren
 	 */
 	MdUser* add_device(BlkDevice* blk_device);

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -916,13 +916,8 @@ namespace storage
 		break;
 	}
 
-	// adjust block size
 	if (block_size && block_size != get_region().get_block_size())
-	{
-	    Region region(get_region());
-	    region.adjust_block_size(block_size);
-	    set_region(region);
-	}
+	    set_region(Region(0, 0, block_size));
 
 	set_size(size);
 	set_topology(Topology(0, optimal_io_size));

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -827,9 +827,13 @@ namespace storage
 	unsigned long long sum = 0;
 	unsigned long long smallest = std::numeric_limits<unsigned long long>::max();
 
+	unsigned int block_size = 0;
+
 	for (const BlkDevice* blk_device : devices)
 	{
 	    unsigned long long size = blk_device->get_size();
+
+	    block_size = std::max( block_size, blk_device->get_region().get_block_size() );
 
 	    const MdUser* md_user = blk_device->get_impl().get_single_out_holder_of_type<const MdUser>();
 	    bool spare = md_user->is_spare();
@@ -910,6 +914,14 @@ namespace storage
 	    case MdLevel::CONTAINER:
 	    case MdLevel::UNKNOWN:
 		break;
+	}
+
+	// adjust block size
+	if (block_size && block_size != get_region().get_block_size())
+	{
+	    Region region(get_region());
+	    region.adjust_block_size(block_size);
+	    set_region(region);
 	}
 
 	set_size(size);

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -802,6 +802,8 @@ namespace storage
 	// big can lead to severe problems later on, e.g. a partition not
 	// fitting anymore, we make a conservative calculation.
 
+	// For combining disks with different block sizes, see doc/md-raid.md.
+
 	const bool conservative = true;
 
 	// Since our size calculation is not accurate we must not recalculate

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -16,9 +16,9 @@ check_PROGRAMS =								\
 	dynamic.test ensure-mounted.test environment.test find-vertex.test	\
 	fstab.test crypttab.test output.test probe.test range.test stable.test	\
 	relatives.test mount-opts.test etc-mdadm.test mount-by.test btrfs.test	\
-	md1.test md2.test md3.test md4.test encryption1.test encryption2.test	\
-	lvm1.test lvm-pv-usable-size.test graphviz.test copy-individual.test	\
-	mountpoint.test bcache1.test
+	md1.test md2.test md3.test md4.test md5.test encryption1.test		\
+	encryption2.test lvm1.test lvm-pv-usable-size.test graphviz.test	\
+	copy-individual.test mountpoint.test bcache1.test
 
 AM_DEFAULT_SOURCE_EXT = .cc
 

--- a/testsuite/md5.cc
+++ b/testsuite/md5.cc
@@ -1,0 +1,50 @@
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE libstorage
+
+#include <boost/test/unit_test.hpp>
+
+#include "storage/Devices/Disk.h"
+#include "storage/Devices/Md.h"
+#include "storage/Devicegraph.h"
+#include "storage/Storage.h"
+#include "storage/Environment.h"
+
+
+using namespace std;
+using namespace storage;
+
+
+BOOST_AUTO_TEST_CASE(adjust_block_size)
+{
+    Environment environment(true, ProbeMode::NONE, TargetMode::DIRECT);
+
+    Storage storage(environment);
+
+    Devicegraph* staging = storage.get_staging();
+
+    Disk* sda = Disk::create(staging, "/dev/sda", Region(0, 10000000, 1024));
+    Disk* sdb = Disk::create(staging, "/dev/sdb", Region(0, 10000000, 512));
+    Disk* sdc = Disk::create(staging, "/dev/sdc", Region(0, 10000000, 4096));
+
+    Md* md0 = Md::create(staging, "/dev/md0");
+    md0->set_md_level(MdLevel::RAID0);
+
+    BOOST_CHECK_EQUAL(md0->get_region().get_block_size(), 512);
+
+    md0->add_device(sda);
+
+    BOOST_CHECK_EQUAL(md0->get_region().get_block_size(), 1024);
+
+    md0->add_device(sdb);
+
+    BOOST_CHECK_EQUAL(md0->get_region().get_block_size(), 1024);
+
+    md0->add_device(sdc);
+
+    BOOST_CHECK_EQUAL(md0->get_region().get_block_size(), 4096);
+
+    md0->remove_device(sdc);
+
+    BOOST_CHECK_EQUAL(md0->get_region().get_block_size(), 1024);
+}


### PR DESCRIPTION
## Task

- https://trello.com/c/eixP9hzP
- https://bugzilla.suse.com/show_bug.cgi?id=1164295

Set RAID block size correctly when creating a RAID in libstorage-ng.

## See also

This is a backport of https://github.com/openSUSE/libstorage-ng/pull/709, https://github.com/openSUSE/libstorage-ng/pull/712, and https://github.com/openSUSE/libstorage-ng/pull/714 to SLE-15-SP1.