### PR TITLE
ignore clusterd VGs also in vgchange command (bsc#1161775)

### DIFF
--- a/storage/Devices/LvmLvImpl.cc
+++ b/storage/Devices/LvmLvImpl.cc
@@ -181,7 +181,7 @@ namespace storage
 
 	    try
 	    {
-		SystemCmd cmd(VGCHANGEBIN " --activate y", SystemCmd::DoThrow);
+		SystemCmd cmd(VGCHANGEBIN " --ignoreskippedcluster --activate y", SystemCmd::DoThrow);
 	    }
 	    catch (const Exception& exception)
 	    {
@@ -215,7 +215,7 @@ namespace storage
     {
 	y2mil("deactivate_lvm_lvs");
 
-	string cmd_line = VGCHANGEBIN " --activate n";
+	string cmd_line = VGCHANGEBIN " --ignoreskippedcluster --activate n";
 
 	SystemCmd cmd(cmd_line);
 


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1161775#c31
- https://trello.com/c/PB0cvnjU

There's still a warning popup when detecting clustered VGs.

## Solution

The `--ignoreskippedcluster` option is also needed in `vgchange`.