### PR TITLE
set default to false for in_etc_crypttab() (bsc#1118977)

### DIFF
--- a/storage/Devices/EncryptionImpl.cc
+++ b/storage/Devices/EncryptionImpl.cc
@@ -51,7 +51,7 @@ namespace storage
 
     Encryption::Impl::Impl(const string& dm_table_name)
 	: BlkDevice::Impl(DEV_MAPPER_DIR "/" + dm_table_name), type(EncryptionType::LUKS1), password(),
-	  key_file(), cipher(), key_size(0), mount_by(MountByType::DEVICE), in_etc_crypttab(true),
+	  key_file(), cipher(), key_size(0), mount_by(MountByType::DEVICE), in_etc_crypttab(false),
 	  open_options()
     {
 	set_dm_table_name(dm_table_name);
@@ -60,7 +60,7 @@ namespace storage
 
     Encryption::Impl::Impl(const xmlNode* node)
 	: BlkDevice::Impl(node), type(EncryptionType::LUKS1), password(), key_file(), cipher(),
-	  key_size(0), mount_by(MountByType::DEVICE), in_etc_crypttab(true), open_options()
+	  key_size(0), mount_by(MountByType::DEVICE), in_etc_crypttab(false), open_options()
     {
 	string tmp;
 


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1118977
- https://trello.com/c/jtojel4R

New encrypted volumes always show up in `/etc/crypttab` - even when they should not.

## Solution

The default should be `false` to not have enrypted volumes show up unexpectedly in `/etc/crypttab`.

yast-storage-ng will change the attribute as needed.

## See also

- https://github.com/yast/yast-storage-ng/pull/1087