### PR TITLE
- moved load registry to separate source file

### DIFF
--- a/storage/Devicegraph.cc
+++ b/storage/Devicegraph.cc
@@ -45,6 +45,7 @@
 #include "storage/Utils/Logger.h"
 #include "storage/Utils/Format.h"
 #include "storage/GraphvizImpl.h"
+#include "storage/EnvironmentImpl.h"
 
 
 namespace storage
@@ -444,6 +445,12 @@ namespace storage
     void
     Devicegraph::write_graphviz(const string& filename, DevicegraphStyleCallbacks* style_callbacks, View view) const
     {
+	if (developer_mode())
+	{
+	    get_impl().write_graphviz(filename, get_debug_devicegraph_style_callbacks(), View::ALL);
+	    return;
+	}
+
 	get_impl().write_graphviz(filename, style_callbacks, view);
     }
 
@@ -451,6 +458,12 @@ namespace storage
     void
     Devicegraph::write_graphviz(const string& filename, DevicegraphStyleCallbacks* style_callbacks) const
     {
+	if (developer_mode())
+	{
+	    get_impl().write_graphviz(filename, get_debug_devicegraph_style_callbacks(), View::ALL);
+	    return;
+	}
+
 	get_impl().write_graphviz(filename, style_callbacks);
     }
 
@@ -459,6 +472,12 @@ namespace storage
     Devicegraph::write_graphviz(const string& filename, GraphvizFlags flags,
 				GraphvizFlags tooltip_flags) const
     {
+	if (developer_mode())
+	{
+	    get_impl().write_graphviz(filename, get_debug_devicegraph_style_callbacks(), View::ALL);
+	    return;
+	}
+
 	AdvancedDevicegraphStyleCallbacks style_callbacks(flags, tooltip_flags);
 
 	get_impl().write_graphviz(filename, &style_callbacks);

--- a/storage/DevicegraphImpl.cc
+++ b/storage/DevicegraphImpl.cc
@@ -29,61 +29,15 @@
 #include "storage/DevicegraphImpl.h"
 #include "storage/Utils/GraphUtils.h"
 #include "storage/Utils/XmlFile.h"
-#include "storage/Utils/StorageTmpl.h"
-#include "storage/Utils/HumanString.h"
-#include "storage/Utils/StorageDefines.h"
 #include "storage/Devices/DeviceImpl.h"
-#include "storage/Devices/BlkDeviceImpl.h"
 #include "storage/Devices/Disk.h"
-#include "storage/Devices/Dasd.h"
-#include "storage/Devices/Multipath.h"
-#include "storage/Devices/DmRaid.h"
-#include "storage/Devices/Md.h"
-#include "storage/Devices/MdContainer.h"
-#include "storage/Devices/MdMember.h"
-#include "storage/Devices/Msdos.h"
-#include "storage/Devices/Gpt.h"
-#include "storage/Devices/DasdPt.h"
-#include "storage/Devices/ImplicitPt.h"
-#include "storage/Devices/Partition.h"
-#include "storage/Devices/StrayBlkDevice.h"
-#include "storage/Devices/PartitionTable.h"
-#include "storage/Devices/LvmPv.h"
-#include "storage/Devices/LvmVg.h"
-#include "storage/Devices/LvmLv.h"
-#include "storage/Devices/Encryption.h"
-#include "storage/Devices/PlainEncryption.h"
-#include "storage/Devices/Luks.h"
-#include "storage/Devices/Bcache.h"
-#include "storage/Devices/BcacheCset.h"
-#include "storage/Filesystems/Ext2.h"
-#include "storage/Filesystems/Ext3.h"
-#include "storage/Filesystems/Ext4.h"
-#include "storage/Filesystems/Ntfs.h"
-#include "storage/Filesystems/Vfat.h"
-#include "storage/Filesystems/Exfat.h"
-#include "storage/Filesystems/Btrfs.h"
-#include "storage/Filesystems/BtrfsSubvolume.h"
-#include "storage/Filesystems/Reiserfs.h"
-#include "storage/Filesystems/Xfs.h"
-#include "storage/Filesystems/Jfs.h"
-#include "storage/Filesystems/F2fs.h"
-#include "storage/Filesystems/Swap.h"
-#include "storage/Filesystems/Iso9660.h"
-#include "storage/Filesystems/Udf.h"
-#include "storage/Filesystems/Bitlocker.h"
 #include "storage/Filesystems/Nfs.h"
 #include "storage/Filesystems/MountPoint.h"
-#include "storage/Holders/HolderImpl.h"
-#include "storage/Holders/User.h"
-#include "storage/Holders/MdUser.h"
-#include "storage/Holders/FilesystemUser.h"
-#include "storage/Holders/Subdevice.h"
-#include "storage/Holders/MdSubdevice.h"
-#include "storage/Holders/Snapshot.h"
+#include "storage/Holders/Holder.h"
 #include "storage/Storage.h"
 #include "storage/Utils/Format.h"
 #include "storage/GraphvizImpl.h"
+#include "storage/LoadRegistry.h"
 
 
 namespace storage
@@ -759,63 +713,6 @@ namespace storage
 
 	return vector<edge_descriptor>(range.begin(), range.end());
     }
-
-
-    typedef std::function<Device* (Devicegraph* devicegraph, const xmlNode* node)> device_load_fnc;
-
-    const map<string, device_load_fnc> device_load_registry = {
-	{ "Disk", &Disk::load },
-	{ "Dasd", &Dasd::load },
-	{ "Multipath", &Multipath::load },
-	{ "DmRaid", &DmRaid::load },
-	{ "Md", &Md::load },
-	{ "MdContainer", &MdContainer::load },
-	{ "MdMember", &MdMember::load },
-	{ "Msdos", &Msdos::load },
-	{ "Gpt", &Gpt::load },
-	{ "DasdPt", &DasdPt::load },
-	{ "ImplicitPt", &ImplicitPt::load },
-	{ "Partition", &Partition::load },
-	{ "StrayBlkDevice", &StrayBlkDevice::load },
-	{ "LvmPv", &LvmPv::load },
-	{ "LvmVg", &LvmVg::load },
-	{ "LvmLv", &LvmLv::load },
-	{ "Encryption", &Encryption::load },
-	{ "PlainEncryption", &PlainEncryption::load },
-	{ "Luks", &Luks::load },
-	{ "Bcache", &Bcache::load },
-	{ "BcacheCset", &BcacheCset::load },
-	{ "Ext2", &Ext2::load },
-	{ "Ext3", &Ext3::load },
-	{ "Ext4", &Ext4::load },
-	{ "Ntfs", &Ntfs::load },
-	{ "Vfat", &Vfat::load },
-	{ "Exfat", &Exfat::load },
-	{ "Btrfs", &Btrfs::load },
-	{ "BtrfsSubvolume", &BtrfsSubvolume::load },
-	{ "Reiserfs", &Reiserfs::load },
-	{ "Xfs", &Xfs::load },
-	{ "Jfs", &Jfs::load },
-	{ "F2fs", &F2fs::load },
-	{ "Swap", &Swap::load },
-	{ "Iso9660", &Iso9660::load },
-	{ "Udf", &Udf::load },
-	{ "Bitlocker", &Bitlocker::load },
-	{ "Nfs", &Nfs::load },
-	{ "MountPoint", &MountPoint::load }
-    };
-
-
-    typedef std::function<Holder* (Devicegraph* devicegraph, const xmlNode* node)> holder_load_fnc;
-
-    const map<string, holder_load_fnc> holder_load_registry = {
-	{ "User", &User::load },
-	{ "MdUser", &MdUser::load },
-	{ "FilesystemUser", &FilesystemUser::load },
-	{ "Subdevice", &Subdevice::load },
-	{ "MdSubdevice", &MdSubdevice::load },
-	{ "Snapshot", &Snapshot::load }
-    };
 
 
     void

--- a/storage/EnvironmentImpl.cc
+++ b/storage/EnvironmentImpl.cc
@@ -117,4 +117,12 @@ namespace storage
 	return p && strcmp(p, "yes") == 0;
     }
 
+
+    bool
+    developer_mode()
+    {
+	const char* p = getenv("LIBSTORAGE_DEVELOPER_MODE");
+	return p && strcmp(p, "yes") == 0;
+    }
+
 }

--- a/storage/EnvironmentImpl.h
+++ b/storage/EnvironmentImpl.h
@@ -89,6 +89,11 @@ namespace storage
      */
     bool support_btrfs_snapshot_relations();
 
+    /**
+     * Switch to enable developer mode. What this mode exactly does is surely undefined.
+     */
+    bool developer_mode();
+
 }
 
 #endif

--- a/storage/LoadRegistry.cc
+++ b/storage/LoadRegistry.cc
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) [2014-2015] Novell, Inc.
+ * Copyright (c) [2016-2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+
+#include "storage/LoadRegistry.h"
+
+#include "storage/Devices/Device.h"
+#include "storage/Devices/BlkDevice.h"
+#include "storage/Devices/Disk.h"
+#include "storage/Devices/Dasd.h"
+#include "storage/Devices/Multipath.h"
+#include "storage/Devices/DmRaid.h"
+#include "storage/Devices/Md.h"
+#include "storage/Devices/MdContainer.h"
+#include "storage/Devices/MdMember.h"
+#include "storage/Devices/Msdos.h"
+#include "storage/Devices/Gpt.h"
+#include "storage/Devices/DasdPt.h"
+#include "storage/Devices/ImplicitPt.h"
+#include "storage/Devices/Partition.h"
+#include "storage/Devices/StrayBlkDevice.h"
+#include "storage/Devices/PartitionTable.h"
+#include "storage/Devices/LvmPv.h"
+#include "storage/Devices/LvmVg.h"
+#include "storage/Devices/LvmLv.h"
+#include "storage/Devices/Encryption.h"
+#include "storage/Devices/PlainEncryption.h"
+#include "storage/Devices/Luks.h"
+#include "storage/Devices/Bcache.h"
+#include "storage/Devices/BcacheCset.h"
+#include "storage/Filesystems/Ext2.h"
+#include "storage/Filesystems/Ext3.h"
+#include "storage/Filesystems/Ext4.h"
+#include "storage/Filesystems/Ntfs.h"
+#include "storage/Filesystems/Vfat.h"
+#include "storage/Filesystems/Exfat.h"
+#include "storage/Filesystems/Btrfs.h"
+#include "storage/Filesystems/BtrfsSubvolume.h"
+#include "storage/Filesystems/Reiserfs.h"
+#include "storage/Filesystems/Xfs.h"
+#include "storage/Filesystems/Jfs.h"
+#include "storage/Filesystems/F2fs.h"
+#include "storage/Filesystems/Swap.h"
+#include "storage/Filesystems/Iso9660.h"
+#include "storage/Filesystems/Udf.h"
+#include "storage/Filesystems/Bitlocker.h"
+#include "storage/Filesystems/Nfs.h"
+#include "storage/Filesystems/MountPoint.h"
+#include "storage/Holders/Holder.h"
+#include "storage/Holders/User.h"
+#include "storage/Holders/MdUser.h"
+#include "storage/Holders/FilesystemUser.h"
+#include "storage/Holders/Subdevice.h"
+#include "storage/Holders/MdSubdevice.h"
+#include "storage/Holders/Snapshot.h"
+
+
+namespace storage
+{
+
+    const map<string, device_load_fnc> device_load_registry = {
+	{ "Disk", &Disk::load },
+	{ "Dasd", &Dasd::load },
+	{ "Multipath", &Multipath::load },
+	{ "DmRaid", &DmRaid::load },
+	{ "Md", &Md::load },
+	{ "MdContainer", &MdContainer::load },
+	{ "MdMember", &MdMember::load },
+	{ "Msdos", &Msdos::load },
+	{ "Gpt", &Gpt::load },
+	{ "DasdPt", &DasdPt::load },
+	{ "ImplicitPt", &ImplicitPt::load },
+	{ "Partition", &Partition::load },
+	{ "StrayBlkDevice", &StrayBlkDevice::load },
+	{ "LvmPv", &LvmPv::load },
+	{ "LvmVg", &LvmVg::load },
+	{ "LvmLv", &LvmLv::load },
+	{ "Encryption", &Encryption::load },
+	{ "PlainEncryption", &PlainEncryption::load },
+	{ "Luks", &Luks::load },
+	{ "Bcache", &Bcache::load },
+	{ "BcacheCset", &BcacheCset::load },
+	{ "Ext2", &Ext2::load },
+	{ "Ext3", &Ext3::load },
+	{ "Ext4", &Ext4::load },
+	{ "Ntfs", &Ntfs::load },
+	{ "Vfat", &Vfat::load },
+	{ "Exfat", &Exfat::load },
+	{ "Btrfs", &Btrfs::load },
+	{ "BtrfsSubvolume", &BtrfsSubvolume::load },
+	{ "Reiserfs", &Reiserfs::load },
+	{ "Xfs", &Xfs::load },
+	{ "Jfs", &Jfs::load },
+	{ "F2fs", &F2fs::load },
+	{ "Swap", &Swap::load },
+	{ "Iso9660", &Iso9660::load },
+	{ "Udf", &Udf::load },
+	{ "Bitlocker", &Bitlocker::load },
+	{ "Nfs", &Nfs::load },
+	{ "MountPoint", &MountPoint::load }
+    };
+
+
+    const map<string, holder_load_fnc> holder_load_registry = {
+	{ "User", &User::load },
+	{ "MdUser", &MdUser::load },
+	{ "FilesystemUser", &FilesystemUser::load },
+	{ "Subdevice", &Subdevice::load },
+	{ "MdSubdevice", &MdSubdevice::load },
+	{ "Snapshot", &Snapshot::load }
+    };
+
+}

--- a/storage/LoadRegistry.cc
+++ b/storage/LoadRegistry.cc
@@ -23,8 +23,6 @@
 
 #include "storage/LoadRegistry.h"
 
-#include "storage/Devices/Device.h"
-#include "storage/Devices/BlkDevice.h"
 #include "storage/Devices/Disk.h"
 #include "storage/Devices/Dasd.h"
 #include "storage/Devices/Multipath.h"
@@ -65,7 +63,6 @@
 #include "storage/Filesystems/Bitlocker.h"
 #include "storage/Filesystems/Nfs.h"
 #include "storage/Filesystems/MountPoint.h"
-#include "storage/Holders/Holder.h"
 #include "storage/Holders/User.h"
 #include "storage/Holders/MdUser.h"
 #include "storage/Holders/FilesystemUser.h"

--- a/storage/LoadRegistry.h
+++ b/storage/LoadRegistry.h
@@ -36,8 +36,14 @@ namespace storage
 
     typedef std::function<Holder* (Devicegraph* devicegraph, const xmlNode* node)> holder_load_fnc;
 
+    /**
+     * Map with name of all non-abstract device types and corresponding load function.
+     */
     extern const map<string, device_load_fnc> device_load_registry;
 
+    /**
+     * Map with name of all non-abstract holder types and corresponding load function.
+     */
     extern const map<string, holder_load_fnc> holder_load_registry;
 
 }

--- a/storage/LoadRegistry.h
+++ b/storage/LoadRegistry.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) [2014-2015] Novell, Inc.
+ * Copyright (c) [2016-2020] SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, contact Novell, Inc.
+ *
+ * To contact Novell about this file by physical or electronic mail, you may
+ * find current contact information at www.novell.com.
+ */
+
+
+#include <map>
+#include <functional>
+
+#include "storage/Devicegraph.h"
+
+
+namespace storage
+{
+    using namespace std;
+
+
+    typedef std::function<Device* (Devicegraph* devicegraph, const xmlNode* node)> device_load_fnc;
+
+    typedef std::function<Holder* (Devicegraph* devicegraph, const xmlNode* node)> holder_load_fnc;
+
+    extern const map<string, device_load_fnc> device_load_registry;
+
+    extern const map<string, holder_load_fnc> holder_load_registry;
+
+}

--- a/storage/Makefile.am
+++ b/storage/Makefile.am
@@ -13,6 +13,7 @@ libstorage_ng_la_SOURCES =						\
 	StorageImpl.h			StorageImpl.cc			\
 	Devicegraph.h			Devicegraph.cc			\
 	DevicegraphImpl.h		DevicegraphImpl.cc		\
+	LoadRegistry.h			LoadRegistry.cc			\
 	Action.h			Action.cc			\
 	Actiongraph.h			Actiongraph.cc			\
 	ActiongraphImpl.h		ActiongraphImpl.cc		\


### PR DESCRIPTION
Split registry of load function to separate file to reduce size of original source file.

Not for any specific PBI, bug or feature.
