### PR TITLE
- disallow resizing thick volume groups with snapshots

### DIFF
--- a/bindings/storage-catches.i
+++ b/bindings/storage-catches.i
@@ -81,6 +81,7 @@
 %catches(storage::NullPointerException) storage::is_partitionable(const Device *device);
 %catches(storage::NullPointerException) storage::is_plain_encryption(const Device *device);
 %catches(storage::NullPointerException) storage::is_reiserfs(const Device *device);
+%catches(storage::NullPointerException) storage::is_snapshot(const Holder *holder);
 %catches(storage::NullPointerException) storage::is_stray_blk_device(const Device *device);
 %catches(storage::NullPointerException) storage::is_subdevice(const Holder *holder);
 %catches(storage::NullPointerException) storage::is_swap(const Device *device);
@@ -179,6 +180,8 @@
 %catches(storage::DeviceHasWrongType, storage::NullPointerException) storage::to_plain_encryption(const Device *device);
 %catches(storage::DeviceHasWrongType, storage::NullPointerException) storage::to_reiserfs(Device *device);
 %catches(storage::DeviceHasWrongType, storage::NullPointerException) storage::to_reiserfs(const Device *device);
+%catches(storage::HolderHasWrongType, storage::NullPointerException) storage::to_snapshot(Holder *holder);
+%catches(storage::HolderHasWrongType, storage::NullPointerException) storage::to_snapshot(const Holder *holder);
 %catches(storage::DeviceHasWrongType, storage::NullPointerException) storage::to_stray_blk_device(Device *device);
 %catches(storage::DeviceHasWrongType, storage::NullPointerException) storage::to_stray_blk_device(const Device *device);
 %catches(storage::HolderHasWrongType, storage::NullPointerException) storage::to_subdevice(Holder *holder);
@@ -247,6 +250,7 @@
 %catches(storage::Exception) storage::Devicegraph::load(const std::string &filename);
 %catches(storage::DeviceNotFoundBySid) storage::Devicegraph::remove_device(sid_t sid);
 %catches(storage::Exception) storage::Devicegraph::save(const std::string &filename) const;
+%catches(storage::Exception) storage::Devicegraph::write_graphviz(const std::string &filename, DevicegraphStyleCallbacks *style_callbacks, View view) const;
 %catches(storage::Exception) storage::Devicegraph::write_graphviz(const std::string &filename, DevicegraphStyleCallbacks *style_callbacks) const;
 %catches(storage::Exception) storage::Devicegraph::write_graphviz(const std::string &filename, GraphvizFlags flags=GraphvizFlags::NAME, GraphvizFlags tooltip_flags=GraphvizFlags::NONE) const;
 %catches(storage::DeviceNotFound, storage::DeviceHasWrongType) storage::Disk::find_by_name(Devicegraph *devicegraph, const std::string &name);
@@ -335,6 +339,7 @@
 %catches(storage::DifferentBlockSizes) storage::Region::operator>(const Region &rhs) const;
 %catches(storage::DifferentBlockSizes) storage::Region::operator>=(const Region &rhs) const;
 %catches(storage::Exception) storage::Region::unused_regions(const std::vector< Region > &used_regions) const;
+%catches(storage::HolderAlreadyExists) storage::Snapshot::create(Devicegraph *devicegraph, const Device *source, const Device *target);
 %catches(storage::LockException, storage::Exception) storage::Storage::Storage(const Environment &environment);
 %catches(storage::Aborted, storage::Exception) storage::Storage::activate(const ActivateCallbacks *activate_callbacks) const;
 %catches(storage::Exception) storage::Storage::calculate_actiongraph();

--- a/bindings/storage-downcast.i
+++ b/bindings/storage-downcast.i
@@ -112,6 +112,7 @@
 	 const storage::Device)
 
 %factory(storage::Holder* storage::downcast,
+	 storage::Snapshot,
 	 storage::MdSubdevice,
 	 storage::Subdevice,
 	 storage::FilesystemUser,
@@ -120,6 +121,7 @@
 	 storage::Holder)
 
 %factory(const storage::Holder* storage::downcast,
+	 const storage::Snapshot,
 	 const storage::MdSubdevice,
 	 const storage::Subdevice,
 	 const storage::FilesystemUser,

--- a/bindings/storage.i
+++ b/bindings/storage.i
@@ -115,6 +115,7 @@ use_ostream(storage::PartitionSlot);
 #include "storage/Holders/User.h"
 #include "storage/Holders/MdUser.h"
 #include "storage/Holders/FilesystemUser.h"
+#include "storage/Holders/Snapshot.h"
 
 #include "storage/SystemInfo/Arch.h"
 
@@ -206,6 +207,7 @@ use_ostream(storage::PartitionSlot);
 %include "../../storage/Holders/User.h"
 %include "../../storage/Holders/MdUser.h"
 %include "../../storage/Holders/FilesystemUser.h"
+%include "../../storage/Holders/Snapshot.h"
 
 %include "../../storage/SystemInfo/Arch.h"
 

--- a/doc/autodocs/doxygen.conf
+++ b/doc/autodocs/doxygen.conf
@@ -30,8 +30,8 @@ FILE_PATTERNS += Bitlocker.h BlkFilesystem.h Btrfs.h BtrfsSubvolume.h Exfat.h	\
 	Xfs.h
 
 INPUT += ../../storage/Holders
-FILE_PATTERNS += FilesystemUser.h Holder.h MdSubdevice.h MdUser.h Subdevice.h	\
-	User.h
+FILE_PATTERNS += FilesystemUser.h Holder.h MdSubdevice.h MdUser.h Snapshot.h	\
+	Subdevice.h User.h
 
 INPUT += ../../storage/Utils
 FILE_PATTERNS += Alignment.h Exception.h HumanString.h Lock.h Logger.h		\

--- a/doc/lvm.md
+++ b/doc/lvm.md
@@ -76,3 +76,21 @@ A cache being used as a thin-pool is included as a thin pool in the
 devicegraph (again analog to the lvs command).
 
 writecache is untested since setting it up fails.
+
+
+LVM RAID
+--------
+
+Only probing of LVM Raid and mirror is supported.
+
+
+LVM Snapshots
+-------------
+
+Only probing of LVM snapshots is supported.
+
+Some actions are also not supported:
+
+- Resizing thick logical volumes with snapshots is not supported.
+
+- Resizing thick snapshots is not supported.

--- a/storage/Devices/LvmLv.h
+++ b/storage/Devices/LvmLv.h
@@ -237,8 +237,8 @@ namespace storage
 	std::vector<const LvmLv*> get_snapshots() const;
 
 	/**
-	 * Check whether the logical volume has a origin. In other
-	 * words, whether it is a snapshots. It can be either a thick
+	 * Check whether the logical volume has an origin. In other
+	 * words, whether it is a snapshot. It can be either a thick
 	 * or thin snapshot.
 	 *
 	 * @see has_snapshots()

--- a/storage/Devices/LvmLvImpl.cc
+++ b/storage/Devices/LvmLvImpl.cc
@@ -754,6 +754,9 @@ namespace storage
 	{
 	    case LvType::NORMAL:
 	    {
+		if (has_snapshots())
+		    return ResizeInfo(false, RB_RESIZE_NOT_SUPPORTED_DUE_TO_SNAPSHOTS);
+
 		ResizeInfo resize_info = BlkDevice::Impl::detect_resize_info(get_non_impl());
 
 		unsigned long long free_extents = lvm_vg->get_impl().number_of_free_extents({ get_sid() });

--- a/storage/Devices/LvmLvImpl.cc
+++ b/storage/Devices/LvmLvImpl.cc
@@ -586,7 +586,7 @@ namespace storage
     {
 	vector<Snapshot*> snapshots = get_in_holders_of_type<Snapshot>(View::ALL);
 
-	if (snapshots.empty())
+	if (snapshots.size() != 1)
 	    ST_THROW(WrongNumberOfParents(snapshots.empty(), 1));
 
 	return to_lvm_lv(snapshots.front()->get_source());
@@ -598,7 +598,7 @@ namespace storage
     {
 	vector<const Snapshot*> snapshots = get_in_holders_of_type<const Snapshot>(View::ALL);
 
-	if (snapshots.empty())
+	if (snapshots.size() != 1)
 	    ST_THROW(WrongNumberOfParents(snapshots.empty(), 1));
 
 	return to_lvm_lv(snapshots.front()->get_source());

--- a/storage/FreeInfo.h
+++ b/storage/FreeInfo.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2004-2010] Novell, Inc.
- * Copyright (c) [2016-2018] SUSE LLC
+ * Copyright (c) [2016-2020] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -138,14 +138,14 @@ namespace storage
 	RB_ON_IMPLICIT_PARTITION_TABLE = 1 << 11,
 
 	/**
-	 * Shrink of LVM logical volume of this type not supported, e.g. thin pools and raids.
+	 * Shrink of LVM logical volume of this type not supported, e.g. thin pools and RAIDs.
 	 *
 	 * Blocks shrink.
 	 */
 	RB_SHRINK_NOT_SUPPORTED_FOR_LVM_LV_TYPE = 1 << 12,
 
 	/**
-	 * Resize of LVM logical volume of this type not supported, e.g. raids.
+	 * Resize of LVM logical volume of this type not supported, e.g. RAIDs.
 	 *
 	 * Blocks shrink and grow.
 	 */
@@ -182,7 +182,14 @@ namespace storage
 	/**
 	 * The encryption password is required.
 	 */
-	RB_PASSWORD_REQUIRED = 1 << 18
+	RB_PASSWORD_REQUIRED = 1 << 18,
+
+	/**
+	 * Resize of LVM logical volume is not supported since it has snapshots.
+	 *
+	 * Blocks shrink and grow.
+	 */
+	RB_RESIZE_NOT_SUPPORTED_DUE_TO_SNAPSHOTS = 1 << 19,
 
     };
 

--- a/storage/Holders/Makefile.am
+++ b/storage/Holders/Makefile.am
@@ -28,5 +28,6 @@ pkginclude_HEADERS =		\
 	MdUser.h		\
 	FilesystemUser.h	\
 	Subdevice.h		\
-	MdSubdevice.h
+	MdSubdevice.h		\
+	Snapshot.h
 

--- a/storage/Holders/Snapshot.h
+++ b/storage/Holders/Snapshot.h
@@ -31,13 +31,8 @@ namespace storage
 {
 
     /**
-     * Relationship between snapshot and snapshot. The snapshot is the
-     * source and the snapshot the target. So far only used for LVM
-     * snapshot.
-     *
-     * Could also be used for btrfs snapshots.
-     *
-     * So far internal to the library.
+     * Relationship between snapshot and snapshot. The snapshot is the source and the
+     * snapshot the target. So far used for LVM and btrfs snapshot.
      */
     class Snapshot : public Holder
     {

--- a/storage/Holders/Snapshot.h
+++ b/storage/Holders/Snapshot.h
@@ -31,8 +31,8 @@ namespace storage
 {
 
     /**
-     * Relationship between snapshot and snapshot. The snapshot is the source and the
-     * snapshot the target. So far used for LVM and btrfs snapshot.
+     * Relationship between origin and snapshot. The origin is the source and the
+     * snapshot the target. Used for LVM and btrfs snapshot.
      */
     class Snapshot : public Holder
     {


### PR DESCRIPTION
Resizing non-thin logical volumes with snapshots is problematic since the logical volume and all snapshots must be inactive. For the time being resizing is disallowed.

yast2-storage-ng will need a new message for the new enum value.

For https://trello.com/c/w1G3xAOd/1825-8-probe-lvm-snapshots-bug1120410.
