### PR TITLE
Fixes for %_libexecdir changing to /usr/libexec

### DIFF
--- a/libstorage-ng.spec.in
+++ b/libstorage-ng.spec.in
@@ -206,13 +206,13 @@ touch %{buildroot}/run/libstorage-ng/lock
 
 %files utils
 %defattr(-,root,root)
-%dir %{_libexecdir}/libstorage-ng
-%{_libexecdir}/libstorage-ng/utils
+%dir %{_prefix}/lib/libstorage-ng
+%{_prefix}/lib/libstorage-ng/utils
 
 %files integration-tests
 %defattr(-,root,root)
 %{python3_sitelib}/storageitu.py*
-%dir %{_libexecdir}/libstorage-ng
-%{_libexecdir}/libstorage-ng/integration-tests
+%dir %{_prefix}/lib/libstorage-ng
+%{_prefix}/lib/libstorage-ng/integration-tests
 
 %changelog


### PR DESCRIPTION
Closes #752