### PR TITLE
add _constraints file for OBS requiring at least 4 GB disk size (bsc#1174375)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Creating Changes And Package And Submitting To OBS
 Creating the changes file and tar archive are handled by jenkins
 using [linuxrc-devtools](https://github.com/openSUSE/linuxrc-devtools).
 
+Additional files needed for OBS building are placed in the `obs`
+subdirectory.
+
 You can generate a preview of the changes file by running
 
 ```sh

--- a/obs/_constraints
+++ b/obs/_constraints
@@ -1,0 +1,7 @@
+<constraints>
+  <hardware>
+    <disk>
+      <size unit="G">4</size>
+    </disk>
+  </hardware>
+</constraints>


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1174375

Building in OBS requires 4 GB disk size (at least on PPC).

Add a `_constraints` file ensuring this size (for all architectures).