### PR TITLE
- handle missing partition device nodes for multipath (bsc#1175981)

### DIFF
--- a/storage/Devices/BlkDeviceImpl.h
+++ b/storage/Devices/BlkDeviceImpl.h
@@ -61,7 +61,7 @@ namespace storage
 
 	virtual void check(const CheckCallbacks* check_callbacks) const override;
 
-	virtual bool is_usable_as_blk_device() const { return true; }
+	virtual bool is_usable_as_blk_device() const { return active; }
 
 	const string& get_name() const { return name; }
 	void set_name(const string& name);

--- a/storage/Devices/PartitionImpl.cc
+++ b/storage/Devices/PartitionImpl.cc
@@ -123,6 +123,9 @@ namespace storage
 	boot = entry.boot;
 	legacy_boot = entry.legacy_boot;
 
+	if (!is_active())
+	    return;
+
 	const CmdUdevadmInfo& cmd_udevadm_info = system_info.getCmdUdevadmInfo(get_name());
 
 	if (!cmd_udevadm_info.get_by_part_label_links().empty())
@@ -176,6 +179,9 @@ namespace storage
     bool
     Partition::Impl::is_usable_as_blk_device() const
     {
+	if (!BlkDevice::Impl::is_usable_as_blk_device())
+	    return false;
+
 	return type == PartitionType::PRIMARY || type == PartitionType::LOGICAL;
     }
 

--- a/storage/Devices/PartitionTableImpl.cc
+++ b/storage/Devices/PartitionTableImpl.cc
@@ -28,6 +28,7 @@
 #include "storage/Devices/PartitionImpl.h"
 #include "storage/Devices/MsdosImpl.h"
 #include "storage/Devices/GptImpl.h"
+#include "storage/Devices/Multipath.h"
 #include "storage/Holders/Subdevice.h"
 #include "storage/Devicegraph.h"
 #include "storage/SystemInfo/SystemInfo.h"
@@ -74,6 +75,15 @@ namespace storage
 	    string name = partitionable->get_impl().partition_name(entry.number);
 
 	    Partition* partition = create_partition(name, entry.region, entry.type);
+
+	    // For multipath the user can disable creation of device nodes for the
+	    // partitions by setting skip_kpartx. See bsc #1175981 for details.
+	    if (is_multipath(get_partitionable()))
+	    {
+		const CmdStat& cmd_stat = prober.get_system_info().getCmdStat(partition->get_name());
+		partition->get_impl().set_active(cmd_stat.is_blk() || cmd_stat.is_lnk());
+	    }
+
 	    partition->get_impl().probe_pass_1a(prober);
 	}
     }

--- a/storage/SystemInfo/CmdStat.h
+++ b/storage/SystemInfo/CmdStat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 SUSE LLC
+ * Copyright (c) [2018-2020] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -47,6 +47,7 @@ namespace storage
 	bool is_blk() const { return S_ISBLK(mode); }
 	bool is_dir() const { return S_ISDIR(mode); }
 	bool is_reg() const { return S_ISREG(mode); }
+	bool is_lnk() const { return S_ISLNK(mode); }
 
 	friend std::ostream& operator<<(std::ostream& s, const CmdStat& cmd_stat);
 

--- a/testsuite/probe/multipath+luks1-mockup.xml
+++ b/testsuite/probe/multipath+luks1-mockup.xml
@@ -678,6 +678,10 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
+      <name>/usr/bin/stat --format '%f' '/dev/mapper/36005076305ffc73a00000000000013b4-part1'</name>
+      <stdout>a1ff</stdout>
+    </Command>
+    <Command>
       <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
       <exit-code>1</exit-code>
     </Command>

--- a/testsuite/probe/multipath1-mockup.xml
+++ b/testsuite/probe/multipath1-mockup.xml
@@ -636,6 +636,10 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
+      <name>/usr/bin/stat --format '%f' '/dev/mapper/36005076305ffc73a00000000000013b4-part1'</name>
+      <stdout>a1ff</stdout>
+    </Command>
+    <Command>
       <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
       <exit-code>1</exit-code>
     </Command>


### PR DESCRIPTION
Handle missing partition device nodes for multipath with option skip_kpartx (bsc#1175981).
