### PR TITLE
Use non-deprecated location for efivars for EFI detection

### DIFF
--- a/storage/SystemInfo/Arch.cc
+++ b/storage/SystemInfo/Arch.cc
@@ -105,7 +105,7 @@ namespace storage
 	}
 	else
 	{
-	    SystemCmd::Options options(TEST_BIN " -d '/sys/firmware/efi/vars'", SystemCmd::DoThrow);
+	    SystemCmd::Options options(TEST_BIN " -d '/sys/firmware/efi/efivars'", SystemCmd::DoThrow);
 	    options.verify = [](int exit_code) { return exit_code == 0 || exit_code == 1; };
 
 	    SystemCmd cmd(options);

--- a/testsuite/probe/ambiguous1-mockup.xml
+++ b/testsuite/probe/ambiguous1-mockup.xml
@@ -187,7 +187,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/bcache1-mockup.xml
+++ b/testsuite/probe/bcache1-mockup.xml
@@ -741,7 +741,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/bcache2-mockup.xml
+++ b/testsuite/probe/bcache2-mockup.xml
@@ -939,7 +939,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/bitlocker1-mockup.xml
+++ b/testsuite/probe/bitlocker1-mockup.xml
@@ -583,7 +583,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/btrfs1-mockup.xml
+++ b/testsuite/probe/btrfs1-mockup.xml
@@ -227,7 +227,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/btrfs2-mockup.xml
+++ b/testsuite/probe/btrfs2-mockup.xml
@@ -939,7 +939,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/btrfs3-mockup.xml
+++ b/testsuite/probe/btrfs3-mockup.xml
@@ -188,7 +188,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/btrfs4-mockup.xml
+++ b/testsuite/probe/btrfs4-mockup.xml
@@ -93,7 +93,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/btrfs5-mockup.xml
+++ b/testsuite/probe/btrfs5-mockup.xml
@@ -104,7 +104,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/dasd1-mockup.xml
+++ b/testsuite/probe/dasd1-mockup.xml
@@ -213,7 +213,7 @@
       <stdout>4096</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/dasd2-mockup.xml
+++ b/testsuite/probe/dasd2-mockup.xml
@@ -401,7 +401,7 @@
       <stdout>4096</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/dasd3-mockup.xml
+++ b/testsuite/probe/dasd3-mockup.xml
@@ -33,7 +33,7 @@
       <stdout>4096</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/disk-mockup.xml
+++ b/testsuite/probe/disk-mockup.xml
@@ -343,7 +343,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <stdout></stdout>
       <stderr></stderr>
     </Command>

--- a/testsuite/probe/disk-zoned1-mockup.xml
+++ b/testsuite/probe/disk-zoned1-mockup.xml
@@ -453,7 +453,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/dmraid1-mockup.xml
+++ b/testsuite/probe/dmraid1-mockup.xml
@@ -630,7 +630,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
     </Command>
     <Command>
       <name>/usr/bin/uname -m</name>

--- a/testsuite/probe/error1-mockup.xml
+++ b/testsuite/probe/error1-mockup.xml
@@ -373,7 +373,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
     </Command>
     <Command>
       <name>/usr/bin/uname -m</name>

--- a/testsuite/probe/external-journal-mockup.xml
+++ b/testsuite/probe/external-journal-mockup.xml
@@ -602,7 +602,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
     </Command>
     <Command>
       <name>/usr/bin/uname -m</name>

--- a/testsuite/probe/luks+lvm1-mockup.xml
+++ b/testsuite/probe/luks+lvm1-mockup.xml
@@ -619,7 +619,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/luks1-mockup.xml
+++ b/testsuite/probe/luks1-mockup.xml
@@ -339,7 +339,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
     </Command>
     <Command>
       <name>/usr/bin/uname -m</name>

--- a/testsuite/probe/luks2-mockup.xml
+++ b/testsuite/probe/luks2-mockup.xml
@@ -429,7 +429,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/luks3-mockup.xml
+++ b/testsuite/probe/luks3-mockup.xml
@@ -197,7 +197,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/lvm+luks1-mockup.xml
+++ b/testsuite/probe/lvm+luks1-mockup.xml
@@ -617,7 +617,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/lvm-cache+thin1-mockup.xml
+++ b/testsuite/probe/lvm-cache+thin1-mockup.xml
@@ -136,7 +136,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/lvm-cache1-mockup.xml
+++ b/testsuite/probe/lvm-cache1-mockup.xml
@@ -120,7 +120,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/lvm-errors1-mockup.xml
+++ b/testsuite/probe/lvm-errors1-mockup.xml
@@ -481,7 +481,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/lvm-mirror1-mockup.xml
+++ b/testsuite/probe/lvm-mirror1-mockup.xml
@@ -105,7 +105,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/lvm-raid1-mockup.xml
+++ b/testsuite/probe/lvm-raid1-mockup.xml
@@ -138,7 +138,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/lvm-snapshot1-mockup.xml
+++ b/testsuite/probe/lvm-snapshot1-mockup.xml
@@ -132,7 +132,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/lvm-unsupported1-mockup.xml
+++ b/testsuite/probe/lvm-unsupported1-mockup.xml
@@ -95,7 +95,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/lvm1-mockup.xml
+++ b/testsuite/probe/lvm1-mockup.xml
@@ -575,7 +575,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
     </Command>
     <Command>
       <name>/usr/bin/uname -m</name>

--- a/testsuite/probe/lvm2-mockup.xml
+++ b/testsuite/probe/lvm2-mockup.xml
@@ -576,7 +576,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/md+lvm1-mockup.xml
+++ b/testsuite/probe/md+lvm1-mockup.xml
@@ -901,7 +901,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/md-ddf1-mockup.xml
+++ b/testsuite/probe/md-ddf1-mockup.xml
@@ -695,7 +695,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
     </Command>
     <Command>
       <name>/usr/bin/uname -m</name>

--- a/testsuite/probe/md-imsm1-mockup.xml
+++ b/testsuite/probe/md-imsm1-mockup.xml
@@ -695,7 +695,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
     </Command>
     <Command>
       <name>/usr/bin/uname -m</name>

--- a/testsuite/probe/md1-mockup.xml
+++ b/testsuite/probe/md1-mockup.xml
@@ -460,7 +460,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <stdout></stdout>
       <stderr></stderr>
     </Command>

--- a/testsuite/probe/md2-mockup.xml
+++ b/testsuite/probe/md2-mockup.xml
@@ -614,7 +614,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
     </Command>
     <Command>
       <name>/usr/bin/uname -m</name>

--- a/testsuite/probe/md3-mockup.xml
+++ b/testsuite/probe/md3-mockup.xml
@@ -1821,7 +1821,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
     </Command>
     <Command>
       <name>/usr/bin/uname -m</name>

--- a/testsuite/probe/missing1-mockup.xml
+++ b/testsuite/probe/missing1-mockup.xml
@@ -294,7 +294,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/multi-mount-point-mockup1.xml
+++ b/testsuite/probe/multi-mount-point-mockup1.xml
@@ -343,7 +343,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <stdout></stdout>
       <stderr></stderr>
     </Command>

--- a/testsuite/probe/multi-mount-point-mockup2.xml
+++ b/testsuite/probe/multi-mount-point-mockup2.xml
@@ -343,7 +343,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <stdout></stdout>
       <stderr></stderr>
     </Command>

--- a/testsuite/probe/multi-mount-point-mockup3.xml
+++ b/testsuite/probe/multi-mount-point-mockup3.xml
@@ -343,7 +343,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <stdout></stdout>
       <stderr></stderr>
     </Command>

--- a/testsuite/probe/multi-mount-point-mockup4.xml
+++ b/testsuite/probe/multi-mount-point-mockup4.xml
@@ -343,7 +343,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <stdout></stdout>
       <stderr></stderr>
     </Command>

--- a/testsuite/probe/multipath+luks1-mockup.xml
+++ b/testsuite/probe/multipath+luks1-mockup.xml
@@ -682,7 +682,7 @@
       <stdout>a1ff</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/multipath1-mockup.xml
+++ b/testsuite/probe/multipath1-mockup.xml
@@ -640,7 +640,7 @@
       <stdout>a1ff</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/nfs1-mockup.xml
+++ b/testsuite/probe/nfs1-mockup.xml
@@ -35,7 +35,7 @@
       <stdout>4096</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/ntfs1-mockup.xml
+++ b/testsuite/probe/ntfs1-mockup.xml
@@ -268,7 +268,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/plain-encryption1-mockup.xml
+++ b/testsuite/probe/plain-encryption1-mockup.xml
@@ -396,7 +396,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/tmpfs1-mockup.xml
+++ b/testsuite/probe/tmpfs1-mockup.xml
@@ -54,7 +54,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>

--- a/testsuite/probe/xen1-mockup.xml
+++ b/testsuite/probe/xen1-mockup.xml
@@ -460,7 +460,7 @@
       <stdout>61b0</stdout>
     </Command>
     <Command>
-      <name>/usr/bin/test -d '/sys/firmware/efi/vars'</name>
+      <name>/usr/bin/test -d '/sys/firmware/efi/efivars'</name>
       <exit-code>1</exit-code>
     </Command>
     <Command>


### PR DESCRIPTION
Starting with Kernel 5.10 on aarch64, the deprecated firmware/vars
layout no longer exists. Since we only detect existence, we can
use firmware/efivars, which is the location that should work
on all architectures going forward.