### PR TITLE
- per default join all action messages for compound actions

### DIFF
--- a/storage/CompoundAction.cc
+++ b/storage/CompoundAction.cc
@@ -47,7 +47,7 @@ namespace storage
     string
     CompoundAction::sentence() const
     {
-	return get_impl().sentence();
+	return get_impl().sentence().translated;
     }
 
 

--- a/storage/CompoundAction/Formatter.cc
+++ b/storage/CompoundAction/Formatter.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2017-2020] SUSE LLC
+ * Copyright (c) [2017-2021] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -45,13 +45,6 @@ namespace storage
         _formatting = has_create<storage::BlkFilesystem>();
         _encrypting = has_create<storage::Encryption>();
         _mounting   = has_create<storage::MountPoint>();
-    }
-
-
-    string
-    CompoundAction::Formatter::string_representation() const
-    {
-	return text().translated;
     }
 
 
@@ -134,9 +127,7 @@ namespace storage
     Text
     CompoundAction::Formatter::default_text() const
     {
-	const CommitData commit_data(_compound_action->get_actiongraph()->get_impl(), Tense::SIMPLE_PRESENT);
-	auto first_action = _compound_action->get_commit_actions().front();
-	return first_action->text(commit_data);
+	return join(_compound_action->get_commit_actions_as_texts(), JoinMode::NEWLINE, 0);
     }
 
 }

--- a/storage/CompoundAction/Formatter.h
+++ b/storage/CompoundAction/Formatter.h
@@ -61,10 +61,6 @@ namespace storage
 
 	virtual ~Formatter() {}
 
-	string string_representation() const;
-
-    private:
-
 	virtual Text text() const = 0;
 
     protected:

--- a/storage/CompoundAction/Formatter/Bcache.h
+++ b/storage/CompoundAction/Formatter/Bcache.h
@@ -38,9 +38,9 @@ namespace storage
 
 	Bcache(const CompoundAction::Impl* compound_action);
 
-    private:
-
 	virtual Text text() const override;
+
+    private:
 
 	Text blk_devices_text() const;
 

--- a/storage/CompoundAction/Formatter/Btrfs.h
+++ b/storage/CompoundAction/Formatter/Btrfs.h
@@ -38,11 +38,11 @@ namespace storage
 
 	Btrfs(const CompoundAction::Impl* compound_action);
 
+	virtual Text text() const override;
+
     private:
 
 	Text blk_devices_text() const;
-
-	virtual Text text() const override;
 
 	Text delete_text() const;
 	Text create_and_mount_text() const;
@@ -62,11 +62,11 @@ namespace storage
 
 	BtrfsQuota(const CompoundAction::Impl* compound_action);
 
+	virtual Text text() const override;
+
     private:
 
 	Text blk_devices_text() const;
-
-	virtual Text text() const override;
 
 	const storage::Btrfs* btrfs = nullptr;
 
@@ -80,11 +80,11 @@ namespace storage
 
 	BtrfsQgroups(const CompoundAction::Impl* compound_action);
 
+	virtual Text text() const override;
+
     private:
 
 	Text blk_devices_text() const;
-
-	virtual Text text() const override;
 
 	const storage::Btrfs* btrfs = nullptr;
 

--- a/storage/CompoundAction/Formatter/BtrfsSubvolume.h
+++ b/storage/CompoundAction/Formatter/BtrfsSubvolume.h
@@ -39,11 +39,11 @@ namespace storage
 
 	BtrfsSubvolume(const CompoundAction::Impl* compound_action);
 
+	virtual Text text() const override;
+
     private:
 
 	Text blk_devices_text() const;
-
-	virtual Text text() const override;
 
 	Text delete_text() const;
 

--- a/storage/CompoundAction/Formatter/LvmLv.h
+++ b/storage/CompoundAction/Formatter/LvmLv.h
@@ -39,9 +39,9 @@ namespace storage
 
 	LvmLv(const CompoundAction::Impl* compound_action);
 
-    private:
-
 	virtual Text text() const override;
+
+    private:
 
 	Text create_encrypted_with_swap_text() const;
 	Text create_with_swap_text() const;

--- a/storage/CompoundAction/Formatter/LvmVg.h
+++ b/storage/CompoundAction/Formatter/LvmVg.h
@@ -40,11 +40,11 @@ namespace storage
 
 	LvmVg(const CompoundAction::Impl* compound_action);
 
+	virtual Text text() const override;
+
     private:
 
 	Text blk_devices_text() const;
-
-	virtual Text text() const override;
 
 	Text create_with_pvs_text() const;
 	Text create_text() const;

--- a/storage/CompoundAction/Formatter/Md.h
+++ b/storage/CompoundAction/Formatter/Md.h
@@ -39,9 +39,9 @@ namespace storage
 
 	Md( const CompoundAction::Impl* compound_action );
 
-    private:
-
 	virtual Text text() const override;
+
+    private:
 
 	Text blk_devices_text() const;
 

--- a/storage/CompoundAction/Formatter/Nfs.h
+++ b/storage/CompoundAction/Formatter/Nfs.h
@@ -38,9 +38,9 @@ namespace storage
 
 	Nfs(const CompoundAction::Impl* compound_action);
 
-    private:
-
 	virtual Text text() const override;
+
+    private:
 
 	Text mount_text() const;
 	Text unmount_text() const;

--- a/storage/CompoundAction/Formatter/Partition.h
+++ b/storage/CompoundAction/Formatter/Partition.h
@@ -39,9 +39,9 @@ namespace storage
 
 	Partition(const CompoundAction::Impl* compound_action);
 
-    private:
-
 	virtual Text text() const override;
+
+    private:
 
 	Text delete_text() const;
 

--- a/storage/CompoundAction/Formatter/StrayBlkDevice.h
+++ b/storage/CompoundAction/Formatter/StrayBlkDevice.h
@@ -39,9 +39,9 @@ namespace storage
 
 	StrayBlkDevice( const CompoundAction::Impl* compound_action );
 
-    private:
-
 	virtual Text text() const override;
+
+    private:
 
 	Text format_as_swap_text() const;
 	Text format_as_encrypted_swap_text() const;

--- a/storage/CompoundAction/Formatter/Tmpfs.h
+++ b/storage/CompoundAction/Formatter/Tmpfs.h
@@ -38,9 +38,9 @@ namespace storage
 
 	Tmpfs(const CompoundAction::Impl* compound_action);
 
-    private:
-
 	virtual Text text() const override;
+
+    private:
 
 	Text mount_text() const;
 	Text unmount_text() const;

--- a/storage/CompoundActionImpl.cc
+++ b/storage/CompoundActionImpl.cc
@@ -20,8 +20,6 @@
  */
 
 
-#include <boost/algorithm/string/join.hpp>
-
 #include "storage/CompoundActionImpl.h"
 #include "storage/CompoundAction/Generator.h"
 #include "storage/CompoundAction/Formatter/Bcache.h"
@@ -62,65 +60,66 @@ namespace storage
     }
 
 
-    vector<string>
-    CompoundAction::Impl::get_commit_actions_as_strings() const
+    vector<Text>
+    CompoundAction::Impl::get_commit_actions_as_texts() const
     {
 	const CommitData commit_data(actiongraph->get_impl(), Tense::SIMPLE_PRESENT);
 
-	vector<string> ret;
+	vector<Text> ret;
+
 	for (const Action::Base* action : commit_actions)
-	    ret.push_back(action->text(commit_data).translated);
+	    ret.push_back(action->text(commit_data));
 
 	return ret;
     }
 
 
-    string
+    Text
     CompoundAction::Impl::sentence() const
     {
 	if (is_partition(target_device))
-	    return CompoundAction::Formatter::Partition(this).string_representation();
+	    return CompoundAction::Formatter::Partition(this).text();
 
 	else if (is_stray_blk_device(target_device))
-	    return CompoundAction::Formatter::StrayBlkDevice(this).string_representation();
+	    return CompoundAction::Formatter::StrayBlkDevice(this).text();
 
 	else if (is_lvm_lv(target_device))
-	    return CompoundAction::Formatter::LvmLv(this).string_representation();
+	    return CompoundAction::Formatter::LvmLv(this).text();
 
 	else if (is_lvm_vg(target_device))
-	    return CompoundAction::Formatter::LvmVg(this).string_representation();
+	    return CompoundAction::Formatter::LvmVg(this).text();
 
 	else if (is_btrfs(target_device))
 	{
 	    switch (type)
 	    {
 		case Type::BTRFS_QUOTA:
-		    return CompoundAction::Formatter::BtrfsQuota(this).string_representation();
+		    return CompoundAction::Formatter::BtrfsQuota(this).text();
 
 		case Type::BTRFS_QGROUPS:
-		    return CompoundAction::Formatter::BtrfsQgroups(this).string_representation();
+		    return CompoundAction::Formatter::BtrfsQgroups(this).text();
 
 		default:
-		    return CompoundAction::Formatter::Btrfs(this).string_representation();
+		    return CompoundAction::Formatter::Btrfs(this).text();
 	    }
 	}
 	else if (is_btrfs_subvolume(target_device))
-	    return CompoundAction::Formatter::BtrfsSubvolume(this).string_representation();
+	    return CompoundAction::Formatter::BtrfsSubvolume(this).text();
 
 	else if (is_nfs(target_device))
-	    return CompoundAction::Formatter::Nfs(this).string_representation();
+	    return CompoundAction::Formatter::Nfs(this).text();
 
 	else if (is_tmpfs(target_device))
-	    return CompoundAction::Formatter::Tmpfs(this).string_representation();
+	    return CompoundAction::Formatter::Tmpfs(this).text();
 
 	else if (is_bcache(target_device))
-	    return CompoundAction::Formatter::Bcache(this).string_representation();
+	    return CompoundAction::Formatter::Bcache(this).text();
 
 	else if (is_md(target_device))
-	    return CompoundAction::Formatter::Md(this).string_representation();
+	    return CompoundAction::Formatter::Md(this).text();
 
 	else
-	    return boost::algorithm::join(get_commit_actions_as_strings(), "\n");
+	    return join(get_commit_actions_as_texts(), JoinMode::NEWLINE, 0);
     }
 
 

--- a/storage/CompoundActionImpl.h
+++ b/storage/CompoundActionImpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) [2017-2020] SUSE LLC
+ * Copyright (c) [2017-2021] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -35,7 +35,6 @@ namespace storage
 {
 
     using std::vector;
-    using std::string;
 
     class PartitionTable;
     class Encryption;
@@ -64,13 +63,9 @@ namespace storage
 
 	void add_commit_action(const Action::Base* action);
 
-    private:
+	vector<Text> get_commit_actions_as_texts() const;
 
-	vector<string> get_commit_actions_as_strings() const;
-
-    public:
-
-	string sentence() const;
+	Text sentence() const;
 
 	bool is_delete() const;
 

--- a/storage/Utils/Text.cc
+++ b/storage/Utils/Text.cc
@@ -85,11 +85,11 @@ namespace storage
 	size_t n1 = values.size();
 
 	// number of texts to include in result, limit is at least 2
-	size_t n2 = min(n1, max(limit, (size_t)(2)));
+	size_t n2 = limit == 0 ? n1 : min(n1, max(limit, (size_t)(2)));
 
 	Text ret;
 
-	for (size_t i = 0; i < n2; i++)
+	for (size_t i = 0; i < n2; ++i)
 	{
 	    if (i == 0)
 	    {

--- a/storage/Utils/Text.h
+++ b/storage/Utils/Text.h
@@ -101,7 +101,7 @@ namespace storage
      * Joins the values either with newlines or commas depending on
      * the join_mode. The number of values included in the result is
      * limited by limit. If values are omitted the result includes a
-     * text like "and 7 more".
+     * text like "and 7 more". A limit of 0 means no limit.
      */
     Text
     join(const vector<Text>& values, JoinMode join_mode, size_t limit);

--- a/testsuite/CompoundAction/btrfs-quota-sentence.cc
+++ b/testsuite/CompoundAction/btrfs-quota-sentence.cc
@@ -192,4 +192,32 @@ BOOST_AUTO_TEST_CASE(test_enable1)
 }
 
 
+BOOST_AUTO_TEST_CASE(test_modify1)
+{
+    initialize_staging_with_three_partitions();
+    Btrfs* btrfs = to_btrfs(sda2->create_blk_filesystem(FsType::BTRFS));
+    btrfs->set_quota(true);
+
+    BtrfsSubvolume* toplevel = btrfs->get_top_level_btrfs_subvolume();
+
+    BtrfsSubvolume* subvolume1 = toplevel->create_btrfs_subvolume("test1");
+
+    copy_staging_to_probed();
+
+    subvolume1->set_nocow(true);
+    BtrfsQgroup* group1 = subvolume1->get_btrfs_qgroup();
+    group1->set_exclusive_limit(1 * GiB);
+
+    const Actiongraph* actiongraph = storage->calculate_actiongraph();
+    vector<const CompoundAction*> compound_actions = actiongraph->get_compound_actions();
+
+    BOOST_REQUIRE_EQUAL(compound_actions.size(), 1);
+
+    // TODO the order here could be different
+
+    BOOST_CHECK_EQUAL(compound_actions[0]->sentence(), "Set limits for qgroup of subvolume test1 on /dev/sda2 (500.00 MiB)" "\n"
+		      "Set option 'no copy on write' for subvolume test1 on /dev/sda2 (500.00 MiB)");
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/testsuite/Utils/join.cc
+++ b/testsuite/Utils/join.cc
@@ -14,8 +14,10 @@ BOOST_AUTO_TEST_CASE(test_zero)
 {
     const vector<string> v;
 
+    BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 0).native, "");
     BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 100).native, "");
 
+    BOOST_CHECK_EQUAL(join(v, JoinMode::COMMA, 0).native, "");
     BOOST_CHECK_EQUAL(join(v, JoinMode::COMMA, 100).native, "");
 }
 
@@ -24,8 +26,10 @@ BOOST_AUTO_TEST_CASE(test_one)
 {
     const vector<string> v = { "1" };
 
+    BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 0).native, "1");
     BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 100).native, "1");
 
+    BOOST_CHECK_EQUAL(join(v, JoinMode::COMMA, 0).native, "1");
     BOOST_CHECK_EQUAL(join(v, JoinMode::COMMA, 100).native, "1");
 }
 
@@ -34,9 +38,11 @@ BOOST_AUTO_TEST_CASE(test_two)
 {
     const vector<string> v = { "1", "2" };
 
+    BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 0).native, "1\n2");
     BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 2).native, "1\n2");
     BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 100).native, "1\n2");
 
+    BOOST_CHECK_EQUAL(join(v, JoinMode::COMMA, 0).native, "1 and 2");
     BOOST_CHECK_EQUAL(join(v, JoinMode::COMMA, 2).native, "1 and 2");
     BOOST_CHECK_EQUAL(join(v, JoinMode::COMMA, 100).native, "1 and 2");
 }
@@ -46,6 +52,7 @@ BOOST_AUTO_TEST_CASE(test_five)
 {
     const vector<string> v = { "1", "2", "3", "4", "5" };
 
+    BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 0).native, "1\n2\n3\n4\n5");
     BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 1).native, "1\n4 more");
     BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 2).native, "1\n4 more");
     BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 3).native, "1\n2\n3 more");
@@ -53,6 +60,7 @@ BOOST_AUTO_TEST_CASE(test_five)
     BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 5).native, "1\n2\n3\n4\n5");
     BOOST_CHECK_EQUAL(join(v, JoinMode::NEWLINE, 100).native, "1\n2\n3\n4\n5");
 
+    BOOST_CHECK_EQUAL(join(v, JoinMode::COMMA, 0).native, "1, 2, 3, 4 and 5");
     BOOST_CHECK_EQUAL(join(v, JoinMode::COMMA, 1).native, "1 and 4 more");
     BOOST_CHECK_EQUAL(join(v, JoinMode::COMMA, 2).native, "1 and 4 more");
     BOOST_CHECK_EQUAL(join(v, JoinMode::COMMA, 3).native, "1, 2 and 3 more");


### PR DESCRIPTION
Per default join all action messages for compound actions. So far only one message was shows.

This is needed when setting nocow for a subvolume and changing a limit for the corresponding qgroup.
