### PR TITLE
Simplify compound actions for subvolumes

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: installation\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2018-02-02 15:00+0000\n"
 "Last-Translator: Arvin Schnell <aschnell@suse.com>\n"
 "Language-Team: Afrikaans <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -893,32 +893,6 @@ msgstr "Skep omruil- logiese volume %1$s (%2$s)"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Skep logiese volume %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Skep logiese volume %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Skep logiese volume %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Skep logiese volume %1$s (%2$s)"
 
 #. TRANSLATORS: displayed before action,
@@ -2152,6 +2126,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Verwyder uit gunstelinge"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Skep logiese volume %1$s (%2$s)"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3167,6 +3149,20 @@ msgstr "kG"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Skep logiese volume %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Skep logiese volume %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Skep logiese volume %1$s (%2$s)"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/ar.po
+++ b/po/ar.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2019-04-04 15:03+0000\n"
 "Last-Translator: Iman Abd Elaziz <Iman.AbdelAziz@arabize.com>\n"
 "Language-Team: Arabic <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -938,35 +938,6 @@ msgstr "إنشاء %1$s 1 على %2$s 2 (‏%3$s 3)"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "إنشاء وحدة التخزين الفرعية %1$s على %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-"إنشاء وحدة التخزين الفرعية %1$s على %2$s بالخيار \"عدم النسخ عند الكتابة\""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-"إنشاء وحدة التخزين الفرعية %1$s على %2$s بالخيار \"عدم النسخ عند الكتابة\""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr ""
-"إنشاء وحدة التخزين الفرعية %1$s على %2$s بالخيار \"عدم النسخ عند الكتابة\""
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2257,6 +2228,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "تتم الآن إزالة %1$s من %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "يتم الآن إنشاء وحدة تخزين فرعية %1$s على %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3288,6 +3267,23 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr ""
+#~ "إنشاء وحدة التخزين الفرعية %1$s على %2$s بالخيار \"عدم النسخ عند الكتابة\""
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr ""
+#~ "إنشاء وحدة التخزين الفرعية %1$s على %2$s بالخيار \"عدم النسخ عند الكتابة\""
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr ""
+#~ "إنشاء وحدة التخزين الفرعية %1$s على %2$s بالخيار \"عدم النسخ عند الكتابة\""
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "إنشاء MD‏ %1$s %2$s (‏%3$s)"

--- a/po/be.po
+++ b/po/be.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2006-01-04 08:58+0100\n"
 "Last-Translator: Alexander Nyakhaychyk <nyakhaychyk@gmail.com>\n"
 "Language-Team: Belarusian <i18n@suse.de>\n"
@@ -891,32 +891,6 @@ msgstr "Стварыць"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Стварыць"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Стварыць"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Стварыць"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Стварыць"
 
 #. TRANSLATORS: displayed before action,
@@ -2145,6 +2119,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Выдаліць"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Стварыць"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3154,6 +3136,20 @@ msgstr ""
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Стварыць"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Стварыць"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Стварыць"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/bg.po
+++ b/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libstorage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2010-06-10 00:16+0300\n"
 "Last-Translator: Borislav Mitev <morbid_viper@tkzs.org>\n"
 "Language-Team: Bulgarian <kde-i18n-doc@kde.org>\n"
@@ -897,32 +897,6 @@ msgstr "Създаване на swap масив %1$s (%2$s)"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Създаване на масив %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Създаване на масив %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Създаване на масив %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Създаване на масив %1$s (%2$s)"
 
 #. TRANSLATORS: displayed before action,
@@ -2151,6 +2125,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Премахване на устройството %1$s от %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Създаване на масив %1$s (%2$s)"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3160,6 +3142,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Създаване на масив %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Създаване на масив %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Създаване на масив %1$s (%2$s)"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/bn.po
+++ b/po/bn.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2004-08-09 10:24+0200\n"
 "Last-Translator: xxx <yyy@example.org>\n"
 "Language-Team: Bengali <i18n@suse.de>\n"
@@ -892,32 +892,6 @@ msgstr " সোয়াপ লজিক্যাল ভলিউম %1$(2%$গু�
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "লজিক্যাল ভলিউম %1$-গুলি(2%$গুলি) সৃষ্টি করুন"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "লজিক্যাল ভলিউম %1$-গুলি(2%$গুলি) সৃষ্টি করুন"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "লজিক্যাল ভলিউম %1$-গুলি(2%$গুলি) সৃষ্টি করুন"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "লজিক্যাল ভলিউম %1$-গুলি(2%$গুলি) সৃষ্টি করুন"
 
 #. TRANSLATORS: displayed before action,
@@ -2152,6 +2126,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "%1$গুলিকে %2$গুলি থেকে অপসারণ করুন"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "লজিক্যাল ভলিউম %1$-গুলি(2%$গুলি) সৃষ্টি করুন"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3167,6 +3149,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "লজিক্যাল ভলিউম %1$-গুলি(2%$গুলি) সৃষ্টি করুন"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "লজিক্যাল ভলিউম %1$-গুলি(2%$গুলি) সৃষ্টি করুন"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "লজিক্যাল ভলিউম %1$-গুলি(2%$গুলি) সৃষ্টি করুন"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/bs.po
+++ b/po/bs.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2002-07-23 18:27+0200\n"
 "Last-Translator: Damir Bjelobradic <Nagual@lugbih.org>\n"
 "Language-Team: Bosnian <i18n@suse.de>\n"
@@ -896,32 +896,6 @@ msgstr "Napravite planove za particije"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Napravite planove za particije"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Napravite planove za particije"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Napravite planove za particije"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Napravite planove za particije"
 
 #. TRANSLATORS: displayed before action,
@@ -2158,6 +2132,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "&Napravi"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Napravite planove za particije"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3173,6 +3155,20 @@ msgstr "MB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Napravite planove za particije"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Napravite planove za particije"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Napravite planove za particije"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/ca.po
+++ b/po/ca.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-11-10 18:50+0000\n"
 "Last-Translator: David Medina <medipas@gmail.com>\n"
 "Language-Team: Catalan <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -924,32 +924,6 @@ msgstr "Crea el qgrup %1$s a %2$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Crea el subvolum %1$s a %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Crea el subvolum %1$s a %2$s amb l'opció \"no copiar en escriure\""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Crea el subvolum %1$s a %2$s amb l'opció \"no copiar en escriure\""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Crea el subvolum %1$s a %2$s amb l'opció \"no copiar en escriure\""
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2205,6 +2179,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Modifica els grups btrfs a %1$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Creant el subvolum %1$s a %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3220,6 +3202,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr "fitxers temporals"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Crea el subvolum %1$s a %2$s amb l'opció \"no copiar en escriure\""
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Crea el subvolum %1$s a %2$s amb l'opció \"no copiar en escriure\""
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Crea el subvolum %1$s a %2$s amb l'opció \"no copiar en escriure\""
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Crea l'MD %1$s %2$s (%3$s)"

--- a/po/cs.po
+++ b/po/cs.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-11-10 18:50+0000\n"
 "Last-Translator: Aleš Kastner <alkas@volny.cz>\n"
 "Language-Team: Czech <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -935,32 +935,6 @@ msgstr "Vytvořit qgroup (q-skupinu) %1$s na %2$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Vytvořit podsvazek %1$s na %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Vytvořit podsvazek %1$s na %2$s s možností 'no copy on write'"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Vytvořit podsvazek %1$s na %2$s s možností 'no copy on write'"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Vytvořit podsvazek %1$s na %2$s s možností 'no copy on write'"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2219,6 +2193,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Změnit btfrs qgroups na %1$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Vytváření podsvazku %1$s na %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3229,6 +3211,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr "tmpfs"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Vytvořit podsvazek %1$s na %2$s s možností 'no copy on write'"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Vytvořit podsvazek %1$s na %2$s s možností 'no copy on write'"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Vytvořit podsvazek %1$s na %2$s s možností 'no copy on write'"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Vytvořit hlavní adresář (MD) %1$s %2$s (%3$s)"

--- a/po/cy.po
+++ b/po/cy.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2003-09-23 10:33+0200\n"
 "Last-Translator: Kevin Donnelly <kevin@dotmon.com>\n"
 "Language-Team: Welsh <i18n@suse.de>\n"
@@ -894,32 +894,6 @@ msgstr "Creu pwyntiau gosod"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Creu pwyntiau gosod"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Creu pwyntiau gosod"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Creu pwyntiau gosod"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Creu pwyntiau gosod"
 
 #. TRANSLATORS: displayed before action,
@@ -2156,6 +2130,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Gwa&redu"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Creu pwyntiau gosod"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3171,6 +3153,20 @@ msgstr "MB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Creu pwyntiau gosod"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Creu pwyntiau gosod"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Creu pwyntiau gosod"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/da.po
+++ b/po/da.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2019-09-26 02:52+0000\n"
 "Last-Translator: scootergrisen <scootergrisen@gmail.com>\n"
 "Language-Team: Danish <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -900,32 +900,6 @@ msgstr "Opret %1$s på %2$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Opret underdiskområdet %1$s på %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Opret underdiskområdet %1$s på %2$s med tilvalget 'no copy on write'"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Opret underdiskområdet %1$s på %2$s med tilvalget 'no copy on write'"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Opret underdiskområdet %1$s på %2$s med tilvalget 'no copy on write'"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2154,6 +2128,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Fjern %1$s fra %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Opretter underdiskområde %1$s på enheden %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3163,6 +3145,23 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr ""
+#~ "Opret underdiskområdet %1$s på %2$s med tilvalget 'no copy on write'"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr ""
+#~ "Opret underdiskområdet %1$s på %2$s med tilvalget 'no copy on write'"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr ""
+#~ "Opret underdiskområdet %1$s på %2$s med tilvalget 'no copy on write'"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/de.po
+++ b/po/de.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-01-14 13:53+0000\n"
 "Last-Translator: Sarah Kriesch <ada.lovelace@gmx.de>\n"
 "Language-Team: German <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -934,35 +934,6 @@ msgstr "%1$s auf %2$s erstellen"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Subvolume %1$s auf %2$s erstellen"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-"Subvolume %1$s auf %2$s mit der Option 'Keine Kopie beim Schreiben' erstellen"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-"Subvolume %1$s auf %2$s mit der Option 'Keine Kopie beim Schreiben' erstellen"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr ""
-"Subvolume %1$s auf %2$s mit der Option 'Keine Kopie beim Schreiben' erstellen"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2219,6 +2190,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "%1$s wird aus %2$s entfernt"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Subvolume %1$s wird auf %2$s erstellt"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3241,6 +3220,26 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr ""
+#~ "Subvolume %1$s auf %2$s mit der Option 'Keine Kopie beim Schreiben' "
+#~ "erstellen"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr ""
+#~ "Subvolume %1$s auf %2$s mit der Option 'Keine Kopie beim Schreiben' "
+#~ "erstellen"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr ""
+#~ "Subvolume %1$s auf %2$s mit der Option 'Keine Kopie beim Schreiben' "
+#~ "erstellen"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "MD %1$s %2$s (%3$s) erstellen"

--- a/po/el.po
+++ b/po/el.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Greek (libstorage)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2018-05-06 20:25+0000\n"
 "Last-Translator: Konstantina Tsolakoglou <konstantina@accountant.com>\n"
 "Language-Team: Greek <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -890,32 +890,6 @@ msgstr "Δημιουργία %1$s στο %2$s (%3$s)"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Δημιουργία Λογικού Τόμου %1$s στη συσκευή %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Δημιουργία Λογικού Τόμου %1$s στη συσκευή %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Δημιουργία Λογικού Τόμου %1$s στη συσκευή %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Δημιουργία Λογικού Τόμου %1$s στη συσκευή %2$s"
 
 #. TRANSLATORS: displayed before action,
@@ -2146,6 +2120,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Αφαίρεση του%1$s  από το %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Δημιουργία Λογικού Τόμου %1$s στη συσκευή %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3158,6 +3140,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Δημιουργία Λογικού Τόμου %1$s στη συσκευή %2$s"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Δημιουργία Λογικού Τόμου %1$s στη συσκευή %2$s"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Δημιουργία Λογικού Τόμου %1$s στη συσκευή %2$s"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Δημιουργία MD %1$s %2$s (%3$s)"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2001-07-17 16:27+0200\n"
 "Last-Translator: James Ogley <ogley@suse.co.uk>\n"
 "Language-Team: English <i18n@suse.de>\n"
@@ -894,32 +894,6 @@ msgstr "Create swap logical volume %1$s (%2$s)"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Create logical volume %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Create logical volume %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Create logical volume %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Create logical volume %1$s (%2$s)"
 
 #. TRANSLATORS: displayed before action,
@@ -2154,6 +2128,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Remove %1$s from %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Create logical volume %1$s (%2$s)"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3169,6 +3151,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Create logical volume %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Create logical volume %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Create logical volume %1$s (%2$s)"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/en_US.po
+++ b/po/en_US.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2002-07-18 14:04+0200\n"
 "Last-Translator: proofreader <i18n@suse.de>\n"
 "Language-Team: English <i18n@suse.de>\n"
@@ -890,32 +890,6 @@ msgstr "Create MD5 sums"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Create MD5 sums"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Create MD5 sums"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Create MD5 sums"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Create MD5 sums"
 
 #. TRANSLATORS: displayed before action,
@@ -2144,6 +2118,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Remove packages"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Create MD5 sums"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3153,6 +3135,20 @@ msgstr ""
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Create MD5 sums"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Create MD5 sums"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Create MD5 sums"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/eo.po
+++ b/po/eo.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2012-02-12 09:27+0100\n"
 "Last-Translator: Karl Eichwalder <ke@suse.de>\n"
 "Language-Team: Esperanto <i18n@suse.de>\n"
@@ -888,32 +888,6 @@ msgstr ""
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr ""
 
 #. TRANSLATORS: displayed before action,
@@ -2134,6 +2108,14 @@ msgstr ""
 #. (10.00 GiB) and /dev/sda2 (10.00 GiB))
 #, c-format
 msgid "Modify btrfs qgroups on %1$s"
+msgstr ""
+
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, c-format
+msgid "Modify subvolume %1$s on %2$s"
 msgstr ""
 
 #. TRANSLATORS:

--- a/po/es.po
+++ b/po/es.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-02-21 00:54+0000\n"
 "Last-Translator: Juan Sarria <juansarriam@gmail.com>\n"
 "Language-Team: Spanish <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -940,32 +940,6 @@ msgstr "Crear %1$s en %2$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Crear subvolumen %1$s en %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Crear subvolumen %1$s en %2$s con la opción \"no copiar al escribir\""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Crear subvolumen %1$s en %2$s con la opción \"no copiar al escribir\""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Crear subvolumen %1$s en %2$s con la opción \"no copiar al escribir\""
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2243,6 +2217,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Eliminando %1$s de %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Creando subvolumen %1$s en %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3261,6 +3243,23 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr ""
+#~ "Crear subvolumen %1$s en %2$s con la opción \"no copiar al escribir\""
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr ""
+#~ "Crear subvolumen %1$s en %2$s con la opción \"no copiar al escribir\""
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr ""
+#~ "Crear subvolumen %1$s en %2$s con la opción \"no copiar al escribir\""
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Crear MD %1$s %2$s (%3$s)"

--- a/po/et.po
+++ b/po/et.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: autoinst.fi\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2019-12-02 16:54+0000\n"
 "Last-Translator: Jaanus Ojangu <jaanus.ojangu@gmail.com>\n"
 "Language-Team: Estonian <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -897,32 +897,6 @@ msgstr "Saale loogilise andmeruumi %1$s (%2$s) loomine"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Loogilise andmeruumi %1$s (%2$s) loomine"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Loogilise andmeruumi %1$s (%2$s) loomine"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Loogilise andmeruumi %1$s (%2$s) loomine"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Loogilise andmeruumi %1$s (%2$s) loomine"
 
 #. TRANSLATORS: displayed before action,
@@ -2169,6 +2143,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "%1$s eemaldamine failist %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Loogilise andmeruumi %1$s (%2$s) loomine"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3204,6 +3186,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Loogilise andmeruumi %1$s (%2$s) loomine"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Loogilise andmeruumi %1$s (%2$s) loomine"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Loogilise andmeruumi %1$s (%2$s) loomine"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/eu.po
+++ b/po/eu.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2003-02-12 10:23+0100\n"
 "Last-Translator: i18n@suse.de\n"
 "Language-Team: Basque <i18n@suse.de>\n"
@@ -888,32 +888,6 @@ msgstr ""
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr ""
 
 #. TRANSLATORS: displayed before action,
@@ -2134,6 +2108,14 @@ msgstr ""
 #. (10.00 GiB) and /dev/sda2 (10.00 GiB))
 #, c-format
 msgid "Modify btrfs qgroups on %1$s"
+msgstr ""
+
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, c-format
+msgid "Modify subvolume %1$s on %2$s"
 msgstr ""
 
 #. TRANSLATORS:

--- a/po/fa.po
+++ b/po/fa.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: opensuse-i 18n\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2013-09-12 11:05+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -888,32 +888,6 @@ msgstr ""
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr ""
 
 #. TRANSLATORS: displayed before action,
@@ -2134,6 +2108,14 @@ msgstr ""
 #. (10.00 GiB) and /dev/sda2 (10.00 GiB))
 #, c-format
 msgid "Modify btrfs qgroups on %1$s"
+msgstr ""
+
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, c-format
+msgid "Modify subvolume %1$s on %2$s"
 msgstr ""
 
 #. TRANSLATORS:

--- a/po/fi.po
+++ b/po/fi.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libstorage.fi\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2021-01-05 16:37+0000\n"
 "Last-Translator: Tommi Nieminen <software@legisign.org>\n"
 "Language-Team: Finnish <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -934,32 +934,6 @@ msgstr "Luo qgroup %1$s laitteelle %2$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Luo alitaltio %1$s laitteelle %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Luo alitaltio %1$s laitteelle %2$s valinnalla ”kopioi kirjoittamatta”"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Luo alitaltio %1$s laitteelle %2$s valinnalla ”kopioi kirjoittamatta”"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Luo alitaltio %1$s laitteelle %2$s valinnalla ”kopioi kirjoittamatta”"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2221,6 +2195,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Muokkaa btrfs:n qgroupsia laitteella %1$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Luodaan alitaltio %1$s laitteelle %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3237,6 +3219,23 @@ msgstr "kt"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr "tmpfs"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr ""
+#~ "Luo alitaltio %1$s laitteelle %2$s valinnalla ”kopioi kirjoittamatta”"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr ""
+#~ "Luo alitaltio %1$s laitteelle %2$s valinnalla ”kopioi kirjoittamatta”"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr ""
+#~ "Luo alitaltio %1$s laitteelle %2$s valinnalla ”kopioi kirjoittamatta”"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Luo MD %1$s -laite %2$s (%3$s)"

--- a/po/fr.po
+++ b/po/fr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-12-29 16:37+0000\n"
 "Last-Translator: Antoine Belvire <antoine.belvire@opensuse.org>\n"
 "Language-Team: French <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -987,38 +987,6 @@ msgstr "Créer le qgroup %1$s sur %2$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Créer le sous-volume %1$s sur %2$s"
-
-# TLABEL partitioning_2002_01_04_0147__351
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-"Créer le sous-volume %1$s sur %2$s avec l'option Pas de copie pour l'écriture"
-
-# TLABEL partitioning_2002_01_04_0147__351
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-"Créer le sous-volume %1$s sur %2$s avec l'option Pas de copie pour l'écriture"
-
-# TLABEL partitioning_2002_01_04_0147__351
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr ""
-"Créer le sous-volume %1$s sur %2$s avec l'option Pas de copie pour l'écriture"
 
 # TLABEL partitioning_2002_03_14_2340__121
 #. TRANSLATORS: displayed before action,
@@ -2413,6 +2381,15 @@ msgstr "Partition réservée Microsoft"
 msgid "Modify btrfs qgroups on %1$s"
 msgstr "Modifier les qgroups btrfs sur %1$s"
 
+# TLABEL partitioning_2002_01_04_0147__351
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Création du sous-volume %1$s sur %2$s"
+
 # TLABEL partitioning_2002_01_04_0147__425
 #. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
@@ -3518,6 +3495,29 @@ msgstr "ko"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr "tmpfs"
+
+# TLABEL partitioning_2002_01_04_0147__351
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr ""
+#~ "Créer le sous-volume %1$s sur %2$s avec l'option Pas de copie pour "
+#~ "l'écriture"
+
+# TLABEL partitioning_2002_01_04_0147__351
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr ""
+#~ "Créer le sous-volume %1$s sur %2$s avec l'option Pas de copie pour "
+#~ "l'écriture"
+
+# TLABEL partitioning_2002_01_04_0147__351
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr ""
+#~ "Créer le sous-volume %1$s sur %2$s avec l'option Pas de copie pour "
+#~ "l'écriture"
 
 # TLABEL partitioning_2002_01_04_0147__351
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/gl.po
+++ b/po/gl.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2019-02-19 09:18+0000\n"
 "Last-Translator: Miguel Branco <mgl.branco@gmail.com>\n"
 "Language-Team: Galician <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -936,32 +936,6 @@ msgstr "Crear %1$s en %2$s (%3$s)"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Crear o subvolume %1$s en %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Crear o subvolume %1$s en %2$s coa opción 'non copiar na escrita'"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Crear o subvolume %1$s en %2$s coa opción 'non copiar na escrita'"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Crear o subvolume %1$s en %2$s coa opción 'non copiar na escrita'"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2222,6 +2196,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Eliminando %1$s de %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Creando o subvolume %1$s en %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3245,6 +3227,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Crear o subvolume %1$s en %2$s coa opción 'non copiar na escrita'"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Crear o subvolume %1$s en %2$s coa opción 'non copiar na escrita'"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Crear o subvolume %1$s en %2$s coa opción 'non copiar na escrita'"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Crear MD %1$s %2$s (%3$s)"

--- a/po/gu.po
+++ b/po/gu.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2005-07-29 15:37+0530\n"
 "Last-Translator: i18n@suse.de\n"
 "Language-Team: Gujarati <i18n@suse.de>\n"
@@ -891,32 +891,6 @@ msgstr " સ્વેપ લોજિકલ વોલ્યૂમ %1$s (%2$s) �
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr " લોજિકલ વોલ્યૂમ %1$s (%2$s) બનાવો "
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr " લોજિકલ વોલ્યૂમ %1$s (%2$s) બનાવો "
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr " લોજિકલ વોલ્યૂમ %1$s (%2$s) બનાવો "
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr " લોજિકલ વોલ્યૂમ %1$s (%2$s) બનાવો "
 
 #. TRANSLATORS: displayed before action,
@@ -2151,6 +2125,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr " %1$s ને %2$s માંથી દૂર કરો "
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr " લોજિકલ વોલ્યૂમ %1$s (%2$s) બનાવો "
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3166,6 +3148,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr " લોજિકલ વોલ્યૂમ %1$s (%2$s) બનાવો "
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr " લોજિકલ વોલ્યૂમ %1$s (%2$s) બનાવો "
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr " લોજિકલ વોલ્યૂમ %1$s (%2$s) બનાવો "
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/he.po
+++ b/po/he.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2004-08-09 10:24+0200\n"
 "Last-Translator: xxx <yyy@example.org>\n"
 "Language-Team: Hebrew <i18n@suse.de>\n"
@@ -1013,35 +1013,6 @@ msgstr "יצור כרך לוגי"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "יצור כרך לוגי"
-
-#  popup heading 
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "יצור כרך לוגי"
-
-#  popup heading 
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "יצור כרך לוגי"
-
-#  popup heading 
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "יצור כרך לוגי"
 
 #  to translators: * Create partition hda3 700 MB (for /var with ext2)
@@ -2476,6 +2447,15 @@ msgstr ""
 msgid "Modify btrfs qgroups on %1$s"
 msgstr "הסר את ההתקן %1 מהקובץ /etc/fstab"
 
+#  popup heading 
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "יצור כרך לוגי"
+
 #  normal text e.g. "Set mount point of /dev/hda1 to /usr"
 #. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
@@ -3629,6 +3609,23 @@ msgstr "מגה בייט"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#  popup heading 
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "יצור כרך לוגי"
+
+#  popup heading 
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "יצור כרך לוגי"
+
+#  popup heading 
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "יצור כרך לוגי"
 
 #  popup heading 
 #, fuzzy

--- a/po/hi.po
+++ b/po/hi.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-09-09 18:51+0000\n"
 "Last-Translator: Panwar <caspian7pena@gmail.com>\n"
 "Language-Team: Hindi <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -896,32 +896,6 @@ msgstr "स्वैप लॉजिकल वॉल्यूम %1$s (%2$s) क
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "लॉजिकल वॉल्यूम %1$s (%2$s) को सृजित करें"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "लॉजिकल वॉल्यूम %1$s (%2$s) को सृजित करें"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "लॉजिकल वॉल्यूम %1$s (%2$s) को सृजित करें"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "लॉजिकल वॉल्यूम %1$s (%2$s) को सृजित करें"
 
 #. TRANSLATORS: displayed before action,
@@ -2156,6 +2130,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "%2$s से %1$s को हटाएं"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "लॉजिकल वॉल्यूम %1$s (%2$s) को सृजित करें"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3171,6 +3153,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "लॉजिकल वॉल्यूम %1$s (%2$s) को सृजित करें"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "लॉजिकल वॉल्यूम %1$s (%2$s) को सृजित करें"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "लॉजिकल वॉल्यूम %1$s (%2$s) को सृजित करें"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/hr.po
+++ b/po/hr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2011-04-03 15:43+0200\n"
 "Last-Translator: Krešimir Jozić <kjozic@gmail.com>\n"
 "Language-Team: Croatian <kde-i18n-doc@kde.org>\n"
@@ -896,32 +896,6 @@ msgstr "Ukloni particiju %1$s (%2$s)"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Ukloni particiju %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Ukloni particiju %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Ukloni particiju %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Ukloni particiju %1$s (%2$s)"
 
 #. TRANSLATORS: displayed before action,
@@ -2151,6 +2125,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Montiram %1$s na %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Ukloni particiju %1$s (%2$s)"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3160,6 +3142,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Ukloni particiju %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Ukloni particiju %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Ukloni particiju %1$s (%2$s)"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/hu.po
+++ b/po/hu.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libstorage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2019-04-04 15:03+0000\n"
 "Last-Translator: Robert Taisz <robert.taisz@emerald.hu>\n"
 "Language-Team: Hungarian <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -1009,38 +1009,6 @@ msgstr "%1$s létrehozás a(z) %2$s eszközön (%3$s)"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "%1$s alkötet létrehozása a(z) %2$s eszközön"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-"%1$s alkötet létrehozása a(z) %2$s eszközön \"íráskor nincs másolás\" "
-"beállítással"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-"%1$s alkötet létrehozása a(z) %2$s eszközön \"íráskor nincs másolás\" "
-"beállítással"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr ""
-"%1$s alkötet létrehozása a(z) %2$s eszközön \"íráskor nincs másolás\" "
-"beállítással"
 
 # modules/inst_custom_part.ycp:623
 #. TRANSLATORS: displayed before action,
@@ -2420,6 +2388,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "%1$s eltávolítása a(z) %2$s kötetcsoportból"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "%1$s alkötet létrehozása a(z) %2$s eszközön"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3515,6 +3491,26 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr ""
+#~ "%1$s alkötet létrehozása a(z) %2$s eszközön \"íráskor nincs másolás\" "
+#~ "beállítással"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr ""
+#~ "%1$s alkötet létrehozása a(z) %2$s eszközön \"íráskor nincs másolás\" "
+#~ "beállítással"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr ""
+#~ "%1$s alkötet létrehozása a(z) %2$s eszközön \"íráskor nincs másolás\" "
+#~ "beállítással"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "MD %1$s %2$s (%3$s) létrehozása"

--- a/po/id.po
+++ b/po/id.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-11-12 04:50+0000\n"
 "Last-Translator: Kukuh Syafaat <syafaatkukuh@gmail.com>\n"
 "Language-Team: Indonesian <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -920,32 +920,6 @@ msgstr "Buat qgrup %1$s pada %2$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Buat subvolume %1$s pada %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Buat subvolume %1$s pada %2$s dengan opsi 'no copy on write'"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Buat subvolume %1$s pada %2$s dengan opsi 'no copy on write'"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Buat subvolume %1$s pada %2$s dengan opsi 'no copy on write'"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2196,6 +2170,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Ubah qgrup btrfs pada %1$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Membuat subvolume %1$s pada %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3206,6 +3188,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr "tmpfs"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Buat subvolume %1$s pada %2$s dengan opsi 'no copy on write'"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Buat subvolume %1$s pada %2$s dengan opsi 'no copy on write'"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Buat subvolume %1$s pada %2$s dengan opsi 'no copy on write'"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Buat MD %1$s %2$s (%3$s)"

--- a/po/it.po
+++ b/po/it.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libstorage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-10-29 08:49+0000\n"
 "Last-Translator: Paolo Za <zapaolo@email.it>\n"
 "Language-Team: Italian <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -997,32 +997,6 @@ msgstr "Crea %1$s su %2$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Creare il sottovolume %1$s su %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Creare il sottovolume %1$s su %2$s con l'opzione 'no copy on write'"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Creare il sottovolume %1$s su %2$s con l'opzione 'no copy on write'"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Creare il sottovolume %1$s su %2$s con l'opzione 'no copy on write'"
 
 # #-#-#-#-#  storage.it.po (storage)  #-#-#-#-#
 # TLABEL modules/inst_custom_part.ycp:2474
@@ -2422,6 +2396,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Rimozione di %1$s da %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Creazione del sottovolume %1$s su %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3452,6 +3434,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr "tmpfs"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Creare il sottovolume %1$s su %2$s con l'opzione 'no copy on write'"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Creare il sottovolume %1$s su %2$s con l'opzione 'no copy on write'"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Creare il sottovolume %1$s su %2$s con l'opzione 'no copy on write'"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Creare l'MD %1$s %2$s (%3$s)"

--- a/po/ja.po
+++ b/po/ja.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libstorage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-11-10 13:50+0000\n"
 "Last-Translator: Yasuhiko Kamata <belphegor@belbel.or.jp>\n"
 "Language-Team: Japanese <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -928,35 +928,6 @@ msgstr "%2$s に対する qgroup %1$s の作成"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "%2$s に対するサブボリューム %1$s の作成"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-"'no copy on write' オプション付きで %2$s に対するサブボリューム %1$s の作成"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-"'no copy on write' オプション付きで %2$s に対するサブボリューム %1$s の作成"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr ""
-"'no copy on write' オプション付きで %2$s に対するサブボリューム %1$s の作成"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2232,6 +2203,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "%1$s にある btrfs qgroup の変更"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "%2$s 内にサブボリューム %1$s を作成しています"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3258,6 +3237,26 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr "tmpfs"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr ""
+#~ "'no copy on write' オプション付きで %2$s に対するサブボリューム %1$s の作"
+#~ "成"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr ""
+#~ "'no copy on write' オプション付きで %2$s に対するサブボリューム %1$s の作"
+#~ "成"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr ""
+#~ "'no copy on write' オプション付きで %2$s に対するサブボリューム %1$s の作"
+#~ "成"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "MD %1$s %2$s (%3$s) の作成"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date:  2005-05-17 19:57+0200\n"
 "Last-Translator: Aiet Kolkhi <aiet@qartuli.net>\n"
 "Language-Team: Georgian <i18n@suse.de>\n"
@@ -892,32 +892,6 @@ msgstr "%1 დანაყოფის შემოწმება"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "%1 დანაყოფის შემოწმება"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "%1 დანაყოფის შემოწმება"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "%1 დანაყოფის შემოწმება"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "%1 დანაყოფის შემოწმება"
 
 #. TRANSLATORS: displayed before action,
@@ -2151,6 +2125,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "მონაცემებიდან ამოღება"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "%1 დანაყოფის შემოწმება"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3178,6 +3160,20 @@ msgstr "კბ"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "%1 დანაყოფის შემოწმება"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "%1 დანაყოფის შემოწმება"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "%1 დანაყოფის შემოწმება"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/km.po
+++ b/po/km.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libstorage.km\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2012-05-11 12:37+0700\n"
 "Last-Translator: Khoem Sokhem <khoemsokhem@khmeros.info>\n"
 "Language-Team: Khmer <support@khmeros.info>\n"
@@ -896,32 +896,6 @@ msgstr "បង្កើត​ភាគ​ថាស​​ស្វប %1$s (%2$s)
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "បង្កើត​ភាគ​ថាស​រង​ %1$s លើ​ឧបករណ៍ %2$s​"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "បង្កើត​ភាគ​ថាស​រង​ %1$s លើ​ឧបករណ៍ %2$s​"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "បង្កើត​ភាគ​ថាស​រង​ %1$s លើ​ឧបករណ៍ %2$s​"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "បង្កើត​ភាគ​ថាស​រង​ %1$s លើ​ឧបករណ៍ %2$s​"
 
 #. TRANSLATORS: displayed before action,
@@ -2150,6 +2124,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "យក %1$s ចេញ​ពី %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "កំពុង​បង្កើត​ភាគ​ថាស​រង​ %1$s លើ​ឧបករណ៍ %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3159,6 +3141,20 @@ msgstr "គីឡូបៃ"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "បង្កើត​ភាគ​ថាស​រង​ %1$s លើ​ឧបករណ៍ %2$s​"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "បង្កើត​ភាគ​ថាស​រង​ %1$s លើ​ឧបករណ៍ %2$s​"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "បង្កើត​ភាគ​ថាស​រង​ %1$s លើ​ឧបករណ៍ %2$s​"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/ko.po
+++ b/po/ko.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libstorage.ko\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2019-04-04 15:03+0000\n"
 "Last-Translator: Hwajin Kim <hwajin.kim@e4net.net>\n"
 "Language-Team: Korean <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -965,35 +965,6 @@ msgstr "%2$s(%3$s)에서 %1$s을(를) 생성"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "%2$s에 %1$s 하위 볼륨을 생성"
-
-# SLE12
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "'no copy on write' 옵션으로 %2$s에서 하위 볼륨 %1$s 생성"
-
-# SLE12
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "'no copy on write' 옵션으로 %2$s에서 하위 볼륨 %1$s 생성"
-
-# SLE12
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "'no copy on write' 옵션으로 %2$s에서 하위 볼륨 %1$s 생성"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2320,6 +2291,15 @@ msgstr "Microsoft 예약된 파티션"
 msgid "Modify btrfs qgroups on %1$s"
 msgstr "%2$s에서 %1$s 제거 중"
 
+# SLE12
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "%2$s에 %1$s 하위 볼륨 생성 중"
+
 #. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
@@ -3354,6 +3334,23 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+# SLE12
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "'no copy on write' 옵션으로 %2$s에서 하위 볼륨 %1$s 생성"
+
+# SLE12
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "'no copy on write' 옵션으로 %2$s에서 하위 볼륨 %1$s 생성"
+
+# SLE12
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "'no copy on write' 옵션으로 %2$s에서 하위 볼륨 %1$s 생성"
 
 # SLE12
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/ku.po
+++ b/po/ku.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: memory.ku.po\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2005-09-23 00:15+0200\n"
 "Last-Translator: Kurdish Team <i18n@suse.de>\n"
 "Language-Team: Kurdish Team <i18n@suse.de>\n"
@@ -889,32 +889,6 @@ msgstr "%1$s Biafirîne"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "%1$s Biafirîne"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "%1$s Biafirîne"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "%1$s Biafirîne"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "%1$s Biafirîne"
 
 #. TRANSLATORS: displayed before action,
@@ -2149,6 +2123,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "%1$s Rake"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "%1$s Biafirîne"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3160,6 +3142,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "%1$s Biafirîne"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "%1$s Biafirîne"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "%1$s Biafirîne"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/libstorage-ng.pot
+++ b/po/libstorage-ng.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -890,32 +890,6 @@ msgstr ""
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr ""
 
 #. TRANSLATORS: displayed before action,
@@ -2136,6 +2110,14 @@ msgstr ""
 #. (10.00 GiB) and /dev/sda2 (10.00 GiB))
 #, c-format
 msgid "Modify btrfs qgroups on %1$s"
+msgstr ""
+
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, c-format
+msgid "Modify subvolume %1$s on %2$s"
 msgstr ""
 
 #. TRANSLATORS:

--- a/po/lo.po
+++ b/po/lo.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2006-01-04 08:58+0100\n"
 "Last-Translator: i18n@suse.de\n"
 "Language-Team: Lao <i18n@suse.de>\n"
@@ -888,32 +888,6 @@ msgstr ""
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr ""
 
 #. TRANSLATORS: displayed before action,
@@ -2134,6 +2108,14 @@ msgstr ""
 #. (10.00 GiB) and /dev/sda2 (10.00 GiB))
 #, c-format
 msgid "Modify btrfs qgroups on %1$s"
+msgstr ""
+
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, c-format
+msgid "Modify subvolume %1$s on %2$s"
 msgstr ""
 
 #. TRANSLATORS:

--- a/po/lt.po
+++ b/po/lt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libstorage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2018-05-10 06:32+0000\n"
 "Last-Translator: Mindaugas Baranauskas <opensuse.lietuviu.kalba@gmail.com>\n"
 "Language-Team: Lithuanian <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -902,32 +902,6 @@ msgstr "Sukurti %1$s ties %2$s (%3$s)"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Sukurti %2$s įrenginio %1$s potomį"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Sukurti potomį %1$s įrenginyje %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Sukurti potomį %1$s įrenginyje %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Sukurti potomį %1$s įrenginyje %2$s"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2159,6 +2133,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Pašalinti %1$s iš %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Kuriamas potomis %1$s įrenginyje %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3172,6 +3154,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Sukurti potomį %1$s įrenginyje %2$s"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Sukurti potomį %1$s įrenginyje %2$s"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Sukurti potomį %1$s įrenginyje %2$s"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/mk.po
+++ b/po/mk.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: base\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2006-10-08 02:39+0200\n"
 "Last-Translator: Zoran Dimovski <zoki.dimovski@gmail.com>\n"
 "Language-Team: Macedonian\n"
@@ -891,32 +891,6 @@ msgstr "&Креирај"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "&Креирај"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "&Креирај"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "&Креирај"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "&Креирај"
 
 #. TRANSLATORS: displayed before action,
@@ -2153,6 +2127,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "&Отстрани"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "&Креирај"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3168,6 +3150,20 @@ msgstr "МБ"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "&Креирај"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "&Креирај"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "&Креирај"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/mr.po
+++ b/po/mr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2005-07-29 15:37+0530\n"
 "Last-Translator: \"( अमेय पाळंदे ) Ameya Palande\" <2ameya@gmail.com>\n"
 "Language-Team: Marathi <i18n@suse.de>\n"
@@ -892,32 +892,6 @@ msgstr "निर्माण करा अदलाबदल लॉजिकल
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "निर्माण करा लॉजिकल संख्या %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "निर्माण करा लॉजिकल संख्या %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "निर्माण करा लॉजिकल संख्या %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "निर्माण करा लॉजिकल संख्या %1$s (%2$s)"
 
 #. TRANSLATORS: displayed before action,
@@ -2152,6 +2126,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "काढा %1$s यातून %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "निर्माण करा लॉजिकल संख्या %1$s (%2$s)"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3167,6 +3149,20 @@ msgstr "केबी"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "निर्माण करा लॉजिकल संख्या %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "निर्माण करा लॉजिकल संख्या %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "निर्माण करा लॉजिकल संख्या %1$s (%2$s)"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/nb.po
+++ b/po/nb.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2009-08-14 15:05+0200\n"
 "Last-Translator: Olav Pettershagen <olav.pet@gmail.com>\n"
 "Language-Team: Norwegian Bokmål <opensuse-translation@opensuse.org>\n"
@@ -893,32 +893,6 @@ msgstr "Opprett volum %1$s (%2$s) for veksleminne"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Opprett undervolumet %1$s på enheten %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Opprett undervolumet %1$s på enheten %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Opprett undervolumet %1$s på enheten %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Opprett undervolumet %1$s på enheten %2$s"
 
 #. TRANSLATORS: displayed before action,
@@ -2147,6 +2121,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Fjern %1$s fra %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Oppretter undervolumet %1$s på enheten %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3156,6 +3138,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Opprett undervolumet %1$s på enheten %2$s"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Opprett undervolumet %1$s på enheten %2$s"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Opprett undervolumet %1$s på enheten %2$s"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/nds.po
+++ b/po/nds.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2003-02-12 09:27+0100\n"
 "Last-Translator: nds <i18n@suse.de>\n"
 "Language-Team: Low German <i18n@suse.de>\n"
@@ -888,32 +888,6 @@ msgstr ""
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr ""
 
 #. TRANSLATORS: displayed before action,
@@ -2134,6 +2108,14 @@ msgstr ""
 #. (10.00 GiB) and /dev/sda2 (10.00 GiB))
 #, c-format
 msgid "Modify btrfs qgroups on %1$s"
+msgstr ""
+
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, c-format
+msgid "Modify subvolume %1$s on %2$s"
 msgstr ""
 
 #. TRANSLATORS:

--- a/po/nl.po
+++ b/po/nl.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libstorage.nl\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-11-10 13:50+0000\n"
 "Last-Translator: Freek de Kruijf <freek@opensuse.org>\n"
 "Language-Team: Dutch <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -930,32 +930,6 @@ msgstr "Qgroup %1$s op %2$s aanmaken"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Subvolume %1$s op %2$s aanmaken"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Subvolume %1$s op %2$s met optie 'no copy on write' aanmaken"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Subvolume %1$s op %2$s met optie 'no copy on write' aanmaken"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Subvolume %1$s op %2$s met optie 'no copy on write' aanmaken"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2203,6 +2177,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Btrfs qgroups wijzigen op %1$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Subvolume %1$s op %2$s wordt aangemaakt"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3216,6 +3198,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr "tmpfs"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Subvolume %1$s op %2$s met optie 'no copy on write' aanmaken"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Subvolume %1$s op %2$s met optie 'no copy on write' aanmaken"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Subvolume %1$s op %2$s met optie 'no copy on write' aanmaken"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "MD %1$s %2$s (%3$s) aanmaken"

--- a/po/nn.po
+++ b/po/nn.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2005-08-11 20:37+0200\n"
 "Last-Translator: nynorsk <i18n@suse.de>\n"
 "Language-Team:  nn <i18n@suse.de>\n"
@@ -892,32 +892,6 @@ msgstr ""
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr ""
 
 #. TRANSLATORS: displayed before action,
@@ -2138,6 +2112,14 @@ msgstr ""
 #. (10.00 GiB) and /dev/sda2 (10.00 GiB))
 #, c-format
 msgid "Modify btrfs qgroups on %1$s"
+msgstr ""
+
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, c-format
+msgid "Modify subvolume %1$s on %2$s"
 msgstr ""
 
 #. TRANSLATORS:

--- a/po/pa.po
+++ b/po/pa.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2005-02-16 10:21+0100\n"
 "Last-Translator: Kanwaljeet Singh Brar <kanwaljeetbrar@yahoo.co.in>\n"
 "Language-Team: Punjabi <i18n@suse.de>\n"
@@ -893,32 +893,6 @@ msgstr "ਸਵੈਪ ਲਾਜ਼ੀਕਲ ਵਾਲੀਅਮ %1$s (%2$s) ਬਣ
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "ਲਾਜ਼ੀਕਲ ਵਾਲੀਅਮ %1$s (%2$s) ਬਣਾਓ"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "ਲਾਜ਼ੀਕਲ ਵਾਲੀਅਮ %1$s (%2$s) ਬਣਾਓ"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "ਲਾਜ਼ੀਕਲ ਵਾਲੀਅਮ %1$s (%2$s) ਬਣਾਓ"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "ਲਾਜ਼ੀਕਲ ਵਾਲੀਅਮ %1$s (%2$s) ਬਣਾਓ"
 
 #. TRANSLATORS: displayed before action,
@@ -2150,6 +2124,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "%1$s ਨੂੰ %2$s ਤੋਂ ਹਟਾਓ"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "ਲਾਜ਼ੀਕਲ ਵਾਲੀਅਮ %1$s (%2$s) ਬਣਾਓ"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3161,6 +3143,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "ਲਾਜ਼ੀਕਲ ਵਾਲੀਅਮ %1$s (%2$s) ਬਣਾਓ"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "ਲਾਜ਼ੀਕਲ ਵਾਲੀਅਮ %1$s (%2$s) ਬਣਾਓ"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "ਲਾਜ਼ੀਕਲ ਵਾਲੀਅਮ %1$s (%2$s) ਬਣਾਓ"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2019-04-04 15:03+0000\n"
 "Last-Translator: Ewelina Michalowska <ewelina.michalowska@stgambit.com>\n"
 "Language-Team: Polish <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -961,38 +961,6 @@ msgstr "Utwórz %1$s na urządzeniu %2$s (%3$s)"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Utwórz podwolumin %1$s na urządzeniu %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-"Utwórz podwolumen %1$s na urządzeniu %2$s z opcją 'no copy on write' (brak "
-"kopiowania przy zapisie)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-"Utwórz podwolumen %1$s na urządzeniu %2$s z opcją 'no copy on write' (brak "
-"kopiowania przy zapisie)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr ""
-"Utwórz podwolumen %1$s na urządzeniu %2$s z opcją 'no copy on write' (brak "
-"kopiowania przy zapisie)"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2288,6 +2256,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Usuwanie urządzenia %1$s z urządzenia %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Tworzenie podwoluminu %1$s na urządzeniu %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3330,6 +3306,26 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr ""
+#~ "Utwórz podwolumen %1$s na urządzeniu %2$s z opcją 'no copy on "
+#~ "write' (brak kopiowania przy zapisie)"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr ""
+#~ "Utwórz podwolumen %1$s na urządzeniu %2$s z opcją 'no copy on "
+#~ "write' (brak kopiowania przy zapisie)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr ""
+#~ "Utwórz podwolumen %1$s na urządzeniu %2$s z opcją 'no copy on "
+#~ "write' (brak kopiowania przy zapisie)"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Utwórz MD %1$s %2$s (%3$s)"

--- a/po/pt.po
+++ b/po/pt.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: @PACKAGE@\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2011-11-10 23:28+0100\n"
 "Last-Translator: Elisio Catana <ecatana@gmail.com>\n"
 "Language-Team: Novell Language <language@novell.com>\n"
@@ -894,32 +894,6 @@ msgstr "Criar volume swap %1$s (%2$s)"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Criar subvolume %1$s no dispositivo %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Criar subvolume %1$s no dispositivo %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Criar subvolume %1$s no dispositivo %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Criar subvolume %1$s no dispositivo %2$s"
 
 #. TRANSLATORS: displayed before action,
@@ -2148,6 +2122,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Remover %1$s do %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "A Criar subvolume %1$s no dispositivo %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3157,6 +3139,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Criar subvolume %1$s no dispositivo %2$s"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Criar subvolume %1$s no dispositivo %2$s"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Criar subvolume %1$s no dispositivo %2$s"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-11-12 04:50+0000\n"
 "Last-Translator: Rodrigo Macedo <rmsolucoeseminformatic4@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://l10n.opensuse.org/projects/"
@@ -928,32 +928,6 @@ msgstr "Criar qgroup %1$s em %2$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Criar subvolume %1$s em %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Criar subvolume %1$s em %2$s com a opção \"sem cópia na gravação\""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Criar subvolume %1$s em %2$s com a opção \"sem cópia na gravação\""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Criar subvolume %1$s em %2$s com a opção \"sem cópia na gravação\""
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2206,6 +2180,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Modificar qgroups de btrfs em %1$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Criando subvolume %1$s em %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3219,6 +3201,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr "tmpfs"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Criar subvolume %1$s em %2$s com a opção \"sem cópia na gravação\""
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Criar subvolume %1$s em %2$s com a opção \"sem cópia na gravação\""
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Criar subvolume %1$s em %2$s com a opção \"sem cópia na gravação\""
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Criara MD %1$s %2$s (%3$s)"

--- a/po/ro.po
+++ b/po/ro.po
@@ -20,7 +20,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: OpenSUSE\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2012-11-19 15:00+0200\n"
 "Last-Translator: Lucian Oprea <oprea.luci@gmail.com>\n"
 "Language-Team: Romanian <LL@li.org>\n"
@@ -908,32 +908,6 @@ msgstr "Creează volum swap %1$s (%2$s)"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Creează subvolumul %1$s pe dispozitivul %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Creează subvolumul %1$s pe dispozitivul %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Creează subvolumul %1$s pe dispozitivul %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Creează subvolumul %1$s pe dispozitivul %2$s"
 
 #. TRANSLATORS: displayed before action,
@@ -2162,6 +2136,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Îndepărtează %1$s de la %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Se creează subvolumul %1$s pe dispozitivul %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3171,6 +3153,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Creează subvolumul %1$s pe dispozitivul %2$s"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Creează subvolumul %1$s pe dispozitivul %2$s"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Creează subvolumul %1$s pe dispozitivul %2$s"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/ru.po
+++ b/po/ru.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libstorage.ru\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2021-01-04 16:37+0000\n"
 "Last-Translator: Alex Minton <alex239@gmail.com>\n"
 "Language-Team: Russian <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -935,32 +935,6 @@ msgstr "Создать qgroup %1$s на %2$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Создать подтом %1$s на %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Создать подтом %1$s на %2$s с параметром «не копировать при записи»"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Создать подтом %1$s на %2$s с параметром «не копировать при записи»"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Создать подтом %1$s на %2$s с параметром «не копировать при записи»"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2229,6 +2203,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Изменить btrfs qgroup на %1$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Создание подтома %1$s на %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3234,6 +3216,20 @@ msgstr "кБ"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr "tmpfs"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Создать подтом %1$s на %2$s с параметром «не копировать при записи»"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Создать подтом %1$s на %2$s с параметром «не копировать при записи»"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Создать подтом %1$s на %2$s с параметром «не копировать при записи»"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Создать MD %1$s %2$s (%3$s)"

--- a/po/si.po
+++ b/po/si.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2005-07-29 15:37+0530\n"
 "Last-Translator: i18n@suse.de\n"
 "Language-Team: Sinhala <i18n@suse.de>\n"
@@ -888,32 +888,6 @@ msgstr ""
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr ""
 
 #. TRANSLATORS: displayed before action,
@@ -2134,6 +2108,14 @@ msgstr ""
 #. (10.00 GiB) and /dev/sda2 (10.00 GiB))
 #, c-format
 msgid "Modify btrfs qgroups on %1$s"
+msgstr ""
+
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, c-format
+msgid "Modify subvolume %1$s on %2$s"
 msgstr ""
 
 #. TRANSLATORS:

--- a/po/sk.po
+++ b/po/sk.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-11-10 18:50+0000\n"
 "Last-Translator: Ferdinand Galko <galko.ferdinand@gmail.com>\n"
 "Language-Team: Slovak <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -922,32 +922,6 @@ msgstr "Vytvoriť qgroup %1$s na %2$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Vytvoriť podzväzok %1$s na %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Vytvoriť podzväzok %1$s na %2$s s voľbou 'no copy on write'"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Vytvoriť podzväzok %1$s na %2$s s voľbou 'no copy on write'"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "Vytvoriť podzväzok %1$s na %2$s s voľbou 'no copy on write'"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2202,6 +2176,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Upraviť položky qgroup btrfs na %1$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Vytvorenie podzväzku %1$s na %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3208,6 +3190,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr "tmpfs"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Vytvoriť podzväzok %1$s na %2$s s voľbou 'no copy on write'"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Vytvoriť podzväzok %1$s na %2$s s voľbou 'no copy on write'"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Vytvoriť podzväzok %1$s na %2$s s voľbou 'no copy on write'"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Vytvoriť MD %1$s %2$s (%3$s)"

--- a/po/sl.po
+++ b/po/sl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2001-10-18 11:02+0200\n"
 "Last-Translator: Janez Krek <janez.krek@euroteh.si>\n"
 "Language-Team: Slovenian\n"
@@ -896,32 +896,6 @@ msgstr "Ustvari logični nosilec"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Ustvari logični nosilec"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Ustvari logični nosilec"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Ustvari logični nosilec"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Ustvari logični nosilec"
 
 #. TRANSLATORS: displayed before action,
@@ -2156,6 +2130,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Odmakni napravo %1 iz /etc/fstab"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Ustvari logični nosilec"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3171,6 +3153,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Ustvari logični nosilec"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Ustvari logični nosilec"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Ustvari logični nosilec"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST2 (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2004-03-31 11:34+0200\n"
 "Last-Translator: opensuse-translations@opensuse.org\n"
 "Language-Team: Serbian <i18n@suse.de>\n"
@@ -898,32 +898,6 @@ msgstr "Izbaci"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Izbaci"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Izbaci"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Izbaci"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Izbaci"
 
 #. TRANSLATORS: displayed before action,
@@ -2199,6 +2173,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Izbaci"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Izbaci"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3241,6 +3223,20 @@ msgstr "У реду"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Izbaci"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Izbaci"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Izbaci"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-05-14 17:08+0000\n"
 "Last-Translator: Luna Jernberg <droidbittin@gmail.com>\n"
 "Language-Team: Swedish <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -954,38 +954,6 @@ msgstr "Skapa %1$s på %2$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "Skapa delvolym %1$s på %2$s"
-
-# SLE12
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-"Skapa delvolym %1$s på %2$s med alternativet \"ingen kopia vid skrivning\""
-
-# SLE12
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-"Skapa delvolym %1$s på %2$s med alternativet \"ingen kopia vid skrivning\""
-
-# SLE12
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr ""
-"Skapa delvolym %1$s på %2$s med alternativet \"ingen kopia vid skrivning\""
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2277,6 +2245,15 @@ msgstr "Microsoft-reserverad partition"
 msgid "Modify btrfs qgroups on %1$s"
 msgstr "Tar bort %1$s från %2$s"
 
+# SLE12
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Skapar delvolym %1$s på %2$s"
+
 #. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
@@ -3302,6 +3279,26 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+# SLE12
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr ""
+#~ "Skapa delvolym %1$s på %2$s med alternativet \"ingen kopia vid skrivning\""
+
+# SLE12
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr ""
+#~ "Skapa delvolym %1$s på %2$s med alternativet \"ingen kopia vid skrivning\""
+
+# SLE12
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr ""
+#~ "Skapa delvolym %1$s på %2$s med alternativet \"ingen kopia vid skrivning\""
 
 # SLE12
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/ta.po
+++ b/po/ta.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2003-08-14 10:47+0200\n"
 "Last-Translator: xxx <yyy@example.org>\n"
 "Language-Team: Tamil <i18n@suse.de>\n"
@@ -892,32 +892,6 @@ msgstr "பரிமாற்ற தருக்கரீதியான அள�
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "தருக்கரீதியான அளவு %1$sஐ (%2$s) உருவாக்கவும்"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "தருக்கரீதியான அளவு %1$sஐ (%2$s) உருவாக்கவும்"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "தருக்கரீதியான அளவு %1$sஐ (%2$s) உருவாக்கவும்"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "தருக்கரீதியான அளவு %1$sஐ (%2$s) உருவாக்கவும்"
 
 #. TRANSLATORS: displayed before action,
@@ -2152,6 +2126,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "%2$sலிருந்து %1$sஐ நீக்கவும்"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "தருக்கரீதியான அளவு %1$sஐ (%2$s) உருவாக்கவும்"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3167,6 +3149,20 @@ msgstr "கேபி"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "தருக்கரீதியான அளவு %1$sஐ (%2$s) உருவாக்கவும்"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "தருக்கரீதியான அளவு %1$sஐ (%2$s) உருவாக்கவும்"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "தருக்கரீதியான அளவு %1$sஐ (%2$s) உருவாக்கவும்"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/tg.po
+++ b/po/tg.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: desktop-translations 20090902\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -884,32 +884,6 @@ msgstr "Ҷудо кунӣ"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr ""
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr ""
 
 #. TRANSLATORS: displayed before action,
@@ -2130,6 +2104,14 @@ msgstr ""
 #. (10.00 GiB) and /dev/sda2 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Modify btrfs qgroups on %1$s"
+msgstr "Ҷудо кунӣ"
+
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
 msgstr "Ҷудо кунӣ"
 
 #. TRANSLATORS:

--- a/po/th.po
+++ b/po/th.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2010-07-09 21:56+0700\n"
 "Last-Translator: Thanomsub Noppaburana <donga.nb@gmail.com>\n"
 "Language-Team: Thai <i18n@suse.de>\n"
@@ -892,32 +892,6 @@ msgstr "สร้างโวลุม swap %1$s (ขนาด %2$s)"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "สร้างโวลุม %1$s (ขนาด %2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "สร้างโวลุม %1$s (ขนาด %2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "สร้างโวลุม %1$s (ขนาด %2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "สร้างโวลุม %1$s (ขนาด %2$s)"
 
 #. TRANSLATORS: displayed before action,
@@ -2150,6 +2124,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "ลบ %1$s ออกจาก %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "กำลังสร้างลบกลุ่มโวลุม %1$s จาก %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3163,6 +3145,20 @@ msgstr "กิโลไบต์"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "สร้างโวลุม %1$s (ขนาด %2$s)"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "สร้างโวลุม %1$s (ขนาด %2$s)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "สร้างโวลุม %1$s (ขนาด %2$s)"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/tr.po
+++ b/po/tr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2001-10-18 10:13+0200\n"
 "Last-Translator: Görkem Çetin <gorkem@gelecek.com.tr>\n"
 "Language-Team: turkish <i18n@suse.de>\n"
@@ -1024,35 +1024,6 @@ msgstr "Mantıksal yığın oluştur"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Mantıksal yığın oluştur"
-
-# include/partitioning/lvm_ui_dialogs.ycp:81
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Mantıksal yığın oluştur"
-
-# include/partitioning/lvm_ui_dialogs.ycp:81
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Mantıksal yığın oluştur"
-
-# include/partitioning/lvm_ui_dialogs.ycp:81
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Mantıksal yığın oluştur"
 
 # please, check %1, %2, %3.
@@ -2562,6 +2533,15 @@ msgstr ""
 msgid "Modify btrfs qgroups on %1$s"
 msgstr "%1 aygıtını /etc/fstab içinden kaldır"
 
+# include/partitioning/lvm_ui_dialogs.ycp:81
+#. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Mantıksal yığın oluştur"
+
 # clients/inst_rootpart.ycp:401
 #. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
@@ -3682,6 +3662,23 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+# include/partitioning/lvm_ui_dialogs.ycp:81
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Mantıksal yığın oluştur"
+
+# include/partitioning/lvm_ui_dialogs.ycp:81
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Mantıksal yığın oluştur"
+
+# include/partitioning/lvm_ui_dialogs.ycp:81
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Mantıksal yığın oluştur"
 
 # include/partitioning/lvm_ui_dialogs.ycp:81
 #, fuzzy

--- a/po/uk.po
+++ b/po/uk.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libstorage.uk\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2018-02-23 14:15+0000\n"
 "Last-Translator: Andriy Bandura <andriykopanytsia@gmail.com>\n"
 "Language-Team: Ukrainian <https://l10n.opensuse.org/projects/libstorage/ng-"
@@ -899,32 +899,6 @@ msgstr "Створити %1$s на %2$s (%3$s)"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Створити підрозділ %1$s на %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Створити підрозділ %1$s на %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Створити підрозділ %1$s на %2$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Створити підрозділ %1$s на %2$s"
 
 #. TRANSLATORS: displayed before action,
@@ -2153,6 +2127,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Вилучити %1$s з %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Створення підтому %1$s на %2$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3163,6 +3145,20 @@ msgstr "КБ"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Створити підрозділ %1$s на %2$s"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Створити підрозділ %1$s на %2$s"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Створити підрозділ %1$s на %2$s"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "Створити MD %1$s %2$s (%3$s)"

--- a/po/vi.po
+++ b/po/vi.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2006-07-12 07:32+0200\n"
 "Last-Translator: Phan Vĩnh Thịnh <teppi82@gmail.com>\n"
 "Language-Team: Vietnamese <i18n@suse.de>\n"
@@ -1025,38 +1025,6 @@ msgstr "kiểu nội suy cần dùng"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "kiểu nội suy cần dùng"
-
-# Type: select
-# Description
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "kiểu nội suy cần dùng"
-
-# Type: select
-# Description
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "kiểu nội suy cần dùng"
-
-# Type: select
-# Description
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "kiểu nội suy cần dùng"
 
 # Type: select
@@ -2477,6 +2445,16 @@ msgstr "Gỡ bỏ các đường dẫn quá thời"
 # Type: select
 # Description
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "kiểu nội suy cần dùng"
+
+# Type: select
+# Description
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3612,6 +3590,26 @@ msgstr "MB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+# Type: select
+# Description
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "kiểu nội suy cần dùng"
+
+# Type: select
+# Description
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "kiểu nội suy cần dùng"
+
+# Type: select
+# Description
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "kiểu nội suy cần dùng"
 
 # Type: select
 # Description

--- a/po/wa.po
+++ b/po/wa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: yast memory\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2011-02-08 22:07+0100\n"
 "Last-Translator: Jean Cayron <jean.cayron@gmail.com>\n"
 "Language-Team: Walloon <linux-wa@walon.org>\n"
@@ -893,32 +893,6 @@ msgstr "Dj' ahive li volume swap %1$s (%2$s)"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Ahiver l' volume %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Ahiver l' volume %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Ahiver l' volume %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Ahiver l' volume %1$s (%2$s)"
 
 #. TRANSLATORS: displayed before action,
@@ -2147,6 +2121,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Oister %1$s di %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Ahiver l' volume %1$s (%2$s)"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3156,6 +3138,20 @@ msgstr "Kb"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Ahiver l' volume %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Ahiver l' volume %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Ahiver l' volume %1$s (%2$s)"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/xh.po
+++ b/po/xh.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: base\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2006-11-03 14:26\n"
 "Last-Translator: Novell Language <language@novell.com>\n"
 "Language-Team: Novell Language <language@novell.com>\n"
@@ -923,32 +923,6 @@ msgstr ""
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Cima isandi ngokwengqiqo elindelekileyo esingu %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Cima isandi ngokwengqiqo elindelekileyo esingu %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Cima isandi ngokwengqiqo elindelekileyo esingu %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Cima isandi ngokwengqiqo elindelekileyo esingu %1$s (%2$s)"
 
 #. TRANSLATORS: displayed before action,
@@ -2225,6 +2199,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Shenxisa u %1$s ukuuka ku %2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Cima isandi ngokwengqiqo elindelekileyo esingu %1$s (%2$s)"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3253,6 +3235,20 @@ msgstr "i-kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Cima isandi ngokwengqiqo elindelekileyo esingu %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Cima isandi ngokwengqiqo elindelekileyo esingu %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Cima isandi ngokwengqiqo elindelekileyo esingu %1$s (%2$s)"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: YaST (@memory@)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-02-17 02:54+0000\n"
 "Last-Translator: Grace Yu <grace.yu@excel-gits.com>\n"
 "Language-Team: Chinese (China) <https://l10n.opensuse.org/projects/"
@@ -897,32 +897,6 @@ msgstr "在 %2$s 上创建 %1$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "在 %2$s 上创建子卷 %1$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "使用“写入时不复制”选项在 %2$s 上创建子卷 %1$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "使用“写入时不复制”选项在 %2$s 上创建子卷 %1$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "使用“写入时不复制”选项在 %2$s 上创建子卷 %1$s"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2151,6 +2125,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "正在从 %2$s 移除 %1$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "正在 %2$s 上创建子卷 %1$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3151,6 +3133,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "使用“写入时不复制”选项在 %2$s 上创建子卷 %1$s"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "使用“写入时不复制”选项在 %2$s 上创建子卷 %1$s"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "使用“写入时不复制”选项在 %2$s 上创建子卷 %1$s"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "创建 MD %1$s %2$s (%3$s)"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libstorage\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2020-02-17 12:54+0000\n"
 "Last-Translator: Grace Yu <grace.yu@excel-gits.com>\n"
 "Language-Team: Chinese (Taiwan) <https://l10n.opensuse.org/projects/"
@@ -900,32 +900,6 @@ msgstr "在 %2$s\t建立 %1$s"
 #, c-format
 msgid "Create subvolume %1$s on %2$s"
 msgstr "在 %2$s 上建立子磁碟區 %1$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "使用「寫入時不複製」選項在 %2$s 上建立子磁碟區 %1$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "使用「寫入時不複製」選項在 %2$s 上建立子磁碟區 %1$s"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
-msgstr "使用「寫入時不複製」選項在 %2$s 上建立子磁碟區 %1$s"
 
 #. TRANSLATORS: displayed before action,
 #. %1$s is replaced by logical volume name (e.g. root),
@@ -2167,6 +2141,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "正在從 %2$s 移除 %1$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "正於 %2$s 上建立子磁碟區 %1$s"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3175,6 +3157,20 @@ msgstr "kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "使用「寫入時不複製」選項在 %2$s 上建立子磁碟區 %1$s"
+
+#, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "使用「寫入時不複製」選項在 %2$s 上建立子磁碟區 %1$s"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "使用「寫入時不複製」選項在 %2$s 上建立子磁碟區 %1$s"
 
 #~ msgid "Create MD %1$s %2$s (%3$s)"
 #~ msgstr "建立 MD %1$s  %2$s (%3$s)"

--- a/po/zu.po
+++ b/po/zu.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: installation\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-20 09:42+0100\n"
+"POT-Creation-Date: 2021-01-28 14:51+0000\n"
 "PO-Revision-Date: 2006-11-03 14:26\n"
 "Last-Translator: Novell Language <language@novell.com>\n"
 "Language-Team: Novell Language <language@novell.com>\n"
@@ -891,32 +891,6 @@ msgstr "Yakha ivolumu enengqondo yokushintshanisa %1$s (%2$s)"
 #. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 #, fuzzy, c-format
 msgid "Create subvolume %1$s on %2$s"
-msgstr "Yakha ivolumu ehlelekile %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with limits for qgroup"
-msgstr "Yakha ivolumu ehlelekile %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
-msgstr "Yakha ivolumu ehlelekile %1$s (%2$s)"
-
-#. TRANSLATORS:
-#. %1$s is replaced with the subvolume path (e.g. var/log),
-#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-#, fuzzy, c-format
-msgid ""
-"Create subvolume %1$s on %2$s with option 'no copy on write' and limits for "
-"qgroup"
 msgstr "Yakha ivolumu ehlelekile %1$s (%2$s)"
 
 #. TRANSLATORS: displayed before action,
@@ -2153,6 +2127,14 @@ msgid "Modify btrfs qgroups on %1$s"
 msgstr "Susa i-%1$s kwi-%2$s"
 
 #. TRANSLATORS:
+#. %1$s is replaced with the subvolume path (e.g. var/log),
+#. %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+#. (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+#, fuzzy, c-format
+msgid "Modify subvolume %1$s on %2$s"
+msgstr "Yakha ivolumu ehlelekile %1$s (%2$s)"
+
+#. TRANSLATORS:
 #. %1$s is replaced with the md level (e.g. RAID1),
 #. %2$s is replaced with the md name (e.g. /dev/md0),
 #. %3$s is replaced with the size (e.g. 2.00 GiB),
@@ -3170,6 +3152,20 @@ msgstr "i-kB"
 #. TRANSLATORS: name of object
 msgid "tmpfs"
 msgstr ""
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with limits for qgroup"
+#~ msgstr "Yakha ivolumu ehlelekile %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid "Create subvolume %1$s on %2$s with option 'no copy on write'"
+#~ msgstr "Yakha ivolumu ehlelekile %1$s (%2$s)"
+
+#, fuzzy, c-format
+#~ msgid ""
+#~ "Create subvolume %1$s on %2$s with option 'no copy on write' and limits "
+#~ "for qgroup"
+#~ msgstr "Yakha ivolumu ehlelekile %1$s (%2$s)"
 
 #, fuzzy
 #~ msgid "Create MD %1$s %2$s (%3$s)"

--- a/storage/CompoundAction/Formatter/BtrfsSubvolume.cc
+++ b/storage/CompoundAction/Formatter/BtrfsSubvolume.cc
@@ -52,22 +52,10 @@ namespace storage
 	    return delete_text();
 
 	else if (has_create<storage::BtrfsSubvolume>())
-	{
-	    bool has_set_nocow = has_action<Action::SetNocow>();
-	    bool has_set_limits = has_action<Action::SetLimits>();
-
-	    if (has_set_nocow && has_set_limits)
-		return create_with_nocow_and_limits_text();
-	    else if (has_set_nocow)
-		return create_with_nocow_text();
-	    else if (has_set_limits)
-		return create_with_limits_text();
-	    else
-		return create_text();
-	}
+	    return create_text();
 
 	else
-	    return default_text();
+	    return edit_text();
     }
 
 
@@ -85,45 +73,6 @@ namespace storage
 
 
     Text
-    CompoundAction::Formatter::BtrfsSubvolume::create_with_nocow_text() const
-    {
-	// TRANSLATORS:
-	// %1$s is replaced with the subvolume path (e.g. var/log),
-	// %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-	//   (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-	Text text = _("Create subvolume %1$s on %2$s with option 'no copy on write'");
-
-	return sformat(text, subvolume->get_path(), blk_devices_text());
-    }
-
-
-    Text
-    CompoundAction::Formatter::BtrfsSubvolume::create_with_limits_text() const
-    {
-	// TRANSLATORS:
-	// %1$s is replaced with the subvolume path (e.g. var/log),
-	// %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-	//   (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-	Text text = _("Create subvolume %1$s on %2$s with limits for qgroup");
-
-	return sformat(text, subvolume->get_path(), blk_devices_text());
-    }
-
-
-    Text
-    CompoundAction::Formatter::BtrfsSubvolume::create_with_nocow_and_limits_text() const
-    {
-	// TRANSLATORS:
-	// %1$s is replaced with the subvolume path (e.g. var/log),
-	// %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
-	//   (10.00 GiB) and /dev/sdb1 (10.00 GiB))
-	Text text = _("Create subvolume %1$s on %2$s with option 'no copy on write' and limits for qgroup");
-
-	return sformat(text, subvolume->get_path(), blk_devices_text());
-    }
-
-
-    Text
     CompoundAction::Formatter::BtrfsSubvolume::create_text() const
     {
 	// TRANSLATORS:
@@ -131,6 +80,18 @@ namespace storage
 	// %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
 	//   (10.00 GiB) and /dev/sdb1 (10.00 GiB))
 	Text text = _("Create subvolume %1$s on %2$s");
+
+	return sformat(text, subvolume->get_path(), blk_devices_text());
+    }
+
+    Text
+    CompoundAction::Formatter::BtrfsSubvolume::edit_text() const
+    {
+	// TRANSLATORS:
+	// %1$s is replaced with the subvolume path (e.g. var/log),
+	// %2$s is replaced with the list of block device name and sizes (e.g. /dev/sda1
+	//   (10.00 GiB) and /dev/sdb1 (10.00 GiB))
+	Text text = _("Modify subvolume %1$s on %2$s");
 
 	return sformat(text, subvolume->get_path(), blk_devices_text());
     }

--- a/storage/CompoundAction/Formatter/BtrfsSubvolume.cc
+++ b/storage/CompoundAction/Formatter/BtrfsSubvolume.cc
@@ -55,7 +55,7 @@ namespace storage
 	    return create_text();
 
 	else if (_compound_action->get_commit_actions().size() > 1)
-	    return edit_text();
+	    return modify_text();
 
 	else
 	    return default_text();
@@ -88,7 +88,7 @@ namespace storage
     }
 
     Text
-    CompoundAction::Formatter::BtrfsSubvolume::edit_text() const
+    CompoundAction::Formatter::BtrfsSubvolume::modify_text() const
     {
 	// TRANSLATORS:
 	// %1$s is replaced with the subvolume path (e.g. var/log),

--- a/storage/CompoundAction/Formatter/BtrfsSubvolume.cc
+++ b/storage/CompoundAction/Formatter/BtrfsSubvolume.cc
@@ -54,8 +54,11 @@ namespace storage
 	else if (has_create<storage::BtrfsSubvolume>())
 	    return create_text();
 
-	else
+	else if (_compound_action->get_commit_actions().size() > 1)
 	    return edit_text();
+
+	else
+	    return default_text();
     }
 
 

--- a/storage/CompoundAction/Formatter/BtrfsSubvolume.h
+++ b/storage/CompoundAction/Formatter/BtrfsSubvolume.h
@@ -47,10 +47,9 @@ namespace storage
 
 	Text delete_text() const;
 
-	Text create_with_nocow_text() const;
-	Text create_with_limits_text() const;
-	Text create_with_nocow_and_limits_text() const;
 	Text create_text() const;
+
+	Text edit_text() const;
 
     private:
 

--- a/storage/CompoundAction/Formatter/BtrfsSubvolume.h
+++ b/storage/CompoundAction/Formatter/BtrfsSubvolume.h
@@ -49,7 +49,7 @@ namespace storage
 
 	Text create_text() const;
 
-	Text edit_text() const;
+	Text modify_text() const;
 
     private:
 

--- a/testsuite/CompoundAction/btrfs-quota-sentence.cc
+++ b/testsuite/CompoundAction/btrfs-quota-sentence.cc
@@ -108,11 +108,11 @@ BOOST_AUTO_TEST_CASE(test_create3)
     BOOST_CHECK_EQUAL(compound_actions[1]->sentence(),
 		      "Enable quota on /dev/sda2 (500.00 MiB)");
     BOOST_CHECK_EQUAL(compound_actions[2]->sentence(),
-		      "Create subvolume test4 on /dev/sda2 (500.00 MiB) with option 'no copy on write' and limits for qgroup");
+		      "Create subvolume test4 on /dev/sda2 (500.00 MiB)");
     BOOST_CHECK_EQUAL(compound_actions[3]->sentence(),
-		      "Create subvolume test3 on /dev/sda2 (500.00 MiB) with option 'no copy on write'");
+		      "Create subvolume test3 on /dev/sda2 (500.00 MiB)");
     BOOST_CHECK_EQUAL(compound_actions[4]->sentence(),
-		      "Create subvolume test2 on /dev/sda2 (500.00 MiB) with limits for qgroup");
+		      "Create subvolume test2 on /dev/sda2 (500.00 MiB)");
     BOOST_CHECK_EQUAL(compound_actions[5]->sentence(),
 		      "Create subvolume test1 on /dev/sda2 (500.00 MiB)");
     BOOST_CHECK_EQUAL(compound_actions[6]->sentence(),
@@ -160,11 +160,11 @@ BOOST_AUTO_TEST_CASE(test_create4)
     BOOST_CHECK_EQUAL(compound_actions[1]->sentence(),
 		      "Enable quota on /dev/sda2 (500.00 MiB) and /dev/sda3 (500.00 MiB)");
     BOOST_CHECK_EQUAL(compound_actions[2]->sentence(),
-		      "Create subvolume test4 on /dev/sda2 (500.00 MiB) and /dev/sda3 (500.00 MiB) with option 'no copy on write' and limits for qgroup");
+		      "Create subvolume test4 on /dev/sda2 (500.00 MiB) and /dev/sda3 (500.00 MiB)");
     BOOST_CHECK_EQUAL(compound_actions[3]->sentence(),
-		      "Create subvolume test3 on /dev/sda2 (500.00 MiB) and /dev/sda3 (500.00 MiB) with option 'no copy on write'");
+		      "Create subvolume test3 on /dev/sda2 (500.00 MiB) and /dev/sda3 (500.00 MiB)");
     BOOST_CHECK_EQUAL(compound_actions[4]->sentence(),
-		      "Create subvolume test2 on /dev/sda2 (500.00 MiB) and /dev/sda3 (500.00 MiB) with limits for qgroup");
+		      "Create subvolume test2 on /dev/sda2 (500.00 MiB) and /dev/sda3 (500.00 MiB)");
     BOOST_CHECK_EQUAL(compound_actions[5]->sentence(),
 		      "Create subvolume test1 on /dev/sda2 (500.00 MiB) and /dev/sda3 (500.00 MiB)");
     BOOST_CHECK_EQUAL(compound_actions[6]->sentence(),
@@ -213,10 +213,7 @@ BOOST_AUTO_TEST_CASE(test_modify1)
 
     BOOST_REQUIRE_EQUAL(compound_actions.size(), 1);
 
-    // TODO the order here could be different
-
-    BOOST_CHECK_EQUAL(compound_actions[0]->sentence(), "Set limits for qgroup of subvolume test1 on /dev/sda2 (500.00 MiB)" "\n"
-		      "Set option 'no copy on write' for subvolume test1 on /dev/sda2 (500.00 MiB)");
+    BOOST_CHECK_EQUAL(compound_actions[0]->sentence(), "Modify subvolume test1 on /dev/sda2 (500.00 MiB)");
 }
 
 

--- a/testsuite/CompoundAction/btrfs-quota-sentence.cc
+++ b/testsuite/CompoundAction/btrfs-quota-sentence.cc
@@ -192,29 +192,4 @@ BOOST_AUTO_TEST_CASE(test_enable1)
 }
 
 
-BOOST_AUTO_TEST_CASE(test_modify1)
-{
-    initialize_staging_with_three_partitions();
-    Btrfs* btrfs = to_btrfs(sda2->create_blk_filesystem(FsType::BTRFS));
-    btrfs->set_quota(true);
-
-    BtrfsSubvolume* toplevel = btrfs->get_top_level_btrfs_subvolume();
-
-    BtrfsSubvolume* subvolume1 = toplevel->create_btrfs_subvolume("test1");
-
-    copy_staging_to_probed();
-
-    subvolume1->set_nocow(true);
-    BtrfsQgroup* group1 = subvolume1->get_btrfs_qgroup();
-    group1->set_exclusive_limit(1 * GiB);
-
-    const Actiongraph* actiongraph = storage->calculate_actiongraph();
-    vector<const CompoundAction*> compound_actions = actiongraph->get_compound_actions();
-
-    BOOST_REQUIRE_EQUAL(compound_actions.size(), 1);
-
-    BOOST_CHECK_EQUAL(compound_actions[0]->sentence(), "Modify subvolume test1 on /dev/sda2 (500.00 MiB)");
-}
-
-
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
### Problem

Compound actions for subvolumes are too complex because they inform about every change over the subvolume, for example:

![Screenshot from 2021-01-21 15-47-03](https://user-images.githubusercontent.com/1112304/105480456-b0288b00-5c9d-11eb-8267-13a15c1bd864.png)

Note that these sentences would become more and more complex when new attributes will be added to the subvolumes. 

### Solution

Simplify the compound actions for subvolumes in order to only show a short sentence when creating or editing a subvolume:

* *Create subvolume `name` on `device`*
* *Modify subvolume `name` on `device`*

Note that when a subvolume is edited, and only one action is done (e.g., activate 'nocow' property), its compound action would default to such single action text:

* *Set option 'no copy on write' for subvolume `name` on `device`*

![Screenshot from 2021-01-28 13-42-32](https://user-images.githubusercontent.com/1112304/106146370-81635680-616e-11eb-995d-a613a5468551.png)

