### PR TITLE
- do not run efibootmgr if efivars in read-only or empty (bsc#1185610)

### DIFF
--- a/storage/SystemInfo/Arch.cc
+++ b/storage/SystemInfo/Arch.cc
@@ -105,7 +105,7 @@ namespace storage
 	}
 	else
 	{
-	    SystemCmd::Options options(TEST_BIN " -d '/sys/firmware/efi/efivars'", SystemCmd::DoThrow);
+	    SystemCmd::Options options(TEST_BIN " -d '" EFIVARS_DIR "'", SystemCmd::DoThrow);
 	    options.verify = [](int exit_code) { return exit_code == 0 || exit_code == 1; };
 
 	    SystemCmd cmd(options);

--- a/storage/Utils/StorageDefines.h
+++ b/storage/Utils/StorageDefines.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) [2004-2015] Novell, Inc.
- * Copyright (c) [2016-2020] SUSE LLC
+ * Copyright (c) [2016-2021] SUSE LLC
  *
  * All Rights Reserved.
  *
@@ -38,6 +38,8 @@
 
 #define SYSFS_DIR "/sys"
 #define PROC_DIR "/proc"
+
+#define EFIVARS_DIR SYSFS_DIR "/firmware/efi/efivars"
 
 
 // commands
@@ -142,7 +144,7 @@
 #define DISPLAY_BIN "/usr/bin/display"
 
 
-//regexes
+// regexes
 
 #define UUID_REGEX "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
 


### PR DESCRIPTION
For https://bugzilla.suse.com/show_bug.cgi?id=1185610.