### PR TITLE
Use dev name in fstab for LUKS devices (jsc#SLE-20416, bsc#1181196)

### DIFF
--- a/storage/Filesystems/BlkFilesystemImpl.cc
+++ b/storage/Filesystems/BlkFilesystemImpl.cc
@@ -37,6 +37,7 @@
 #include "storage/Holders/FilesystemUserImpl.h"
 #include "storage/Devices/BlkDeviceImpl.h"
 #include "storage/Devices/LvmLv.h"
+#include "storage/Devices/Luks.h"
 #include "storage/Devicegraph.h"
 #include "storage/SystemInfo/SystemInfo.h"
 #include "storage/StorageImpl.h"
@@ -113,7 +114,14 @@ namespace storage
     {
 	const BlkDevice* blk_device = get_blk_device();
 
-	if (is_lvm_lv(blk_device))
+	/*
+	 * If the device name of the block device is fully stable, then use it.
+	 * That's true by definition for LVM LVs. It's also true for LUKS
+	 * devices as long as the name used in /etc/crypttab remains stable.
+	 * According to bsc#1181196 and the subsequent jsc#SLE-20416, using
+	 * that name is the safest option for LUKS devices when systemd is used.
+	 */
+	if (is_lvm_lv(blk_device) || is_luks(blk_device))
 	    return MountByType::DEVICE;
 	else
 	    return get_storage()->get_default_mount_by();


### PR DESCRIPTION
## Problem

According to [bsc#1181196](https://bugzilla.suse.com/show_bug.cgi?id=1181196) (later moved to [jsc#PM-2460](https://jira.suse.com/browse/PM-2460) -> [jsc#SLE-20416](https://jira.suse.com/browse/SLE-20416)), specifying /etc/fstab entries via UUID= for LUKS devices shouldn't be done because it means that some tools, such as systemd generators, cannot know which LUKS device to activate to make a file-system appear unless all volumes are set up at boot.

Therefore instead of UUID, the reporter recommends to use the name of the resulting encrypted block device (eg. `/dev/mapper/cr_xxx `) since it also identifies the LUKS-backed device without ambiguity.

## Solution

This PR makes libstorage-ng use the device name by default for LUKS devices, instead of the global default `mount_by` method. That behavior is kind of equivalent to what libstorage-ng has always done for LVM LVs (which also have stable device names). 

This only changes the default `mount_by` proposed by libstorage-ng when creating a new mount point. It does not limit the options for the user to select any other mount_by method for the mount point (actually, using the default global value that is commonly UUID has worked for most cases in the past).