### PR TITLE
Add glibc-locale buildrequires for testsuite on SUSE distros

### DIFF
--- a/libstorage-ng.spec.in
+++ b/libstorage-ng.spec.in
@@ -12,7 +12,7 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
 
@@ -23,7 +23,7 @@ Release:        0
 Summary:        Library for storage management
 License:        GPL-2.0-only
 Group:          System/Libraries
-Url:            http://github.com/openSUSE/libstorage-ng
+URL:            https://github.com/openSUSE/libstorage-ng
 Source:         libstorage-ng-%{version}.tar.xz
 %if 0%{?suse_version} >= 1330
 BuildRequires:  libboost_headers-devel
@@ -38,6 +38,8 @@ BuildRequires:  graphviz
 BuildRequires:  grep
 BuildRequires:  libtool
 BuildRequires:  pkgconfig
+BuildRequires:  pkgconfig(python3)
+BuildRequires:  python-rpm-macros
 BuildRequires:  ruby
 BuildRequires:  ruby-devel
 %if 0%{?suse_version} == 1315
@@ -58,10 +60,8 @@ BuildRequires:  glibc-langpack-fr
 BuildRequires:  glibc-langpack-en
 %else
 BuildRequires:  libjson-c-devel
+BuildRequires:  glibc-locale
 %endif
-BuildRequires:  pkgconfig(python3)
-BuildRequires:  python-rpm-macros
-BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %description
 This package contains libstorage-ng, a library for storage management.
@@ -183,14 +183,11 @@ touch %{buildroot}/run/libstorage-ng/lock
 %find_lang libstorage-ng
 
 %post -n %{libname} -p /sbin/ldconfig
-
 %postun -n %{libname} -p /sbin/ldconfig
 
 %files -n %{name}-lang -f libstorage-ng.lang
-%defattr(-,root,root)
 
 %files -n %{libname}
-%defattr(-,root,root)
 %doc %dir %{_docdir}/%{name}
 %doc %{_docdir}/%{name}/AUTHORS
 %license %{_docdir}/%{name}/LICENSE
@@ -198,14 +195,12 @@ touch %{buildroot}/run/libstorage-ng/lock
 %ghost /run/libstorage-ng
 
 %files devel
-%defattr(-,root,root)
 %{_libdir}/libstorage-ng.so
 %{_includedir}/storage
 %dir %{_docdir}/%{name}/autodocs
 %doc %{_docdir}/%{name}/autodocs/*
 
 %files python3
-%defattr(-,root,root)
 %{python3_sitelib}/storage.py*
 %attr(755,root,root) %{python3_sitearch}/_storage.so
 # Fedora has brp-python-bytecompile so apparently they want those packaged
@@ -214,7 +209,6 @@ touch %{buildroot}/run/libstorage-ng/lock
 %endif
 
 %files ruby
-%defattr(-,root,root)
 %if 0%{?fedora}
 %{ruby_vendorarchdir}/storage.so
 %else
@@ -222,12 +216,10 @@ touch %{buildroot}/run/libstorage-ng/lock
 %endif
 
 %files utils
-%defattr(-,root,root)
 %dir %{_prefix}/lib/libstorage-ng
 %{_prefix}/lib/libstorage-ng/utils
 
 %files integration-tests
-%defattr(-,root,root)
 %{python3_sitelib}/storageitu.py*
 %dir %{_prefix}/lib/libstorage-ng
 %{_prefix}/lib/libstorage-ng/integration-tests


### PR DESCRIPTION
The testsuite uses non-base locales and hence needs the full glibc-locale package for working.