### PR TITLE
- allow SystemCmd to take a vector with command arguments

### DIFF
--- a/integration-tests/luks/create-key-file-unused.py
+++ b/integration-tests/luks/create-key-file-unused.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+# requirements: empty partition /dev/sdc1
+
+
+from storage import *
+from storageitu import *
+
+
+set_logger(get_logfile_logger())
+
+environment = Environment(False)
+
+storage = Storage(environment)
+storage.probe()
+
+staging = storage.get_staging()
+
+sdc1 = Partition.find_by_name(staging, "/dev/sdc1")
+
+luks = to_luks(sdc1.create_encryption("cr-test"))
+luks.set_type(EncryptionType_LUKS2)
+
+# password is needed since the key-file is not used in commit
+
+luks.set_key_file("/root/does-not-exist.key")
+luks.set_use_key_file_in_commit(False)
+luks.set_password("12345678")
+
+ext4 = luks.create_blk_filesystem(FsType_EXT4)
+
+print(staging)
+
+commit(storage)
+

--- a/integration-tests/luks/create-key-file.py
+++ b/integration-tests/luks/create-key-file.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+
+# requirements: empty partition /dev/sdc1, file /root/test.key
+
+
+from storage import *
+from storageitu import *
+
+
+set_logger(get_logfile_logger())
+
+environment = Environment(False)
+
+storage = Storage(environment)
+storage.probe()
+
+staging = storage.get_staging()
+
+sdc1 = Partition.find_by_name(staging, "/dev/sdc1")
+
+luks = to_luks(sdc1.create_encryption("cr-test"))
+luks.set_type(EncryptionType_LUKS2)
+
+# no need for a password here
+
+luks.set_key_file("/root/test.key")
+
+ext4 = luks.create_blk_filesystem(FsType_EXT4)
+
+print(staging)
+
+commit(storage)
+

--- a/storage/Devices/BitlockerV2Impl.cc
+++ b/storage/Devices/BitlockerV2Impl.cc
@@ -291,7 +291,7 @@ namespace storage
 	    }
 
 	    if (ret)
-		SystemCmd(UDEVADM_BIN_SETTLE);
+		SystemCmd({ UDEVADM_BIN_SETTLE });
 
 	    return ret;
 	}

--- a/storage/Devices/BlkDeviceImpl.cc
+++ b/storage/Devices/BlkDeviceImpl.cc
@@ -960,7 +960,7 @@ namespace storage
     void
     wait_for_devices(const vector<const BlkDevice*>& blk_devices)
     {
-	SystemCmd(UDEVADM_BIN_SETTLE);
+	SystemCmd({ UDEVADM_BIN_SETTLE });
 
 	if (Mockup::get_mode() == Mockup::Mode::PLAYBACK)
 	    return;
@@ -1007,7 +1007,7 @@ namespace storage
     void
     wait_for_detach_devices(const vector<string>& dev_names)
     {
-	SystemCmd(UDEVADM_BIN_SETTLE);
+	SystemCmd({ UDEVADM_BIN_SETTLE });
 
 	if (Mockup::get_mode() == Mockup::Mode::PLAYBACK)
 	    return;

--- a/storage/Devices/DasdPtImpl.cc
+++ b/storage/Devices/DasdPtImpl.cc
@@ -232,7 +232,7 @@ namespace storage
 
 	SystemCmd cmd(cmd_line, SystemCmd::DoThrow);
 
-	SystemCmd(UDEVADM_BIN_SETTLE);
+	SystemCmd({ UDEVADM_BIN_SETTLE });
     }
 
 

--- a/storage/Devices/DmRaidImpl.cc
+++ b/storage/Devices/DmRaidImpl.cc
@@ -107,7 +107,7 @@ namespace storage
 	SystemCmd cmd(cmd_line);
 
 	if (cmd.retcode() == 0)
-	    SystemCmd(UDEVADM_BIN_SETTLE);
+	    SystemCmd({ UDEVADM_BIN_SETTLE });
 
 	return cmd.retcode() == 0;
     }

--- a/storage/Devices/GptImpl.cc
+++ b/storage/Devices/GptImpl.cc
@@ -283,7 +283,7 @@ namespace storage
 
 	SystemCmd cmd(cmd_line, SystemCmd::DoThrow);
 
-	SystemCmd(UDEVADM_BIN_SETTLE);
+	SystemCmd({ UDEVADM_BIN_SETTLE });
     }
 
 
@@ -327,7 +327,7 @@ namespace storage
 
 	SystemCmd cmd(cmd_line, SystemCmd::DoThrow);
 
-	SystemCmd(UDEVADM_BIN_SETTLE);
+	SystemCmd({ UDEVADM_BIN_SETTLE });
     }
 
 

--- a/storage/Devices/LuksImpl.cc
+++ b/storage/Devices/LuksImpl.cc
@@ -334,7 +334,7 @@ namespace storage
 	    }
 
 	    if (ret)
-		SystemCmd(UDEVADM_BIN_SETTLE);
+		SystemCmd({ UDEVADM_BIN_SETTLE });
 
 	    return ret;
 	}

--- a/storage/Devices/LvmLv.h
+++ b/storage/Devices/LvmLv.h
@@ -100,7 +100,7 @@ namespace storage
 
 	/**
 	 * A mirror volume. This is different from RAID1 in that it
-	 * has the mirror log on a seperate device.
+	 * has the mirror log on a separate device.
 	 *
 	 * Cannot be created by the library.
 	 */

--- a/storage/Devices/LvmLvImpl.cc
+++ b/storage/Devices/LvmLvImpl.cc
@@ -217,7 +217,7 @@ namespace storage
 	    bool ret = number_of_inactive != CmdLvs().number_of_inactive();
 
 	    if (ret)
-		SystemCmd(UDEVADM_BIN_SETTLE);
+		SystemCmd({ UDEVADM_BIN_SETTLE });
 
 	    return ret;
 	}

--- a/storage/Devices/MdImpl.cc
+++ b/storage/Devices/MdImpl.cc
@@ -21,7 +21,7 @@
  */
 
 
-#include <ctype.h>
+#include <cctype>
 #include <boost/integer/common_factor_rt.hpp>
 #include <boost/algorithm/string.hpp>
 
@@ -410,7 +410,7 @@ namespace storage
 		SystemCmd cmd(MDADM_BIN " --assemble --scan");
 
 		if (cmd.retcode() == 0)
-		    SystemCmd(UDEVADM_BIN_SETTLE);
+		    SystemCmd({ UDEVADM_BIN_SETTLE });
 
 		return cmd.retcode() == 0;
 	    }
@@ -426,7 +426,7 @@ namespace storage
 		SystemCmd cmd2(cmd_line2);
 
 		if (cmd2.retcode() == 0)
-		    SystemCmd(UDEVADM_BIN_SETTLE);
+		    SystemCmd({ UDEVADM_BIN_SETTLE });
 
 		unlink(filename.c_str());
 

--- a/storage/Devices/MsdosImpl.cc
+++ b/storage/Devices/MsdosImpl.cc
@@ -320,7 +320,7 @@ namespace storage
 
 	SystemCmd cmd(cmd_line, SystemCmd::DoThrow);
 
-	SystemCmd(UDEVADM_BIN_SETTLE);
+	SystemCmd({ UDEVADM_BIN_SETTLE });
     }
 
 

--- a/storage/Devices/MultipathImpl.cc
+++ b/storage/Devices/MultipathImpl.cc
@@ -130,11 +130,11 @@ namespace storage
 	    {
 		SystemCmd cmd1(MULTIPATH_BIN, SystemCmd::DoThrow);
 
-		SystemCmd(UDEVADM_BIN_SETTLE);
+		SystemCmd({ UDEVADM_BIN_SETTLE });
 
 		SystemCmd cmd2(MULTIPATHD_BIN, SystemCmd::DoThrow);
 
-		SystemCmd(UDEVADM_BIN_SETTLE);
+		SystemCmd({ UDEVADM_BIN_SETTLE });
 
 		return true;
 	    }

--- a/storage/Devices/PartitionImpl.cc
+++ b/storage/Devices/PartitionImpl.cc
@@ -1010,7 +1010,7 @@ namespace storage
 	cmd_line += to_string(get_region().get_start() * factor) + " " +
 	    to_string((get_region().get_end() - tmps.size()) * factor + (factor - 1));
 
-	SystemCmd(UDEVADM_BIN_SETTLE);
+	SystemCmd({ UDEVADM_BIN_SETTLE });
 
 	SystemCmd cmd(cmd_line, SystemCmd::DoThrow);
 
@@ -1020,7 +1020,7 @@ namespace storage
 	{
 	    if (!PartedVersion::supports_wipe_signatures())
 	    {
-		SystemCmd(UDEVADM_BIN_SETTLE);
+		SystemCmd({ UDEVADM_BIN_SETTLE });
 		wipe_device();
 	    }
 
@@ -1110,7 +1110,7 @@ namespace storage
 
 	    cmd_line += to_string(get_region().get_end() - i) + " " + to_string(get_region().get_end() - i);
 
-	    SystemCmd(UDEVADM_BIN_SETTLE);
+	    SystemCmd({ UDEVADM_BIN_SETTLE });
 
 	    SystemCmd cmd(cmd_line, SystemCmd::DoThrow);
 	}
@@ -1134,7 +1134,7 @@ namespace storage
 	    string cmd_line = PARTED_BIN " --script " + quote(partitionable->get_name()) + " rm " +
 		to_string(i);
 
-	    SystemCmd(UDEVADM_BIN_SETTLE);
+	    SystemCmd({ UDEVADM_BIN_SETTLE });
 
 	    SystemCmd cmd(cmd_line, SystemCmd::DoThrow);
 	}
@@ -1142,7 +1142,7 @@ namespace storage
 	string cmd_line = PARTED_BIN " --script " + quote(partitionable->get_name()) +
 	    " unit s resizepart " + to_string(get_number()) + " " + to_string(get_region().get_end());
 
-	SystemCmd(UDEVADM_BIN_SETTLE);
+	SystemCmd({ UDEVADM_BIN_SETTLE });
 
 	wait_for_devices({ get_non_impl() });
 

--- a/storage/SystemInfo/Arch.cc
+++ b/storage/SystemInfo/Arch.cc
@@ -72,7 +72,7 @@ namespace storage
     void
     Arch::probe()
     {
-	SystemCmd cmd1(UNAME_BIN " -m", SystemCmd::DoThrow);
+	SystemCmd cmd1({ UNAME_BIN, "-m" }, SystemCmd::DoThrow);
 
 	if (cmd1.stdout().size() == 1)
 	    arch = cmd1.stdout().front();
@@ -120,7 +120,7 @@ namespace storage
 	    efiboot = string(tenv) == "yes";
 	}
 
-	SystemCmd cmd2(GETCONF_BIN " PAGESIZE", SystemCmd::DoThrow);
+	SystemCmd cmd2({ GETCONF_BIN, "PAGESIZE" }, SystemCmd::DoThrow);
 
 	if (cmd2.stdout().size() == 1)
 	    cmd2.stdout().front() >> page_size;

--- a/storage/SystemInfo/CmdBlkid.cc
+++ b/storage/SystemInfo/CmdBlkid.cc
@@ -41,7 +41,7 @@ namespace storage
 
     Blkid::Blkid()
     {
-	SystemCmd::Options options(BLKID_BIN " -c '" DEV_NULL_FILE "'", SystemCmd::DoThrow);
+	SystemCmd::Options options({ BLKID_BIN, "-c", DEV_NULL_FILE }, SystemCmd::DoThrow);
 
 	// If blkid does not find anything it returns 2 (see bsc #1203285).
 	options.verify = [](int exit_code) { return exit_code == 0 || exit_code == 2; };

--- a/storage/SystemInfo/CmdBtrfs.cc
+++ b/storage/SystemInfo/CmdBtrfs.cc
@@ -41,7 +41,7 @@ namespace storage
 
     CmdBtrfsFilesystemShow::CmdBtrfsFilesystemShow()
     {
-	SystemCmd::Options cmd_options(BTRFS_BIN " filesystem show", SystemCmd::DoThrow);
+	SystemCmd::Options cmd_options({ BTRFS_BIN, "filesystem", "show" }, SystemCmd::DoThrow);
 	cmd_options.verify = [](int) { return true; };
 
 	SystemCmd cmd(cmd_options);
@@ -631,7 +631,7 @@ namespace storage
 	if (did_set_version)
 	    return;
 
-	SystemCmd cmd(BTRFS_BIN " --version", SystemCmd::DoThrow);
+	SystemCmd cmd({ BTRFS_BIN, "--version" }, SystemCmd::DoThrow);
 	if (cmd.stdout().empty())
 	    ST_THROW(SystemCmdException(&cmd, "failed to query btrfs version"));
 

--- a/storage/SystemInfo/CmdDmraid.cc
+++ b/storage/SystemInfo/CmdDmraid.cc
@@ -38,7 +38,7 @@ namespace storage
 
     CmdDmraid::CmdDmraid()
     {
-	SystemCmd cmd(DMRAID_BIN " --sets=active -ccc");
+	SystemCmd cmd({ DMRAID_BIN, "--sets=active", "-ccc" });
 	if (cmd.retcode() == 0)
 	    parse(cmd.stdout());
     }

--- a/storage/SystemInfo/CmdDmsetup.cc
+++ b/storage/SystemInfo/CmdDmsetup.cc
@@ -38,8 +38,8 @@ namespace storage
 
     CmdDmsetupInfo::CmdDmsetupInfo()
     {
-	SystemCmd cmd(DMSETUP_BIN " --columns --separator '/' --noheadings -o name,major,minor,"
-		      "segments,subsystem,uuid info", SystemCmd::DoThrow);
+	SystemCmd cmd({ DMSETUP_BIN, "--columns", "--separator", "/", "--noheadings", "-o", "name,major,minor,"
+		"segments,subsystem,uuid", "info" }, SystemCmd::DoThrow);
 
 	parse(cmd.stdout());
     }
@@ -105,9 +105,9 @@ namespace storage
 
     CmdDmsetupTable::CmdDmsetupTable()
     {
-	SystemCmd c(DMSETUP_BIN " table", SystemCmd::DoThrow);
+	SystemCmd cmd({ DMSETUP_BIN, "table" }, SystemCmd::DoThrow);
 
-	parse(c.stdout());
+	parse(cmd.stdout());
     }
 
 

--- a/storage/SystemInfo/CmdLsscsi.cc
+++ b/storage/SystemInfo/CmdLsscsi.cc
@@ -40,7 +40,7 @@ namespace storage
     {
 	const bool json = LsscsiVersion::supports_json_option();
 
-	SystemCmd cmd(LSSCSI_BIN " --transport", SystemCmd::DoThrow);
+	SystemCmd cmd({ LSSCSI_BIN, "--transport" }, SystemCmd::DoThrow);
 
 	parse(cmd.stdout());
     }
@@ -136,7 +136,7 @@ namespace storage
 	if (did_set_version)
 	    return;
 
-	SystemCmd cmd(LSSCSI_BIN " --version", SystemCmd::DoThrow);
+	SystemCmd cmd({ LSSCSI_BIN, "--version" }, SystemCmd::DoThrow);
 	if (cmd.stderr().empty())
 	    ST_THROW(SystemCmdException(&cmd, "failed to query lsscsi version"));
 

--- a/storage/SystemInfo/CmdMultipath.cc
+++ b/storage/SystemInfo/CmdMultipath.cc
@@ -38,11 +38,11 @@ namespace storage
 
     CmdMultipath::CmdMultipath(bool test)
     {
-	string cmd_line = MULTIPATH_BIN " -d -v 2";
+	SystemCmd::Args cmd_args({ MULTIPATH_BIN, "-d", "-v", "2" });
 	if (!test)
-	    cmd_line += " -ll";
+	    cmd_args << "-ll";
 
-	SystemCmd cmd(cmd_line);
+	SystemCmd cmd(cmd_args);
 	if (cmd.retcode() != 0 || cmd.stdout().empty())
 	    return;
 

--- a/storage/SystemInfo/CmdNvme.cc
+++ b/storage/SystemInfo/CmdNvme.cc
@@ -38,7 +38,7 @@ namespace storage
 
     CmdNvmeList::CmdNvmeList()
     {
-	SystemCmd cmd(NVME_BIN " list --verbose --output json", SystemCmd::DoThrow);
+	SystemCmd cmd({ NVME_BIN, "list", "--verbose", "--output", "json" }, SystemCmd::DoThrow);
 
 	parse(cmd.stdout());
     }
@@ -60,7 +60,7 @@ namespace storage
 
     CmdNvmeListSubsys::CmdNvmeListSubsys()
     {
-	SystemCmd cmd(NVME_BIN " list-subsys --verbose --output json", SystemCmd::DoThrow);
+	SystemCmd cmd({ NVME_BIN, "list-subsys", "--verbose", "--output", "json" }, SystemCmd::DoThrow);
 
 	parse(cmd.stdout());
     }

--- a/storage/SystemInfo/CmdParted.cc
+++ b/storage/SystemInfo/CmdParted.cc
@@ -83,7 +83,7 @@ namespace storage
 	parse(cmd.stdout(), cmd.stderr());
 
 	if (PartedVersion::print_triggers_udev())
-	    SystemCmd(UDEVADM_BIN_SETTLE);
+	    SystemCmd({ UDEVADM_BIN_SETTLE });
     }
 
 
@@ -676,7 +676,7 @@ namespace storage
 	if (did_set_version)
 	    return;
 
-	SystemCmd cmd(PARTED_BIN " --version", SystemCmd::DoThrow);
+	SystemCmd cmd({ PARTED_BIN, "--version" }, SystemCmd::DoThrow);
 	if (cmd.stdout().empty())
 	    ST_THROW(SystemCmdException(&cmd, "failed to query parted version"));
 

--- a/storage/SystemInfo/CmdUdevadm.cc
+++ b/storage/SystemInfo/CmdUdevadm.cc
@@ -49,7 +49,7 @@ namespace storage
 	// can happen since e.g. 'parted' opens the disk device read-write
 	// even when all parted commands are read-only, thus triggering udev
 	// events (fixed in recent versions). So always run 'udevadm settle'.
-	SystemCmd(UDEVADM_BIN_SETTLE);
+	SystemCmd({ UDEVADM_BIN_SETTLE });
 
 	SystemCmd cmd(UDEVADM_BIN " info " + quote(file), SystemCmd::DoThrow);
 

--- a/storage/Utils/Mockup.cc
+++ b/storage/Utils/Mockup.cc
@@ -21,6 +21,8 @@
  */
 
 
+#include <boost/algorithm/string.hpp>
+
 #include "storage/Utils/Mockup.h"
 #include "storage/Utils/XmlFile.h"
 #include "storage/Utils/ExceptionImpl.h"
@@ -194,6 +196,13 @@ namespace storage
     Mockup::set_command(const string& name, const Command& command)
     {
 	commands[name] = command;
+    }
+
+
+    void
+    Mockup::set_command(const vector<string>& name, const Command& command)
+    {
+	commands[boost::join(name, " ")] = command;
     }
 
 

--- a/storage/Utils/Mockup.h
+++ b/storage/Utils/Mockup.h
@@ -26,6 +26,7 @@
 
 
 #include <string>
+#include <vector>
 #include <map>
 #include <set>
 
@@ -47,6 +48,7 @@
 namespace storage
 {
     using std::string;
+    using std::vector;
     using std::map;
     using std::set;
 
@@ -72,6 +74,7 @@ namespace storage
 	static bool has_command(const string& name);
 	static const Command& get_command(const string& name);
 	static void set_command(const string& name, const Command& command);
+	static void set_command(const vector<string>& name, const Command& command);
 	static void erase_command(const string& name);
 
 	static bool has_file(const string& name);

--- a/storage/Utils/StorageDefines.h
+++ b/storage/Utils/StorageDefines.h
@@ -132,7 +132,7 @@
 #define DASDVIEW_BIN "/sbin/dasdview"
 
 #define UDEVADM_BIN "/usr/bin/udevadm"
-#define UDEVADM_BIN_SETTLE UDEVADM_BIN " settle --timeout=20"
+#define UDEVADM_BIN_SETTLE UDEVADM_BIN, "settle", "--timeout=20"
 
 #define RPCBIND_BIN "/sbin/rpcbind"
 

--- a/testsuite/SystemInfo/blkid.cc
+++ b/testsuite/SystemInfo/blkid.cc
@@ -18,7 +18,7 @@ void
 check(const vector<string>& input, const vector<string>& output)
 {
     Mockup::set_mode(Mockup::Mode::PLAYBACK);
-    Mockup::set_command(BLKID_BIN " -c '/dev/null'", input);
+    Mockup::set_command(BLKID_BIN " -c /dev/null", input);
 
     Blkid blkid;
 

--- a/testsuite/SystemInfo/dmsetup-info.cc
+++ b/testsuite/SystemInfo/dmsetup-info.cc
@@ -19,7 +19,7 @@ void
 check(const vector<string>& input, const vector<string>& output)
 {
     Mockup::set_mode(Mockup::Mode::PLAYBACK);
-    Mockup::set_command(DMSETUP_BIN " --columns --separator '/' --noheadings -o name,major,minor,"
+    Mockup::set_command(DMSETUP_BIN " --columns --separator / --noheadings -o name,major,minor,"
 			"segments,subsystem,uuid info", input);
 
     CmdDmsetupInfo cmddmsetupinfo;

--- a/testsuite/SystemInfo/udevadm-info.cc
+++ b/testsuite/SystemInfo/udevadm-info.cc
@@ -19,7 +19,7 @@ void
 check(const string& file, const vector<string>& input, const vector<string>& output)
 {
     Mockup::set_mode(Mockup::Mode::PLAYBACK);
-    Mockup::set_command(UDEVADM_BIN_SETTLE, {});
+    Mockup::set_command({ UDEVADM_BIN_SETTLE }, {});
     Mockup::set_command(UDEVADM_BIN " info " + quote(file), input);
 
     CmdUdevadmInfo cmd_udevadm_info(file);

--- a/testsuite/find-vertex.cc
+++ b/testsuite/find-vertex.cc
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(find_vertex)
 
     Mockup::set_mode(Mockup::Mode::PLAYBACK);
 
-    Mockup::set_command(UDEVADM_BIN_SETTLE, vector<string>({}));
+    Mockup::set_command({ UDEVADM_BIN_SETTLE }, vector<string>({}));
 
     storage.remove_devicegraph("system");
     storage.copy_devicegraph("staging", "system");

--- a/testsuite/freeinfo/test6.cc
+++ b/testsuite/freeinfo/test6.cc
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(test_ext4)
 	"Estimated minimum size of the filesystem: 1000000"
     });
 
-    Mockup::set_command(UDEVADM_BIN_SETTLE, vector<string> {});
+    Mockup::set_command({ UDEVADM_BIN_SETTLE }, vector<string> {});
 
     // Check min and max size.
 
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(test_ntfs)
 	"You might resize at 10737418240 bytes or 10 GB (freeing 1014 GB)."
     });
 
-    Mockup::set_command(UDEVADM_BIN_SETTLE, vector<string> {});
+    Mockup::set_command({ UDEVADM_BIN_SETTLE }, vector<string> {});
 
     // Check min and max size.
 

--- a/testsuite/probe/ambiguous1-mockup.xml
+++ b/testsuite/probe/ambiguous1-mockup.xml
@@ -7,7 +7,7 @@
       <stdout>sdc</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdc: UUID="d090269c-1a57-4bd3-a182-5a300b818a72" UUID_SUB="ac4735ad-3176-4f88-a9d8-7744f9c56548" BLOCK_SIZE="4096" TYPE="btrfs" PTUUID="401f8ba4" PTTYPE="dos"</stdout>
     </Command>
     <Command>

--- a/testsuite/probe/ambiguous2-mockup.xml
+++ b/testsuite/probe/ambiguous2-mockup.xml
@@ -7,7 +7,7 @@
       <stdout>sdc</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdc: UUID="d090269c-1a57-4bd3-a182-5a300b818a72" UUID_SUB="ac4735ad-3176-4f88-a9d8-7744f9c56548" BLOCK_SIZE="4096" TYPE="btrfs" PTUUID="e00c8073-6bd2-44e6-90d0-2e7c17185cde" PTTYPE="gpt"</stdout>
     </Command>
     <Command>

--- a/testsuite/probe/bcache1-mockup.xml
+++ b/testsuite/probe/bcache1-mockup.xml
@@ -52,7 +52,7 @@
       <stdout>congested_read_threshold_us</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/vda1: PARTUUID="859d0fce-3cd9-4069-a6b6-d78431a99e60"</stdout>
       <stdout>/dev/vda2: UUID="5ce8ad5b-38f8-49fe-99c3-04a9ad465c31" TYPE="xfs" PARTUUID="0a89f532-fb02-420b-b9a7-ff5469a3888b"</stdout>
       <stdout>/dev/vdb: UUID="d531d625-9aa0-4958-b660-3656bc43fe6d" TYPE="bcache"</stdout>

--- a/testsuite/probe/bcache2-mockup.xml
+++ b/testsuite/probe/bcache2-mockup.xml
@@ -49,7 +49,7 @@
       <stdout>congested_read_threshold_us</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="d1ea1be5-6c19-4b3f-a279-4a60bbddfbf4" TYPE="ext4" PARTUUID="b3ebf520-c53b-448c-903b-91fe80cfe0cc"</stdout>
       <stdout>/dev/sda2: PARTUUID="ff7469c5-d706-4408-b11c-dee3d83c5d67"</stdout>
       <stdout>/dev/sda3: UUID="9b357750-7a80-4217-af7a-ae99a52b454e" TYPE="swap" PARTUUID="1352e018-27e4-4db5-9226-37af93d07773"</stdout>

--- a/testsuite/probe/bitlocker1-mockup.xml
+++ b/testsuite/probe/bitlocker1-mockup.xml
@@ -72,7 +72,7 @@
       <stdout>loop39</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: LABEL="System-reserviert" UUID="4AACFB81ACFB65BB" TYPE="ntfs" PARTUUID="17d20df8-01"</stdout>
       <stdout>/dev/sda2: TYPE="BitLocker" PARTUUID="17d20df8-02"</stdout>
       <stdout>/dev/loop0: TYPE="squashfs"</stdout>

--- a/testsuite/probe/bitlocker2-mockup.xml
+++ b/testsuite/probe/bitlocker2-mockup.xml
@@ -75,7 +75,7 @@
       <stdout>loop39</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/loop1: TYPE="squashfs"</stdout>
       <stdout>/dev/zram1: UUID="18888d3d-0968-491f-b8d7-a051a054247f" TYPE="swap"</stdout>
       <stdout>/dev/loop4: TYPE="squashfs"</stdout>

--- a/testsuite/probe/btrfs1-mockup.xml
+++ b/testsuite/probe/btrfs1-mockup.xml
@@ -8,7 +8,7 @@
       <stdout>sda</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: PARTUUID="cd6c52e1-4fcd-4404-9a84-12d64719f0ac"</stdout>
       <stdout>/dev/sda2: UUID="3df53f69-df60-4481-888f-99072f9c516f" UUID_SUB="8af7625c-0d6f-453a-adee-850dcceb5f1b" BLOCK_SIZE="4096" TYPE="btrfs" PARTUUID="2c5cd4b4-a2a4-433f-bda9-1b505fc38594"</stdout>
       <stdout>/dev/sda3: UUID="68c946ab-e975-44b9-a7df-dfa52b987e83" UUID_SUB="42c2ddfb-e5c6-4130-8372-489d2654148e" BLOCK_SIZE="4096" TYPE="btrfs" PARTUUID="c9978b13-bff5-4c9e-9c33-75a231323afb"</stdout>

--- a/testsuite/probe/btrfs2-mockup.xml
+++ b/testsuite/probe/btrfs2-mockup.xml
@@ -11,7 +11,7 @@
       <stdout>sr0</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sde1: UUID="b7b96325-feb5-4e7e-a7f4-014ce2402e71" UUID_SUB="01341db4-53a2-47e2-bf46-745bffb595e3" TYPE="btrfs" PARTUUID="165c5614-4a94-44cb-9a1f-6642f2e0e9e9"</stdout>
       <stdout>/dev/sdb1: UUID="b7b96325-feb5-4e7e-a7f4-014ce2402e71" UUID_SUB="6c6352f7-9f7f-411c-b01b-d406ac59fed4" TYPE="btrfs" PARTUUID="54826369-b9f4-49ce-8c0c-2664b1c59f9c"</stdout>
       <stdout>/dev/sdd1: UUID="b7b96325-feb5-4e7e-a7f4-014ce2402e71" UUID_SUB="7a23d238-9363-4db7-97e6-d035440cf505" TYPE="btrfs" PARTUUID="01ac1c26-e386-4d2f-a26f-dd52705ead64"</stdout>

--- a/testsuite/probe/btrfs3-mockup.xml
+++ b/testsuite/probe/btrfs3-mockup.xml
@@ -6,7 +6,7 @@
       <stdout>sdc</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdc1: UUID="e5d4d2c5-090a-46b3-9c77-b3176ce00a94" UUID_SUB="82a5a0b7-3cf1-409d-8aca-0fd490f4be2b" TYPE="btrfs" PARTUUID="c1413aab-aba8-471e-819a-06c56cc55a83"</stdout>
     </Command>
     <Command>

--- a/testsuite/probe/btrfs4-mockup.xml
+++ b/testsuite/probe/btrfs4-mockup.xml
@@ -7,7 +7,7 @@
       <stdout>sdd</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdd1: UUID="048815b8-5bea-423d-a739-51c81c3eba2c" UUID_SUB="87592a17-fcab-4ebb-8e29-22b29480a75d" TYPE="btrfs" PARTUUID="db35c54e-4869-4976-90aa-f91eb380fc6d"</stdout>
     </Command>
     <Command>

--- a/testsuite/probe/btrfs5-mockup.xml
+++ b/testsuite/probe/btrfs5-mockup.xml
@@ -7,7 +7,7 @@
       <stdout>sdb</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdb1: UUID="d7c6297b-c069-4ab5-983e-e599c607e9b8" UUID_SUB="b7ff0f47-5efc-476c-8edb-d39f944aa3ab" BLOCK_SIZE="4096" TYPE="btrfs" PARTUUID="1ebc0646-6f26-4f95-9462-265c97508c9c"</stdout>
     </Command>
     <Command>

--- a/testsuite/probe/dasd1-mockup.xml
+++ b/testsuite/probe/dasd1-mockup.xml
@@ -7,7 +7,7 @@
       <stdout>dasda</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/dasda1: UUID="26343be9-0042-4188-a5d0-e816cd3362f0" TYPE="ext2"</stdout>
       <stdout>/dev/dasda2: UUID="1623c840-f97a-4121-9322-456ed6eb5fbc" TYPE="swap"</stdout>
       <stdout>/dev/dasda3: UUID="9bb4594e-8ffd-4aea-b137-a89c22815724" TYPE="ext4"</stdout>

--- a/testsuite/probe/dasd2-mockup.xml
+++ b/testsuite/probe/dasd2-mockup.xml
@@ -9,7 +9,7 @@
       <stdout>dasdb</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/dasda1: UUID="ec6433ac-5273-4056-9665-7af12778181b" TYPE="ext4"</stdout>
       <stdout>/dev/dasdb1: UUID="61fa834d-3ae1-462f-afbc-d3bc9b728564" TYPE="ext2"</stdout>
       <stdout>/dev/dasdb2: UUID="3d9a5b64-b1e3-499e-adad-52e036be91a1" TYPE="ext4"</stdout>

--- a/testsuite/probe/dasd3-mockup.xml
+++ b/testsuite/probe/dasd3-mockup.xml
@@ -7,7 +7,7 @@
       <stdout>vda</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
     </Command>
     <Command>
       <name>/usr/bin/udevadm info '/dev/vda'</name>

--- a/testsuite/probe/disk-mockup.xml
+++ b/testsuite/probe/disk-mockup.xml
@@ -9,7 +9,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="86b64dbc-0530-4a4b-bca7-72e2c8b4e317" TYPE="swap" PARTUUID="00032f15-01" </stdout>
       <stdout>/dev/sda2: UUID="9f0f12c5-4d18-494b-b234-7342c953e99a" TYPE="ext4" PTTYPE="dos" PARTUUID="00032f15-02" </stdout>
       <stdout>/dev/sr0: UUID="2014-10-27-14-56-02-00" LABEL="openSUSE-13.2-DVD-x86_640051" TYPE="iso9660" PTUUID="10ce3e4f" PTTYPE="dos" </stdout>

--- a/testsuite/probe/disk-zoned1-mockup.xml
+++ b/testsuite/probe/disk-zoned1-mockup.xml
@@ -8,7 +8,7 @@
       <stdout>sdb</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: PARTUUID="ed46be48-d6e2-4074-9cd9-bb6591d51bb0"</stdout>
       <stdout>/dev/sda2: UUID="9c26db30-77b5-40be-8cb0-ece5e334f59b" TYPE="ext4" PARTUUID="0b9860f1-65b1-41bb-810f-b4a074e91c2a"</stdout>
       <stdout>/dev/sda3: UUID="ca79ec91-ab91-4ec3-b8f8-254b4dbbd2ca" TYPE="swap" PARTUUID="b8385e05-4150-4f6f-9b94-3d5b0593b1f3"</stdout>

--- a/testsuite/probe/dmraid1-mockup.xml
+++ b/testsuite/probe/dmraid1-mockup.xml
@@ -14,7 +14,7 @@
       <stdout>dm-3</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="cd8a95dc-0b17-4fdd-b6f4-71f58c1dc764" TYPE="swap" PARTUUID="321b4d22-01"</stdout>
       <stdout>/dev/sda2: UUID="53ec5c2a-b156-4926-9db5-0adbef5cc181" TYPE="ext4" PTTYPE="dos" PARTUUID="321b4d22-02"</stdout>
       <stdout>/dev/sdb1: UUID="fa6b93f4-261b-4a21-94c4-506df6814009" TYPE="ext4" PARTUUID="273c9981-c9ff-4dc7-a16a-d8e6fc445e60"</stdout>

--- a/testsuite/probe/error1-mockup.xml
+++ b/testsuite/probe/error1-mockup.xml
@@ -10,7 +10,7 @@
       <stdout>dm-2</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="h6d56s-qYq0-PWtG-Vso0-jWHR-mfH0-rohSdU" TYPE="LVM2_member" PARTUUID="36f7ecf1-01"</stdout>
       <stdout>/dev/sr0: UUID="2016-05-17-02-06-58-00" LABEL="openSUSE-Tumbleweed-DVD-x86_6400" TYPE="iso9660" PTUUID="6b8b4567" PTTYPE="dos"</stdout>
       <stdout>/dev/mapper/system-root: UUID="7992b624-af87-446f-896a-b310acd6e082" TYPE="ext4"</stdout>

--- a/testsuite/probe/external-journal-mockup.xml
+++ b/testsuite/probe/external-journal-mockup.xml
@@ -9,7 +9,7 @@
       <stdout>sda</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="cd8a95dc-0b17-4fdd-b6f4-71f58c1dc764" TYPE="swap" PARTUUID="321b4d22-01"</stdout>
       <stdout>/dev/sda2: UUID="53ec5c2a-b156-4926-9db5-0adbef5cc181" TYPE="ext4" PTTYPE="dos" PARTUUID="321b4d22-02"</stdout>
       <stdout>/dev/sda3: UUID="a49739a9-ea0c-47f5-9189-cd49ec79ec51" LOGUUID="a49739a9-ea0c-47f5-9189-cd49ec79ec51" TYPE="jbd" PARTUUID="321b4d22-03"</stdout>

--- a/testsuite/probe/integrity-mockup.xml
+++ b/testsuite/probe/integrity-mockup.xml
@@ -21,7 +21,7 @@
       <stdout>dm-3</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/loop1: UUID="9da09aa7-eb1d-48ca-b39d-4211bf9b8419" BLOCK_SIZE="4096" TYPE="ext4"</stdout>
       <stdout>/dev/mapper/live-base: UUID="9da09aa7-eb1d-48ca-b39d-4211bf9b8419" BLOCK_SIZE="4096" TYPE="ext4"</stdout>
       <stdout>/dev/sr0: BLOCK_SIZE="2048" UUID="2022-04-26-02-02-29-00" LABEL="CDROM" TYPE="iso9660" PTTYPE="dos"</stdout>
@@ -133,7 +133,7 @@
       <exit-code>127</exit-code>
     </Command>
     <Command>
-      <name>/sbin/dmsetup --columns --separator '/' --noheadings -o name,major,minor,segments,subsystem,uuid info</name>
+      <name>/sbin/dmsetup --columns --separator / --noheadings -o name,major,minor,segments,subsystem,uuid info</name>
       <stdout>crypto/254/3/1/CRYPT/CRYPT-LUKS2-08b5a71487124c758ac004ff7d2912bb-crypto</stdout>
       <stdout>crypto_dif/254/2/1/CRYPT/CRYPT-INTEGRITY-08b5a71487124c758ac004ff7d2912bb-crypto_dif</stdout>
       <stdout>live-base/254/1/1//</stdout>

--- a/testsuite/probe/luks+lvm1-mockup.xml
+++ b/testsuite/probe/luks+lvm1-mockup.xml
@@ -12,7 +12,7 @@
       <stdout>dm-3</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: PARTUUID="6eb8e93e-44f6-4703-b754-273596962fc7"</stdout>
       <stdout>/dev/sda2: UUID="7dd2d696-765d-4951-80bf-54d9ad4655f3" TYPE="crypto_LUKS" PARTUUID="c9b5d198-ba13-46ad-976a-b1591a92708d"</stdout>
       <stdout>/dev/sr0: UUID="2018-02-14-08-49-58-00" LABEL="SLE-15-Installer-DVD-x86_644.001" TYPE="iso9660" PTUUID="27199cde" PTTYPE="dos"</stdout>

--- a/testsuite/probe/luks1-mockup.xml
+++ b/testsuite/probe/luks1-mockup.xml
@@ -9,7 +9,7 @@
       <stdout>dm-0</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="2c724d55-2b15-4cf4-afa6-2b8abe968ffb" TYPE="ext4" PTTYPE="dos" PARTUUID="36f7ecf1-01"</stdout>
       <stdout>/dev/sda2: UUID="90da7454-0be6-4b44-957a-61a05408b8fb" TYPE="crypto_LUKS" PARTUUID="36f7ecf1-02"</stdout>
       <stdout>/dev/sr0: UUID="2016-05-17-02-06-58-00" LABEL="openSUSE-Tumbleweed-DVD-x86_6400" TYPE="iso9660" PTUUID="6b8b4567" PTTYPE="dos"</stdout>

--- a/testsuite/probe/luks2-mockup.xml
+++ b/testsuite/probe/luks2-mockup.xml
@@ -10,7 +10,7 @@
       <stdout>dm-6</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdb1: UUID="109ae070-3bf4-452c-9680-93df9b01a368" TYPE="crypto_LUKS" PARTUUID="cfbfee80-68d6-458a-b40f-d3d88d93802d"</stdout>
       <stdout>/dev/sdb2: UUID="cf01696e-1c94-40be-8088-4ad33c8a539b" TYPE="crypto_LUKS" PARTUUID="85157169-6340-4077-9558-72c86feed83d"</stdout>
       <stdout>/dev/sdb3: UUID="aa68b93d-a5f9-4294-80a8-c4e660cc56dd" TYPE="crypto_LUKS" PARTUUID="06f9594b-16cd-4bf4-a6b8-657123af74c3"</stdout>
@@ -54,7 +54,7 @@
       <exit-code>1</exit-code>
     </Command>
     <Command>
-      <name>/sbin/dmsetup --columns --separator '/' --noheadings -o name,major,minor,segments,subsystem,uuid info</name>
+      <name>/sbin/dmsetup --columns --separator / --noheadings -o name,major,minor,segments,subsystem,uuid info</name>
       <stdout>cr-test3/254/8/1/CRYPT/CRYPT-LUKS1-aa68b93da5f9429480a8c4e660cc56dd-cr-test3</stdout>
       <stdout>cr-test1/254/6/1/CRYPT/CRYPT-LUKS1-109ae0703bf4452c968093df9b01a368-cr-test1</stdout>
     </Command>

--- a/testsuite/probe/luks3-mockup.xml
+++ b/testsuite/probe/luks3-mockup.xml
@@ -7,7 +7,7 @@
       <stdout>dm-5</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdc1: UUID="9a80f55f-c8a8-4767-8852-92eccf494a58" TYPE="crypto_LUKS" PARTUUID="41f58dd7-bd8b-4a2b-af17-43b998b46719"</stdout>
       <stdout>/dev/mapper/cr-test2: UUID="c3d92f3c-e127-4bcc-9274-7dd95a634aa6" TYPE="ext4"</stdout>
     </Command>

--- a/testsuite/probe/lvm+luks1-mockup.xml
+++ b/testsuite/probe/lvm+luks1-mockup.xml
@@ -12,7 +12,7 @@
       <stdout>dm-3</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: PARTUUID="08f6f145-9f0e-4eb8-ab29-970d52f5f450"</stdout>
       <stdout>/dev/sda2: UUID="LUccrU-BPDa-B4ys-jt56-7LNc-V9O7-SWSF4Z" TYPE="LVM2_member" PARTUUID="39bed96f-570d-47a1-aa94-b3d746a15b5e"</stdout>
       <stdout>/dev/sr0: UUID="2018-02-14-08-49-58-00" LABEL="SLE-15-Installer-DVD-x86_644.001" TYPE="iso9660" PTUUID="27199cde" PTTYPE="dos"</stdout>

--- a/testsuite/probe/lvm-cache+thin1-mockup.xml
+++ b/testsuite/probe/lvm-cache+thin1-mockup.xml
@@ -26,7 +26,7 @@
       <stdout>dm-12</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdb1: UUID="yBFbY8-vki4-iNgt-q8rl-TyXr-JAXP-dsDbLb" TYPE="LVM2_member" PARTUUID="4aaca997-6b29-401d-82fb-22db97e9513c"</stdout>
       <stdout>/dev/sdc1: UUID="yl1iTY-OK07-oTd4-j8t1-tJE3-YAsR-Hz0nMW" TYPE="LVM2_member" PARTUUID="c990a453-db97-4d05-bc25-c1a0af765781"</stdout>
       <stdout>/dev/sr0: UUID="2020-04-14-20-39-57-61" LABEL="openSUSE-Tumbleweed-DVD-x86_6422" TYPE="iso9660" PTUUID="02815942" PTTYPE="dos"</stdout>

--- a/testsuite/probe/lvm-cache1-mockup.xml
+++ b/testsuite/probe/lvm-cache1-mockup.xml
@@ -19,7 +19,7 @@
       <stdout>dm-3</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdb1: UUID="yBFbY8-vki4-iNgt-q8rl-TyXr-JAXP-dsDbLb" TYPE="LVM2_member" PARTUUID="4aaca997-6b29-401d-82fb-22db97e9513c"</stdout>
       <stdout>/dev/sdc1: UUID="yl1iTY-OK07-oTd4-j8t1-tJE3-YAsR-Hz0nMW" TYPE="LVM2_member" PARTUUID="c990a453-db97-4d05-bc25-c1a0af765781"</stdout>
       <stdout>/dev/sr0: UUID="2020-04-14-20-39-57-61" LABEL="openSUSE-Tumbleweed-DVD-x86_6422" TYPE="iso9660" PTUUID="02815942" PTTYPE="dos"</stdout>

--- a/testsuite/probe/lvm-errors1-mockup.xml
+++ b/testsuite/probe/lvm-errors1-mockup.xml
@@ -8,7 +8,7 @@
       <stdout>sdc</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdb1: UUID="u6c690-dm2j-IC7t-v8Lg-3Ylk-sUXY-BHsVmY" TYPE="LVM2_member" PARTUUID="6d4c5707-349f-44bd-b121-9a3c703c459a"</stdout>
       <stdout>/dev/sdb2: UUID="u6c690-dm2j-IC7t-v8Lg-3Ylk-sUXY-BHsVmY" TYPE="LVM2_member" PARTUUID="a23655a2-486c-4b77-8a48-f469e127773e"</stdout>
       <stdout>/dev/sdc1: UUID="mGE1D8-R1d2-H4ue-qhhp-yZNL-RJ5o-gYkrwS" TYPE="LVM2_member" PARTUUID="02a97d80-5580-4199-832c-79a0a9eac9b1"</stdout>

--- a/testsuite/probe/lvm-mirror1-mockup.xml
+++ b/testsuite/probe/lvm-mirror1-mockup.xml
@@ -14,7 +14,7 @@
       <stdout>dm-3</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdb1: UUID="fPX3qj-HoV1-8LKW-LDdn-orRe-cOiq-c26KY2" TYPE="LVM2_member" PARTUUID="f9590da6-b0b1-4a9a-a96e-ad4cce9b38ec"</stdout>
       <stdout>/dev/sdc1: UUID="T98uGe-UrkY-9MGI-quEq-lOlS-VdDw-iUvAyR" TYPE="LVM2_member" PARTUUID="3f101065-3c66-4442-ae53-d34387b0d388"</stdout>
       <stdout>/dev/sdd1: UUID="Zc4NYV-8vGx-xI8f-J3BO-GoMP-4N4d-JEqTvB" TYPE="LVM2_member" PARTUUID="7918ca97-b0ce-4a41-b14d-c20787b9ee25"</stdout>

--- a/testsuite/probe/lvm-raid1-mockup.xml
+++ b/testsuite/probe/lvm-raid1-mockup.xml
@@ -23,7 +23,7 @@
       <stdout>dm-3</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdb1: UUID="NckLF5-ANBL-jQ8s-pdVM-N5vO-amnj-DrVeSO" TYPE="LVM2_member" PARTUUID="f9590da6-b0b1-4a9a-a96e-ad4cce9b38ec"</stdout>
       <stdout>/dev/sdc1: UUID="olCBzh-Ryv2-EAqo-odFV-jVfq-yhZP-Ucu2o0" TYPE="LVM2_member" PARTUUID="3f101065-3c66-4442-ae53-d34387b0d388"</stdout>
       <stdout>/dev/sdd1: UUID="23noYM-jaV9-qgmv-gX36-ee6q-3Dsx-JW1n6H" TYPE="LVM2_member" PARTUUID="7918ca97-b0ce-4a41-b14d-c20787b9ee25"</stdout>

--- a/testsuite/probe/lvm-snapshot1-mockup.xml
+++ b/testsuite/probe/lvm-snapshot1-mockup.xml
@@ -25,7 +25,7 @@
       <stdout>dm-12</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdb1: UUID="fPX3qj-HoV1-8LKW-LDdn-orRe-cOiq-c26KY2" TYPE="LVM2_member" PARTUUID="f9590da6-b0b1-4a9a-a96e-ad4cce9b38ec"</stdout>
       <stdout>/dev/sr0: UUID="2020-04-14-20-39-57-61" LABEL="openSUSE-Tumbleweed-DVD-x86_6422" TYPE="iso9660" PTUUID="02815942" PTTYPE="dos"</stdout>
       <stdout>/dev/mapper/test-linear1: UUID="aa77c6d0-c3bc-4bc4-bc09-f015c54424ec" TYPE="ext4"</stdout>

--- a/testsuite/probe/lvm-unsupported1-mockup.xml
+++ b/testsuite/probe/lvm-unsupported1-mockup.xml
@@ -12,7 +12,7 @@
       <stdout>dm-3</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdb1: UUID="5BCmwE-mBgc-rGp1-ZH2R-KHq3-RrBJ-kTsJhu" TYPE="LVM2_member" PARTUUID="f9590da6-b0b1-4a9a-a96e-ad4cce9b38ec"</stdout>
       <stdout>/dev/sdc1: UUID="APNIVK-BRs2-POnd-yHX7-QYHS-Dmwp-0MVvLH" TYPE="LVM2_member" PARTUUID="3f101065-3c66-4442-ae53-d34387b0d388"</stdout>
       <stdout>/dev/sr0: UUID="2020-04-14-20-39-57-61" LABEL="openSUSE-Tumbleweed-DVD-x86_6422" TYPE="iso9660" PTUUID="02815942" PTTYPE="dos"</stdout>

--- a/testsuite/probe/lvm1-mockup.xml
+++ b/testsuite/probe/lvm1-mockup.xml
@@ -11,7 +11,7 @@
       <stdout>dm-2</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="h6d56s-qYq0-PWtG-Vso0-jWHR-mfH0-rohSdU" TYPE="LVM2_member" PARTUUID="36f7ecf1-01"</stdout>
       <stdout>/dev/sr0: UUID="2016-05-17-02-06-58-00" LABEL="openSUSE-Tumbleweed-DVD-x86_6400" TYPE="iso9660" PTUUID="6b8b4567" PTTYPE="dos"</stdout>
       <stdout>/dev/mapper/system-root: UUID="7992b624-af87-446f-896a-b310acd6e082" TYPE="ext4"</stdout>

--- a/testsuite/probe/lvm2-mockup.xml
+++ b/testsuite/probe/lvm2-mockup.xml
@@ -15,7 +15,7 @@
       <stdout>dm-3</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="c0007ded-8168-453b-b818-3b3e7bf6b87d" TYPE="ext4" PTTYPE="dos" PARTUUID="c64661b6-01"</stdout>
       <stdout>/dev/sda2: UUID="QFKFMR-Lz4J-mm8p-gom1-48id-SQpF-OFVjF7" TYPE="LVM2_member" PARTUUID="c64661b6-02"</stdout>
       <stdout>/dev/sr0: UUID="2017-09-14-11-02-47-00" LABEL="openSUSE-Tumbleweed-DVD-x86_6400" TYPE="iso9660" PTUUID="133d779e" PTTYPE="dos"</stdout>

--- a/testsuite/probe/md+lvm1-mockup.xml
+++ b/testsuite/probe/md+lvm1-mockup.xml
@@ -18,7 +18,7 @@
       <stdout>lrwxrwxrwx 1 root root 8 Jun  4 09:24 md-b -&gt; ../md127</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdc1: UUID="623f3da0-9f31-bf71-164f-bf5358ffcd65" UUID_SUB="1565e1c3-2b64-68e2-cb60-aa4a082995a3" LABEL="any:0" TYPE="linux_raid_member" PARTUUID="bdc63351-757d-4201-b49e-5d360119d4f7"</stdout>
       <stdout>/dev/sdc2: UUID="fcb43c8a-ec95-3676-9d0a-703d89cf2f42" UUID_SUB="1fd1c1e0-2849-4053-e654-7c55beffeb87" LABEL="any:md-b" TYPE="linux_raid_member" PARTUUID="204185a2-15f9-47ba-9155-3ef7bc917034"</stdout>
       <stdout>/dev/sdd1: UUID="623f3da0-9f31-bf71-164f-bf5358ffcd65" UUID_SUB="ab1cca43-62cf-5fd1-fb8c-d44e452facad" LABEL="any:0" TYPE="linux_raid_member" PARTUUID="beb395a9-e6cf-4240-a36f-a0ecedd6edc3"</stdout>

--- a/testsuite/probe/md-ddf1-mockup.xml
+++ b/testsuite/probe/md-ddf1-mockup.xml
@@ -21,7 +21,7 @@
       <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:31 ddf0 -> ../md127</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="691eb75f-2f8f-4ec9-8515-60b34237bd6d" TYPE="swap" PARTUUID="321b4d22-01"</stdout>
       <stdout>/dev/sda2: UUID="4d2e6fde-d105-4f15-b8e1-4173badc8c66" TYPE="ext4" PTTYPE="dos" PARTUUID="321b4d22-02"</stdout>
       <stdout>/dev/sdb: UUID="Linux-MDM-^M--M-&gt;M-o" TYPE="ddf_raid_member"</stdout>

--- a/testsuite/probe/md-imsm1-mockup.xml
+++ b/testsuite/probe/md-imsm1-mockup.xml
@@ -21,7 +21,7 @@
       <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:41 imsm0 -> ../md127</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="691eb75f-2f8f-4ec9-8515-60b34237bd6d" TYPE="swap" PARTUUID="321b4d22-01"</stdout>
       <stdout>/dev/sda2: UUID="4d2e6fde-d105-4f15-b8e1-4173badc8c66" TYPE="ext4" PTTYPE="dos" PARTUUID="321b4d22-02"</stdout>
       <stdout>/dev/sdb: TYPE="isw_raid_member"</stdout>

--- a/testsuite/probe/md1-mockup.xml
+++ b/testsuite/probe/md1-mockup.xml
@@ -76,7 +76,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda: UUID="2ce25515-3d25-5c09-a0e9-1f18d9c098d3" UUID_SUB="0193d8d8-ba9f-1a0d-3dad-ae7e9d264336" LABEL="(none):0" TYPE="linux_raid_member" </stdout>
       <stdout>/dev/sdb: UUID="2ce25515-3d25-5c09-a0e9-1f18d9c098d3" UUID_SUB="d49e9bf5-6946-5039-0c60-23d3d6f3c1fb" LABEL="(none):0" TYPE="linux_raid_member" </stdout>
       <stdout>/dev/sdc: UUID="2ce25515-3d25-5c09-a0e9-1f18d9c098d3" UUID_SUB="96411a8d-e9c9-b287-4be7-c3f0343693be" LABEL="(none):0" TYPE="linux_raid_member" </stdout>

--- a/testsuite/probe/md2-mockup.xml
+++ b/testsuite/probe/md2-mockup.xml
@@ -77,7 +77,7 @@
       <stdout>loop63</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda: UUID="3e531727-0857-f684-cd2e-394b62046b74" UUID_SUB="ad3cff36-a8fd-6728-2f2d-8c348472cddd" LABEL="any:1" TYPE="linux_raid_member" </stdout>
       <stdout>/dev/sdb: UUID="3e531727-0857-f684-cd2e-394b62046b74" UUID_SUB="6ba92495-88b5-33a4-ed2b-1fb1fa6387f7" LABEL="any:1" TYPE="linux_raid_member" </stdout>
       <stdout>/dev/sdc: UUID="c8440826-8e55-745c-d7e1-4cddac26716d" UUID_SUB="df4a8d48-2a56-b0b2-3cfb-7fd99bf196ac" LABEL="any:2" TYPE="linux_raid_member" </stdout>

--- a/testsuite/probe/md3-mockup.xml
+++ b/testsuite/probe/md3-mockup.xml
@@ -25,7 +25,7 @@
       <stdout>lrwxrwxrwx 1 root root 8 Aug  7 13:31 test5p1 -> ../md_test5p1</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="2fd6a519-1b93-42dc-bc8f-99ac033a17a9" TYPE="ext4" PTTYPE="dos" PARTUUID="7ec989ba-839c-4991-8a13-b66eab52c828"</stdout>
       <stdout>/dev/sda2: PARTUUID="2a68a80b-94f7-4770-abf5-058f9660e791"</stdout>
       <stdout>/dev/sda3: UUID="fd1d0005-fb00-4cf8-ac57-c480276afbe8" TYPE="swap" PARTUUID="8e2978ee-6ecb-4f3d-98d6-3a19ae5b1744"</stdout>

--- a/testsuite/probe/missing1-mockup.xml
+++ b/testsuite/probe/missing1-mockup.xml
@@ -7,7 +7,7 @@
       <stdout>sda</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="97919fd7-6e7a-4f1c-bcf4-112b06de569a" TYPE="swap" PARTUUID="46e8a22d-01"</stdout>
       <stdout>/dev/sda2: UUID="03b3f314-8d2f-4617-95a0-626812aba79e" UUID_SUB="268a3209-9833-4ec5-9b17-58f95deb7d1c" TYPE="btrfs" PTTYPE="dos" PARTUUID="46e8a22d-02"</stdout>
       <stdout>/dev/sr0: UUID="2017-03-14-10-21-10-00" LABEL="openSUSE-Tumbleweed-DVD-x86_6400" TYPE="iso9660" PTUUID="3d094a7b" PTTYPE="dos"</stdout>

--- a/testsuite/probe/multi-mount-point-mockup1.xml
+++ b/testsuite/probe/multi-mount-point-mockup1.xml
@@ -9,7 +9,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="86b64dbc-0530-4a4b-bca7-72e2c8b4e317" TYPE="swap" PARTUUID="00032f15-01" </stdout>
       <stdout>/dev/sda2: UUID="9f0f12c5-4d18-494b-b234-7342c953e99a" TYPE="ext4" PTTYPE="dos" PARTUUID="00032f15-02" </stdout>
       <stdout>/dev/sr0: UUID="2014-10-27-14-56-02-00" LABEL="openSUSE-13.2-DVD-x86_640051" TYPE="iso9660" PTUUID="10ce3e4f" PTTYPE="dos" </stdout>

--- a/testsuite/probe/multi-mount-point-mockup2.xml
+++ b/testsuite/probe/multi-mount-point-mockup2.xml
@@ -9,7 +9,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="86b64dbc-0530-4a4b-bca7-72e2c8b4e317" TYPE="swap" PARTUUID="00032f15-01" </stdout>
       <stdout>/dev/sda2: UUID="9f0f12c5-4d18-494b-b234-7342c953e99a" TYPE="ext4" PTTYPE="dos" PARTUUID="00032f15-02" </stdout>
       <stdout>/dev/sr0: UUID="2014-10-27-14-56-02-00" LABEL="openSUSE-13.2-DVD-x86_640051" TYPE="iso9660" PTUUID="10ce3e4f" PTTYPE="dos" </stdout>

--- a/testsuite/probe/multi-mount-point-mockup3.xml
+++ b/testsuite/probe/multi-mount-point-mockup3.xml
@@ -9,7 +9,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="86b64dbc-0530-4a4b-bca7-72e2c8b4e317" TYPE="swap" PARTUUID="00032f15-01" </stdout>
       <stdout>/dev/sda2: UUID="9f0f12c5-4d18-494b-b234-7342c953e99a" TYPE="ext4" PTTYPE="dos" PARTUUID="00032f15-02" </stdout>
       <stdout>/dev/sr0: UUID="2014-10-27-14-56-02-00" LABEL="openSUSE-13.2-DVD-x86_640051" TYPE="iso9660" PTUUID="10ce3e4f" PTTYPE="dos" </stdout>

--- a/testsuite/probe/multi-mount-point-mockup4.xml
+++ b/testsuite/probe/multi-mount-point-mockup4.xml
@@ -9,7 +9,7 @@
       <stderr></stderr>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="86b64dbc-0530-4a4b-bca7-72e2c8b4e317" TYPE="swap" PARTUUID="00032f15-01" </stdout>
       <stdout>/dev/sda2: UUID="9f0f12c5-4d18-494b-b234-7342c953e99a" TYPE="ext4" PTTYPE="dos" PARTUUID="00032f15-02" </stdout>
       <stdout>/dev/sr0: UUID="2014-10-27-14-56-02-00" LABEL="openSUSE-13.2-DVD-x86_640051" TYPE="iso9660" PTUUID="10ce3e4f" PTTYPE="dos" </stdout>

--- a/testsuite/probe/multipath+luks1-mockup.xml
+++ b/testsuite/probe/multipath+luks1-mockup.xml
@@ -16,7 +16,7 @@
       <stdout>dm-3</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/dasda1: UUID="dfbde9dc-d646-40ce-941f-ca7e8799a15d" TYPE="ext2"</stdout>
       <stdout>/dev/dasda2: UUID="01f660ee-1a3e-45bc-8e4c-fb7c7ab3bd1d" TYPE="ext4"</stdout>
       <stdout>/dev/dasda3: UUID="523bf89a-41a7-4697-bda1-7415e73e76ec" TYPE="swap"</stdout>

--- a/testsuite/probe/multipath1-mockup.xml
+++ b/testsuite/probe/multipath1-mockup.xml
@@ -14,7 +14,7 @@
       <stdout>dasdb</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/dasdb1: UUID="26343be9-0042-4188-a5d0-e816cd3362f0" TYPE="ext2"</stdout>
       <stdout>/dev/dasdb2: UUID="1623c840-f97a-4121-9322-456ed6eb5fbc" TYPE="swap"</stdout>
       <stdout>/dev/dasdb3: UUID="9bb4594e-8ffd-4aea-b137-a89c22815724" TYPE="ext4"</stdout>

--- a/testsuite/probe/nfs1-mockup.xml
+++ b/testsuite/probe/nfs1-mockup.xml
@@ -6,7 +6,7 @@
       <name>/bin/ls -1 --sort=none '/sys/block'</name>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
     </Command>
     <Command>
       <name>/sbin/dmraid --sets=active -ccc</name>

--- a/testsuite/probe/ntfs1-mockup.xml
+++ b/testsuite/probe/ntfs1-mockup.xml
@@ -7,7 +7,7 @@
       <stdout>sdc</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdc1: UUID="6D0EF67C257F7035" TYPE="ntfs" PARTUUID="69b45287-55e4-4365-aacb-fc154be9d848"</stdout>
       <stdout>/dev/sdc2: UUID="172A54612F0EC61E" TYPE="ntfs" PARTUUID="ed234211-acfd-4e4b-b417-94f9b90ae8b5"</stdout>
       <stdout>/dev/sdc3: UUID="3C03540236D27F38" TYPE="ntfs" PARTUUID="42186f98-cd68-4aa7-916f-c53aea3b22ad"</stdout>

--- a/testsuite/probe/plain-encryption1-mockup.xml
+++ b/testsuite/probe/plain-encryption1-mockup.xml
@@ -9,7 +9,7 @@
       <stdout>dm-7</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdc1: PARTUUID="6ff11cf3-cdda-4ca3-88ca-faff87c3dffe"</stdout>
       <stdout>/dev/sdc2: PARTUUID="f645b83c-005f-42cd-baf6-2ae82dc9f767"</stdout>
       <stdout>/dev/sdc3: PARTUUID="56bcdb52-1b46-4485-a4af-d9430c2bf36f"</stdout>

--- a/testsuite/probe/prefixed1-mockup.xml
+++ b/testsuite/probe/prefixed1-mockup.xml
@@ -74,7 +74,7 @@
       <stdout>loop39</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: UUID="2162322e-f6e3-4575-bcbc-df7f0ff0c76b" BLOCK_SIZE="4096" TYPE="ext4" PARTUUID="ddbf3a29-4fa3-48e5-8d56-391844006671"</stdout>
       <stdout>/dev/sda2: UUID="ffdedb10-5a78-4d49-868a-f8abe9e4f329" BLOCK_SIZE="4096" TYPE="ext4" PARTUUID="94edec53-e8c5-4158-8b99-80fc1e4cfab1"</stdout>
       <stdout>/dev/zram0: UUID="858aa176-dfb0-4d87-89fe-1d0ef4c673db" BLOCK_SIZE="4096" TYPE="ext2"</stdout>

--- a/testsuite/probe/prefixed2-mockup.xml
+++ b/testsuite/probe/prefixed2-mockup.xml
@@ -74,7 +74,7 @@
       <stdout>loop39</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/loop1: TYPE="squashfs"</stdout>
       <stdout>/dev/loop8: TYPE="squashfs"</stdout>
       <stdout>/dev/zram1: UUID="f20276e8-c186-46a8-9dce-c9f106112e96" TYPE="swap"</stdout>

--- a/testsuite/probe/swap1-mockup.xml
+++ b/testsuite/probe/swap1-mockup.xml
@@ -8,7 +8,7 @@
       <stdout>sda</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sr0: BLOCK_SIZE="2048" UUID="2023-01-16-00-17-36-48" LABEL="openSUSE-Tumbleweed-DVD-x86_64" TYPE="iso9660" PTUUID="7923e922" PTTYPE="dos"</stdout>
       <stdout>/dev/sda4: UUID="cfaace10-22a9-4598-8468-a50b52dd5914" TYPE="swap" PARTUUID="aaf1bcfc-b925-431b-a007-af6a6581cb8b"</stdout>
       <stdout>/dev/sda2: UUID="0787c43b-2e18-4690-9d4c-d9a9bf2e8711" UUID_SUB="70c6ab0b-2e9a-4246-ac3b-5b7642fc5e6c" BLOCK_SIZE="4096" TYPE="btrfs" PARTUUID="1f941fb4-50a7-499a-b37f-0a35a11acfa5"</stdout>

--- a/testsuite/probe/tmpfs1-mockup.xml
+++ b/testsuite/probe/tmpfs1-mockup.xml
@@ -8,7 +8,7 @@
       <stdout>sda</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sda1: PARTUUID="e920e60d-4a30-4d5b-b0ea-6717a626f558"</stdout>
       <stdout>/dev/sda2: UUID="4af57350-cd8c-4803-99c7-0df40d4b3336" BLOCK_SIZE="4096" TYPE="ext4" PARTUUID="b28965fd-46fe-4e21-9992-ebe56788de68"</stdout>
       <stdout>/dev/sda3: UUID="5591b541-5f49-4f14-ace4-663b54ba1105" TYPE="swap" PARTUUID="55b4e909-62fa-44d8-85de-4ca90d603f5e"</stdout>

--- a/testsuite/probe/unsupported1-mockup.xml
+++ b/testsuite/probe/unsupported1-mockup.xml
@@ -7,7 +7,7 @@
       <stdout>sdd</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/sdc1: BLOCK_SIZE="1024" TYPE="minix" PARTUUID="5d543afa-1d1c-4373-8565-1c417156e893"</stdout>
       <stdout>/dev/sdd: PTTYPE="PMBR"</stdout>
     </Command>

--- a/testsuite/probe/xen1-mockup.xml
+++ b/testsuite/probe/xen1-mockup.xml
@@ -73,7 +73,7 @@
       <stdout>loop53</stdout>
     </Command>
     <Command>
-      <name>/sbin/blkid -c '/dev/null'</name>
+      <name>/sbin/blkid -c /dev/null</name>
       <stdout>/dev/loop0: TYPE="squashfs"</stdout>
       <stdout>/dev/loop1: TYPE="squashfs"</stdout>
       <stdout>/dev/loop2: TYPE="squashfs"</stdout>


### PR DESCRIPTION
This was suggested by a security review years ago and also seems to be faster.
