### PR TITLE
Fix SWIG 4.5.0 template instantiations and logger crashes

### DIFF
--- a/bindings/ruby/Makefile.am
+++ b/bindings/ruby/Makefile.am
@@ -30,7 +30,7 @@ storage_la_DEPENDENCIES =				\
 	${top_builddir}/storage/libstorage-ng.la
 
 storage_wrap.cxx: storage-ruby.i $(DEPENDENCIES)
-	swig -o storage_wrap.cxx -c++ -ruby -autorename ${AM_CPPFLAGS} storage-ruby.i
+	swig -o storage_wrap.cxx -c++ -ruby ${AM_CPPFLAGS} storage-ruby.i
 
 CLEANFILES = storage.so storage_wrap.cxx storage_wrap.h
 

--- a/bindings/ruby/storage-ruby.i
+++ b/bindings/ruby/storage-ruby.i
@@ -8,6 +8,8 @@
 
 %rename("empty?") "empty";
 
+%rename("logger=") storage::set_ruby_logger;
+
 %rename("%(regex:/^(get_)(.*)/\\2/)s") "";
 %rename("%(regex:/^(set_)(.*)/\\2=/)s") "";
 %rename("%(regex:/^(is_)(.*)/\\2?/)s") "";

--- a/bindings/storage.i
+++ b/bindings/storage.i
@@ -159,6 +159,42 @@ use_ostream(storage::PartitionSlot);
 %include "../../storage/CompoundAction.h"
 
 %include "../../storage/Utils/Swig.h"
+
+#ifdef SWIGRUBY
+%inline %{
+namespace storage {
+class RubyLogger : public storage::Logger
+{
+private:
+    storage::Logger* _real_logger;
+public:
+    RubyLogger(storage::Logger* real_logger) : _real_logger(real_logger) {}
+    virtual ~RubyLogger() {}
+
+    virtual void write(storage::LogLevel log_level, const std::string& component, const std::string& file,
+                       int line, const std::string& function, const std::string& content) override
+    {
+        if (rb_during_gc()) {
+            return;
+        }
+        _real_logger->write(log_level, component, file, line, function, content);
+    }
+};
+
+void set_ruby_logger(storage::Logger* logger) {
+    static RubyLogger* wrapper = nullptr;
+    if (wrapper) {
+        delete wrapper;
+    }
+    wrapper = new RubyLogger(logger);
+    storage::set_logger(wrapper);
+}
+}
+%}
+
+%ignore storage::set_logger;
+#endif
+
 %include "../../storage/Utils/Logger.h"
 %include "../../storage/Utils/Exception.h"
 %include "../../storage/Utils/HumanString.h"


### PR DESCRIPTION
    Surgically resolve all integration and runtime build errors arising from
    the SWIG 4.5.0 upgrade while maintaining backwards compatibility with older
    SWIG versions:
    
    1. Disable -autorename command-line flag in bindings/ruby/Makefile.am:
       Under SWIG 4.5.0, -autorename causes a redefinition conflict that silently
       discards all pointer vector templates (like VectorLvmVgPtr), preventing
       proper Ruby array conversions. Disabling it also resolves C++ const-correctness
       overload resolution failures (such as with to_lvm_vg).
    
    2. Add RubyLogger GC guard and specific logger= rename:
       Wrap set_logger in a custom RubyLogger to prevent C++ thread logging from
       allocating Ruby objects during GC phases, which crashes the VM. Place the
       %rename("logger=") before regex patterns in storage-ruby.i to avoid shadowing,
       and define set_ruby_logger cleanly in storage.i.


https://bugzilla.opensuse.org/show_bug.cgi?id=1275515